### PR TITLE
feat(chunker): Phase 3 semantic chunking — sync trait bridge + fastembed feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,19 @@
   `doc.strategy_fingerprint` from the returned document.
 - Point-ID spaces for `.md` and source-code files change on first Phase 2
   run; drop or GC old Qdrant collections if you want a clean slate.
+
+### Added (Phase 3)
+
+- `SemanticSignalProvider` sync trait with `EmbeddingProviderAdapter`
+  bridging the async `EmbeddingProvider`.
+- `SemanticChunker` splits prose at p95 adjacent-sentence cosine-distance
+  peaks (default percentile, tunable).
+- Optional `fastembed` Cargo feature for local ONNX sentence embeddings.
+- `--enable-semantic`, `--semantic-provider`, `--semantic-percentile` CLI flags.
+
+### Migration (Phase 3)
+
+- Enabling `--enable-semantic` moves `.md` / `.txt` documents into a new
+  `semantic:v1|…` point-ID space. Phase 2 recursive / markdown points remain
+  untouched but will not be re-associated.
+- The `Chunker` trait is unchanged; Phase 2 callers are unaffected.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +30,30 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -30,6 +74,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +101,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-trait"
@@ -65,10 +135,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -86,10 +211,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "blake3"
@@ -117,10 +257,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -135,12 +299,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -219,10 +394,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -231,6 +466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -245,7 +489,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -266,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -307,6 +551,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d1092288af9ecfd5378565a17df11a13dbe172d4a71abe9b55a9689f1336b8e"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +672,41 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -340,6 +725,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,10 +757,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastembed"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f54fc1188b7f7eac8f47be2ab7b3a79ffd842cc8ff2e38316dd59ba4858890e"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -363,10 +815,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -393,6 +876,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,7 +911,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -462,6 +972,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,12 +1016,46 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ureq 2.12.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -533,6 +1106,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -557,7 +1131,23 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -566,7 +1156,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -578,9 +1168,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -666,6 +1258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +1285,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +1332,30 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -733,10 +1395,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -757,10 +1438,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -794,10 +1500,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matchers"
@@ -809,10 +1546,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -826,12 +1605,166 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -844,16 +1777,139 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -866,6 +1922,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -896,6 +1958,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +2010,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -961,10 +2070,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -1044,6 +2174,7 @@ dependencies = [
  "blake3",
  "chunk",
  "criterion",
+ "fastembed",
  "loom",
  "proptest",
  "pulldown-cmark",
@@ -1069,6 +2200,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1110,6 +2242,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error 2.0.1",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +2308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +2326,17 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1164,17 +2374,23 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1185,16 +2401,25 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -1241,6 +2466,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1283,7 +2509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -1295,6 +2521,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,10 +2541,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1404,6 +2673,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,16 +2710,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1472,6 +2791,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1517,13 +2857,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "tiktoken-rs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bstr",
  "fancy-regex",
  "lazy_static",
@@ -1567,6 +2921,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,12 +2981,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1888,10 +3298,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1906,6 +3337,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,16 +3399,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2028,6 +3538,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +3571,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +3596,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -2066,10 +3629,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2081,10 +3661,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2253,6 +3851,12 @@ name = "xtask"
 version = "0.1.0"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,3 +3964,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chunk = "0.10"
+fastembed = { version = "5", optional = true }
 tiktoken-rs = "0.11"
 pulldown-cmark = "0.13"
+unicode-segmentation = "1"
 tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 tree-sitter-python = "0.25"
@@ -49,6 +51,7 @@ proptest = "1"
 
 [features]
 loom = []
+fastembed = ["dep:fastembed"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(feature, values(\"loom\"))"] }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The project is split into a reusable Rust library and a thin CLI runner. The lib
   fall back to the Phase 1 recursive chunker.
 - Per-chunker strategy fingerprints (`markdown:v1|…`, `code:v1|lang=rust|…`)
   keep Markdown, code, and prose in disjoint point-ID spaces.
+- Opt-in **semantic chunking** (`--enable-semantic`): sentence-level similarity
+  splitting at the p95 distance percentile. Default signal source bridges the
+  existing async embedding provider; local ONNX via
+  [`fastembed`](https://github.com/Anush008/fastembed-rs) is available behind
+  the `fastembed` Cargo feature. Semantic fingerprints (`semantic:v1|…`) open
+  a distinct point-ID space.
 
 ## Architecture
 
@@ -123,6 +129,26 @@ The point-ID hashing now includes the chunker strategy fingerprint. Qdrant
 collections populated by earlier ragloom builds will retain their old points,
 but new runs will write to a disjoint ID space. Drop or GC the old collection
 if you want a clean state.
+
+### Semantic (opt-in)
+
+Enable with `--enable-semantic` (default: off). When enabled, the Router
+replaces the `RecursiveChunker` fallback and Markdown chunker with a
+`SemanticChunker` that splits prose at topical boundaries. Source-code
+extensions continue to use the Phase 2 CodeChunker.
+
+| Flag | Values | Default |
+| --- | --- | --- |
+| `--enable-semantic` | flag | off |
+| `--semantic-provider` | `adapter`, `fastembed` | `adapter` |
+| `--semantic-percentile` | `1..=99` | `95` |
+
+`adapter` reuses your configured `--embed-backend` (OpenAI or HTTP). Every
+sentence costs one embedding call — plan your API budget accordingly.
+
+`fastembed` runs `sentence-transformers/all-MiniLM-L6-v2` locally (384 dim,
+zero API cost). Build with `cargo build --features fastembed`. First run
+downloads ~25 MB of model weights into `~/.cache/.fastembed_cache/`.
 
 ## Quick Start
 

--- a/benches/chunker.rs
+++ b/benches/chunker.rs
@@ -9,6 +9,9 @@
 //! Rust code-aware chunkers to the comparison set.
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ragloom::transform::chunker::semantic::{
+    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+};
 use ragloom::transform::chunker::{
     ChunkHint, Chunker, CodeChunker, MarkdownChunker,
     code::Language,
@@ -17,6 +20,14 @@ use ragloom::transform::chunker::{
 };
 #[allow(deprecated)]
 use ragloom::transform::chunker::{ChunkerConfig, chunk_document};
+
+struct StaticSignal;
+impl SemanticSignalProvider for StaticSignal {
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
+    }
+    fn fingerprint(&self) -> &str { "bench:static" }
+}
 
 fn sample(size: usize) -> String {
     let base = "The quick brown fox jumps over the lazy dog. ";
@@ -118,6 +129,16 @@ fn bench(c: &mut Criterion) {
                 b.iter(|| chk.chunk(text, &ChunkHint::none()).unwrap());
             },
         );
+
+        let semantic_sample = sample(n);
+        group.bench_with_input(BenchmarkId::new("semantic_static_512", n), &semantic_sample, |b, text| {
+            let chk = SemanticChunker::new(
+                std::sync::Arc::new(StaticSignal),
+                RecursiveConfig { metric: SizeMetric::Chars, max_size: 512, min_size: 0, overlap: 0 },
+                95,
+            ).unwrap();
+            b.iter(|| chk.chunk(text, &ChunkHint::none()).unwrap());
+        });
     }
     group.finish();
 }

--- a/benches/chunker.rs
+++ b/benches/chunker.rs
@@ -10,7 +10,7 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use ragloom::transform::chunker::semantic::{
-    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+    SemanticChunker, SemanticSignalProvider, signal::SemanticError,
 };
 use ragloom::transform::chunker::{
     ChunkHint, Chunker, CodeChunker, MarkdownChunker,
@@ -26,7 +26,9 @@ impl SemanticSignalProvider for StaticSignal {
     fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
         Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
     }
-    fn fingerprint(&self) -> &str { "bench:static" }
+    fn fingerprint(&self) -> &str {
+        "bench:static"
+    }
 }
 
 fn sample(size: usize) -> String {
@@ -131,14 +133,24 @@ fn bench(c: &mut Criterion) {
         );
 
         let semantic_sample = sample(n);
-        group.bench_with_input(BenchmarkId::new("semantic_static_512", n), &semantic_sample, |b, text| {
-            let chk = SemanticChunker::new(
-                std::sync::Arc::new(StaticSignal),
-                RecursiveConfig { metric: SizeMetric::Chars, max_size: 512, min_size: 0, overlap: 0 },
-                95,
-            ).unwrap();
-            b.iter(|| chk.chunk(text, &ChunkHint::none()).unwrap());
-        });
+        group.bench_with_input(
+            BenchmarkId::new("semantic_static_512", n),
+            &semantic_sample,
+            |b, text| {
+                let chk = SemanticChunker::new(
+                    std::sync::Arc::new(StaticSignal),
+                    RecursiveConfig {
+                        metric: SizeMetric::Chars,
+                        max_size: 512,
+                        min_size: 0,
+                        overlap: 0,
+                    },
+                    95,
+                )
+                .unwrap();
+                b.iter(|| chk.chunk(text, &ChunkHint::none()).unwrap());
+            },
+        );
     }
     group.finish();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,6 +280,16 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
             .with_context("--chunker-mode=single requires --chunker-single"));
     }
 
+    if enable_semantic
+        && chunker_mode == "single"
+        && chunker_single.as_deref() != Some("semantic")
+    {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
+            "--enable-semantic is only honored with --chunker-mode=router or \
+             --chunker-mode=single with --chunker-single=semantic",
+        ));
+    }
+
     let semantic_provider = semantic_provider.unwrap_or_else(|| "adapter".to_string());
     match semantic_provider.as_str() {
         "adapter" => {}
@@ -671,5 +681,31 @@ mod tests {
                 semantic_percentile: 95,
             }
         );
+    }
+
+    #[test]
+    fn enable_semantic_errors_in_single_mode_without_semantic() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+            "--chunker-mode".to_string(),
+            "single".to_string(),
+            "--chunker-single".to_string(),
+            "recursive".to_string(),
+            "--enable-semantic".to_string(),
+        ];
+        let err = parse_args(&args).expect_err("must reject");
+        assert!(err.to_string().contains("--enable-semantic"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ pub struct RunConfig {
     pub tokenizer: String,
     pub chunker_mode: String,
     pub chunker_single: Option<String>,
+    pub enable_semantic: bool,
+    pub semantic_provider: String,
+    pub semantic_percentile: u8,
 }
 
 /// Embedding backend selection.
@@ -82,6 +85,9 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
     let mut tokenizer: Option<String> = None;
     let mut chunker_mode: Option<String> = None;
     let mut chunker_single: Option<String> = None;
+    let mut enable_semantic = false;
+    let mut semantic_provider: Option<String> = None;
+    let mut semantic_percentile: Option<String> = None;
 
     let mut iter = args.iter().skip(1);
     while let Some(arg) = iter.next() {
@@ -119,6 +125,11 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
             "--tokenizer" => tokenizer = next_value(),
             "--chunker-mode" => chunker_mode = next_value(),
             "--chunker-single" => chunker_single = next_value(),
+            "--enable-semantic" => {
+                enable_semantic = true;
+            }
+            "--semantic-provider" => semantic_provider = next_value(),
+            "--semantic-percentile" => semantic_percentile = next_value(),
             "--help" | "-h" => {
                 return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
                     "usage: ragloom --dir <path> --qdrant-url <url> --collection <name> [--embed-backend <openai|http>]",
@@ -269,6 +280,39 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
             .with_context("--chunker-mode=single requires --chunker-single"));
     }
 
+    let semantic_provider = semantic_provider.unwrap_or_else(|| "adapter".to_string());
+    match semantic_provider.as_str() {
+        "adapter" => {}
+        "fastembed" => {
+            #[cfg(not(feature = "fastembed"))]
+            {
+                return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
+                    "--semantic-provider=fastembed requires the \"fastembed\" Cargo feature",
+                ));
+            }
+        }
+        other => {
+            return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
+                format!("invalid --semantic-provider: {other} (expected: adapter|fastembed)"),
+            ));
+        }
+    }
+
+    let semantic_percentile = semantic_percentile
+        .map(|s| {
+            s.parse::<u8>().map_err(|e| {
+                RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+                    .with_context(format!("--semantic-percentile must be 1..=99: {e}"))
+            })
+        })
+        .transpose()?
+        .unwrap_or(95);
+    if !(1..=99).contains(&semantic_percentile) {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
+            format!("--semantic-percentile must be in 1..=99, got {semantic_percentile}"),
+        ));
+    }
+
     Ok(RunConfig {
         dir,
         embed_backend,
@@ -282,6 +326,9 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
         tokenizer,
         chunker_mode,
         chunker_single,
+        enable_semantic,
+        semantic_provider,
+        semantic_percentile,
     })
 }
 
@@ -301,6 +348,13 @@ fn parse_code_lang(s: &str) -> Result<ragloom::transform::chunker::code::Languag
         "bash" => Ok(Language::Bash),
         other => Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
             .with_context(format!("unsupported language: {other}"))),
+    }
+}
+
+fn embedding_fingerprint(cfg: &RunConfig) -> String {
+    match &cfg.embed_backend {
+        EmbedBackend::OpenAi { model, .. } => format!("openai:{}", model),
+        EmbedBackend::Http { model, .. } => format!("http:{}", model),
     }
 }
 
@@ -345,6 +399,8 @@ async fn try_main() -> Result<(), RagloomError> {
 
     let runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
     let (queue, shutdown) = AsyncRuntime::new(runtime, 128).start();
+
+    let embed_fingerprint = embedding_fingerprint(&cfg);
 
     let embedding: std::sync::Arc<dyn ragloom::embed::EmbeddingProvider + Send + Sync> =
         match cfg.embed_backend {
@@ -418,44 +474,93 @@ async fn try_main() -> Result<(), RagloomError> {
     }
 
     use ragloom::transform::chunker::{
-        Chunker, MarkdownChunker, default_router, recursive::RecursiveChunker,
+        Chunker, EmbeddingProviderAdapter, MarkdownChunker, SemanticChunker,
+        SemanticSignalProvider, default_router, recursive::RecursiveChunker, semantic_router,
     };
 
-    let chunker: std::sync::Arc<dyn Chunker> = match cfg.chunker_mode.as_str() {
-        "router" => std::sync::Arc::new(default_router(rec_cfg).map_err(|e| {
-            RagloomError::new(RagloomErrorKind::Config, e).with_context("invalid router config")
-        })?),
-        "single" => {
-            let kind = cfg.chunker_single.as_deref().unwrap();
-            match kind {
-                "recursive" => {
-                    std::sync::Arc::new(RecursiveChunker::new(rec_cfg).map_err(|e| {
-                        RagloomError::new(RagloomErrorKind::Config, e)
-                            .with_context("invalid chunker config")
-                    })?)
-                }
-                "markdown" => std::sync::Arc::new(MarkdownChunker::new(rec_cfg).map_err(|e| {
-                    RagloomError::new(RagloomErrorKind::Config, e)
-                        .with_context("invalid markdown config")
-                })?),
-                s if s.starts_with("code:") => {
-                    let lang = parse_code_lang(&s[5..])?;
-                    std::sync::Arc::new(
-                        ragloom::transform::chunker::CodeChunker::new(lang, rec_cfg).map_err(
-                            |e| {
-                                RagloomError::new(RagloomErrorKind::Config, e)
-                                    .with_context("invalid code config")
-                            },
-                        )?,
-                    )
-                }
-                other => {
-                    return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
-                        .with_context(format!("invalid --chunker-single: {other}")));
+    let chunker: std::sync::Arc<dyn Chunker> = if cfg.chunker_mode == "router"
+        && cfg.enable_semantic
+    {
+        let signal: std::sync::Arc<dyn SemanticSignalProvider> = match cfg.semantic_provider.as_str() {
+            "adapter" => std::sync::Arc::new(EmbeddingProviderAdapter::new(
+                std::sync::Arc::clone(&embedding),
+                embed_fingerprint.clone(),
+            )),
+            #[cfg(feature = "fastembed")]
+            "fastembed" => std::sync::Arc::new(
+                ragloom::transform::chunker::FastembedSignalProvider::new().map_err(|e| {
+                    RagloomError::new(RagloomErrorKind::Config, e).with_context("fastembed init")
+                })?,
+            ),
+            other => {
+                return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+                    .with_context(format!("unsupported --semantic-provider: {other}")));
+            }
+        };
+        let semantic_chunker: std::sync::Arc<dyn Chunker> = std::sync::Arc::new(
+            SemanticChunker::new(signal, rec_cfg, cfg.semantic_percentile).map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Config, e)
+                    .with_context("invalid semantic config")
+            })?,
+        );
+        std::sync::Arc::new(semantic_router(rec_cfg, semantic_chunker).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::Config, e)
+                .with_context("invalid semantic router config")
+        })?)
+    } else {
+        match cfg.chunker_mode.as_str() {
+            "router" => std::sync::Arc::new(default_router(rec_cfg).map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Config, e)
+                    .with_context("invalid router config")
+            })?),
+            "single" => {
+                let kind = cfg.chunker_single.as_deref().unwrap();
+                match kind {
+                    "semantic" => {
+                        let signal: std::sync::Arc<dyn SemanticSignalProvider> =
+                            std::sync::Arc::new(EmbeddingProviderAdapter::new(
+                                std::sync::Arc::clone(&embedding),
+                                embed_fingerprint.clone(),
+                            ));
+                        std::sync::Arc::new(
+                            SemanticChunker::new(signal, rec_cfg, cfg.semantic_percentile)
+                                .map_err(|e| {
+                                    RagloomError::new(RagloomErrorKind::Config, e)
+                                        .with_context("invalid semantic config")
+                                })?,
+                        )
+                    }
+                    "recursive" => {
+                        std::sync::Arc::new(RecursiveChunker::new(rec_cfg).map_err(|e| {
+                            RagloomError::new(RagloomErrorKind::Config, e)
+                                .with_context("invalid chunker config")
+                        })?)
+                    }
+                    "markdown" => {
+                        std::sync::Arc::new(MarkdownChunker::new(rec_cfg).map_err(|e| {
+                            RagloomError::new(RagloomErrorKind::Config, e)
+                                .with_context("invalid markdown config")
+                        })?)
+                    }
+                    s if s.starts_with("code:") => {
+                        let lang = parse_code_lang(&s[5..])?;
+                        std::sync::Arc::new(
+                            ragloom::transform::chunker::CodeChunker::new(lang, rec_cfg).map_err(
+                                |e| {
+                                    RagloomError::new(RagloomErrorKind::Config, e)
+                                        .with_context("invalid code config")
+                                },
+                            )?,
+                        )
+                    }
+                    other => {
+                        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+                            .with_context(format!("invalid --chunker-single: {other}")));
+                    }
                 }
             }
+            _ => unreachable!("validated in parse_args"),
         }
-        _ => unreachable!("validated in parse_args"),
     };
 
     let pipeline = PipelineExecutor::with_chunker(
@@ -554,6 +659,9 @@ mod tests {
                 tokenizer: "tiktoken-cl100k".to_string(),
                 chunker_mode: "router".to_string(),
                 chunker_single: None,
+                enable_semantic: false,
+                semantic_provider: "adapter".to_string(),
+                semantic_percentile: 95,
             }
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,15 +286,19 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
         "fastembed" => {
             #[cfg(not(feature = "fastembed"))]
             {
-                return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
-                    "--semantic-provider=fastembed requires the \"fastembed\" Cargo feature",
-                ));
+                return Err(
+                    RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
+                        "--semantic-provider=fastembed requires the \"fastembed\" Cargo feature",
+                    ),
+                );
             }
         }
         other => {
-            return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
-                format!("invalid --semantic-provider: {other} (expected: adapter|fastembed)"),
-            ));
+            return Err(
+                RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(format!(
+                    "invalid --semantic-provider: {other} (expected: adapter|fastembed)"
+                )),
+            );
         }
     }
 
@@ -308,9 +312,11 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
         .transpose()?
         .unwrap_or(95);
     if !(1..=99).contains(&semantic_percentile) {
-        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
-            format!("--semantic-percentile must be in 1..=99, got {semantic_percentile}"),
-        ));
+        return Err(
+            RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(format!(
+                "--semantic-percentile must be in 1..=99, got {semantic_percentile}"
+            )),
+        );
     }
 
     Ok(RunConfig {
@@ -481,22 +487,24 @@ async fn try_main() -> Result<(), RagloomError> {
     let chunker: std::sync::Arc<dyn Chunker> = if cfg.chunker_mode == "router"
         && cfg.enable_semantic
     {
-        let signal: std::sync::Arc<dyn SemanticSignalProvider> = match cfg.semantic_provider.as_str() {
-            "adapter" => std::sync::Arc::new(EmbeddingProviderAdapter::new(
-                std::sync::Arc::clone(&embedding),
-                embed_fingerprint.clone(),
-            )),
-            #[cfg(feature = "fastembed")]
-            "fastembed" => std::sync::Arc::new(
-                ragloom::transform::chunker::FastembedSignalProvider::new().map_err(|e| {
-                    RagloomError::new(RagloomErrorKind::Config, e).with_context("fastembed init")
-                })?,
-            ),
-            other => {
-                return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
-                    .with_context(format!("unsupported --semantic-provider: {other}")));
-            }
-        };
+        let signal: std::sync::Arc<dyn SemanticSignalProvider> =
+            match cfg.semantic_provider.as_str() {
+                "adapter" => std::sync::Arc::new(EmbeddingProviderAdapter::new(
+                    std::sync::Arc::clone(&embedding),
+                    embed_fingerprint.clone(),
+                )),
+                #[cfg(feature = "fastembed")]
+                "fastembed" => std::sync::Arc::new(
+                    ragloom::transform::chunker::FastembedSignalProvider::new().map_err(|e| {
+                        RagloomError::new(RagloomErrorKind::Config, e)
+                            .with_context("fastembed init")
+                    })?,
+                ),
+                other => {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+                        .with_context(format!("unsupported --semantic-provider: {other}")));
+                }
+            };
         let semantic_chunker: std::sync::Arc<dyn Chunker> = std::sync::Arc::new(
             SemanticChunker::new(signal, rec_cfg, cfg.semantic_percentile).map_err(|e| {
                 RagloomError::new(RagloomErrorKind::Config, e)
@@ -510,8 +518,7 @@ async fn try_main() -> Result<(), RagloomError> {
     } else {
         match cfg.chunker_mode.as_str() {
             "router" => std::sync::Arc::new(default_router(rec_cfg).map_err(|e| {
-                RagloomError::new(RagloomErrorKind::Config, e)
-                    .with_context("invalid router config")
+                RagloomError::new(RagloomErrorKind::Config, e).with_context("invalid router config")
             })?),
             "single" => {
                 let kind = cfg.chunker_single.as_deref().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,14 +280,14 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
             .with_context("--chunker-mode=single requires --chunker-single"));
     }
 
-    if enable_semantic
-        && chunker_mode == "single"
-        && chunker_single.as_deref() != Some("semantic")
+    if enable_semantic && chunker_mode == "single" && chunker_single.as_deref() != Some("semantic")
     {
-        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
-            "--enable-semantic is only honored with --chunker-mode=router or \
+        return Err(
+            RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
+                "--enable-semantic is only honored with --chunker-mode=router or \
              --chunker-mode=single with --chunker-single=semantic",
-        ));
+            ),
+        );
     }
 
     let semantic_provider = semantic_provider.unwrap_or_else(|| "adapter".to_string());

--- a/src/transform/chunker/error.rs
+++ b/src/transform/chunker/error.rs
@@ -18,6 +18,8 @@ pub enum ChunkError {
         pos: usize,
         detail: String,
     },
+    #[error("semantic chunker: {0}")]
+    Semantic(#[from] crate::transform::chunker::semantic::signal::SemanticError),
 }
 
 pub type ChunkResult<T> = Result<T, ChunkError>;

--- a/src/transform/chunker/mod.rs
+++ b/src/transform/chunker/mod.rs
@@ -25,7 +25,10 @@ pub use markdown::MarkdownChunker;
 pub use public_types::{BoundaryKind, Chunk, ChunkedDocument};
 pub use recursive::RecursiveChunker;
 pub use router::{ChunkerRouter, default_router};
-pub use semantic::{EmbeddingProviderAdapter, SemanticError, SemanticSignalProvider};
+pub use semantic::{
+    EmbeddingProviderAdapter, SemanticChunker, SemanticConfig, SemanticError,
+    SemanticSignalProvider,
+};
 #[cfg(feature = "fastembed")]
 pub use semantic::FastembedSignalProvider;
 pub use size::{CharCounter, SizeMetric, TiktokenCounter, TokenCounter};

--- a/src/transform/chunker/mod.rs
+++ b/src/transform/chunker/mod.rs
@@ -24,7 +24,7 @@ pub use fingerprint::StrategyFingerprint;
 pub use markdown::MarkdownChunker;
 pub use public_types::{BoundaryKind, Chunk, ChunkedDocument};
 pub use recursive::RecursiveChunker;
-pub use router::{ChunkerRouter, default_router};
+pub use router::{ChunkerRouter, default_router, semantic_router};
 pub use semantic::{
     EmbeddingProviderAdapter, SemanticChunker, SemanticConfig, SemanticError,
     SemanticSignalProvider,

--- a/src/transform/chunker/mod.rs
+++ b/src/transform/chunker/mod.rs
@@ -15,6 +15,7 @@ pub mod markdown;
 mod public_types;
 pub mod recursive;
 pub mod router;
+pub mod semantic;
 pub mod size;
 
 pub use code::{CodeChunker, Language};
@@ -24,6 +25,9 @@ pub use markdown::MarkdownChunker;
 pub use public_types::{BoundaryKind, Chunk, ChunkedDocument};
 pub use recursive::RecursiveChunker;
 pub use router::{ChunkerRouter, default_router};
+pub use semantic::{EmbeddingProviderAdapter, SemanticError, SemanticSignalProvider};
+#[cfg(feature = "fastembed")]
+pub use semantic::FastembedSignalProvider;
 pub use size::{CharCounter, SizeMetric, TiktokenCounter, TokenCounter};
 
 #[allow(deprecated)]

--- a/src/transform/chunker/mod.rs
+++ b/src/transform/chunker/mod.rs
@@ -25,12 +25,12 @@ pub use markdown::MarkdownChunker;
 pub use public_types::{BoundaryKind, Chunk, ChunkedDocument};
 pub use recursive::RecursiveChunker;
 pub use router::{ChunkerRouter, default_router, semantic_router};
+#[cfg(feature = "fastembed")]
+pub use semantic::FastembedSignalProvider;
 pub use semantic::{
     EmbeddingProviderAdapter, SemanticChunker, SemanticConfig, SemanticError,
     SemanticSignalProvider,
 };
-#[cfg(feature = "fastembed")]
-pub use semantic::FastembedSignalProvider;
 pub use size::{CharCounter, SizeMetric, TiktokenCounter, TokenCounter};
 
 #[allow(deprecated)]

--- a/src/transform/chunker/router.rs
+++ b/src/transform/chunker/router.rs
@@ -144,6 +144,60 @@ pub fn default_router(base: RecursiveConfig) -> ChunkResult<ChunkerRouter> {
         .build())
 }
 
+/// Router variant that replaces Markdown and the default fallback with
+/// a caller-supplied `SemanticChunker`. Code extensions retain their
+/// Phase 2 `CodeChunker` instances.
+pub fn semantic_router(
+    base: RecursiveConfig,
+    semantic: Arc<dyn Chunker>,
+) -> ChunkResult<ChunkerRouter> {
+    use super::code::{CodeChunker, Language};
+
+    let mk_code = |lang| -> ChunkResult<Arc<dyn Chunker>> {
+        Ok(Arc::new(CodeChunker::new(lang, base)?))
+    };
+
+    let rust = mk_code(Language::Rust)?;
+    let py = mk_code(Language::Python)?;
+    let js = mk_code(Language::JavaScript)?;
+    let ts = mk_code(Language::TypeScript)?;
+    let tsx = mk_code(Language::Tsx)?;
+    let go = mk_code(Language::Go)?;
+    let java = mk_code(Language::Java)?;
+    let c_lang = mk_code(Language::C)?;
+    let cpp = mk_code(Language::Cpp)?;
+    let ruby = mk_code(Language::Ruby)?;
+    let bash = mk_code(Language::Bash)?;
+
+    Ok(ChunkerRouter::builder(Arc::clone(&semantic))
+        .register("md", Arc::clone(&semantic))
+        .register("markdown", Arc::clone(&semantic))
+        .register("mdx", Arc::clone(&semantic))
+        .register("rs", rust)
+        .register("py", Arc::clone(&py))
+        .register("pyi", py)
+        .register("js", Arc::clone(&js))
+        .register("mjs", Arc::clone(&js))
+        .register("cjs", Arc::clone(&js))
+        .register("jsx", js)
+        .register("ts", Arc::clone(&ts))
+        .register("tsx", tsx)
+        .register("go", go)
+        .register("java", java)
+        .register("c", Arc::clone(&c_lang))
+        .register("h", c_lang)
+        .register("cpp", Arc::clone(&cpp))
+        .register("cc", Arc::clone(&cpp))
+        .register("cxx", Arc::clone(&cpp))
+        .register("hpp", Arc::clone(&cpp))
+        .register("hh", Arc::clone(&cpp))
+        .register("hxx", cpp)
+        .register("rb", ruby)
+        .register("sh", Arc::clone(&bash))
+        .register("bash", bash)
+        .build())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,5 +246,60 @@ mod tests {
         let hint = ChunkHint::from_path("/tmp/MAIN.RS");
         let doc = router.chunk("fn a() {}\nfn b() {}\n", &hint).unwrap();
         assert!(doc.strategy_fingerprint.as_str().contains("lang=rust"));
+    }
+}
+
+#[cfg(test)]
+mod semantic_tests {
+    use super::*;
+    use crate::transform::chunker::semantic::{
+        SemanticChunker, SemanticSignalProvider, signal::SemanticError,
+    };
+    use crate::transform::chunker::size::SizeMetric;
+    use std::sync::Arc;
+
+    struct StubSignal;
+    impl SemanticSignalProvider for StubSignal {
+        fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+            Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
+        }
+        fn fingerprint(&self) -> &str { "stub:router" }
+    }
+
+    fn cfg() -> RecursiveConfig {
+        RecursiveConfig { metric: SizeMetric::Chars, max_size: 1000, min_size: 0, overlap: 0 }
+    }
+
+    #[test]
+    fn txt_routes_to_semantic_chunker() {
+        let semantic: Arc<dyn Chunker> = Arc::new(
+            SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap(),
+        );
+        let router = semantic_router(cfg(), semantic).unwrap();
+        let hint = ChunkHint::from_path("/tmp/notes.txt");
+        let doc = router.chunk("A. B. C.", &hint).unwrap();
+        assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
+    }
+
+    #[test]
+    fn rs_keeps_code_rust_chunker() {
+        let semantic: Arc<dyn Chunker> = Arc::new(
+            SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap(),
+        );
+        let router = semantic_router(cfg(), semantic).unwrap();
+        let hint = ChunkHint::from_path("/tmp/main.rs");
+        let doc = router.chunk("fn a() {}\nfn b() {}\n", &hint).unwrap();
+        assert!(doc.strategy_fingerprint.as_str().contains("lang=rust"));
+    }
+
+    #[test]
+    fn md_routes_to_semantic_chunker() {
+        let semantic: Arc<dyn Chunker> = Arc::new(
+            SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap(),
+        );
+        let router = semantic_router(cfg(), semantic).unwrap();
+        let hint = ChunkHint::from_path("/tmp/notes.md");
+        let doc = router.chunk("# hi\n\nA. B.", &hint).unwrap();
+        assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
     }
 }

--- a/src/transform/chunker/router.rs
+++ b/src/transform/chunker/router.rs
@@ -153,9 +153,8 @@ pub fn semantic_router(
 ) -> ChunkResult<ChunkerRouter> {
     use super::code::{CodeChunker, Language};
 
-    let mk_code = |lang| -> ChunkResult<Arc<dyn Chunker>> {
-        Ok(Arc::new(CodeChunker::new(lang, base)?))
-    };
+    let mk_code =
+        |lang| -> ChunkResult<Arc<dyn Chunker>> { Ok(Arc::new(CodeChunker::new(lang, base)?)) };
 
     let rust = mk_code(Language::Rust)?;
     let py = mk_code(Language::Python)?;
@@ -263,18 +262,24 @@ mod semantic_tests {
         fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
             Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
         }
-        fn fingerprint(&self) -> &str { "stub:router" }
+        fn fingerprint(&self) -> &str {
+            "stub:router"
+        }
     }
 
     fn cfg() -> RecursiveConfig {
-        RecursiveConfig { metric: SizeMetric::Chars, max_size: 1000, min_size: 0, overlap: 0 }
+        RecursiveConfig {
+            metric: SizeMetric::Chars,
+            max_size: 1000,
+            min_size: 0,
+            overlap: 0,
+        }
     }
 
     #[test]
     fn txt_routes_to_semantic_chunker() {
-        let semantic: Arc<dyn Chunker> = Arc::new(
-            SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap(),
-        );
+        let semantic: Arc<dyn Chunker> =
+            Arc::new(SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap());
         let router = semantic_router(cfg(), semantic).unwrap();
         let hint = ChunkHint::from_path("/tmp/notes.txt");
         let doc = router.chunk("A. B. C.", &hint).unwrap();
@@ -283,9 +288,8 @@ mod semantic_tests {
 
     #[test]
     fn rs_keeps_code_rust_chunker() {
-        let semantic: Arc<dyn Chunker> = Arc::new(
-            SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap(),
-        );
+        let semantic: Arc<dyn Chunker> =
+            Arc::new(SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap());
         let router = semantic_router(cfg(), semantic).unwrap();
         let hint = ChunkHint::from_path("/tmp/main.rs");
         let doc = router.chunk("fn a() {}\nfn b() {}\n", &hint).unwrap();
@@ -294,9 +298,8 @@ mod semantic_tests {
 
     #[test]
     fn md_routes_to_semantic_chunker() {
-        let semantic: Arc<dyn Chunker> = Arc::new(
-            SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap(),
-        );
+        let semantic: Arc<dyn Chunker> =
+            Arc::new(SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap());
         let router = semantic_router(cfg(), semantic).unwrap();
         let hint = ChunkHint::from_path("/tmp/notes.md");
         let doc = router.chunk("# hi\n\nA. B.", &hint).unwrap();

--- a/src/transform/chunker/semantic/adapter.rs
+++ b/src/transform/chunker/semantic/adapter.rs
@@ -1,0 +1,20 @@
+//! Placeholder for Task 3.
+
+use std::sync::Arc;
+
+use super::signal::{SemanticError, SemanticSignalProvider};
+
+/// Placeholder — real struct ships in Task 3.
+pub struct EmbeddingProviderAdapter {
+    _provider: Arc<dyn crate::embed::EmbeddingProvider + Send + Sync>,
+    _fingerprint: String,
+}
+
+impl SemanticSignalProvider for EmbeddingProviderAdapter {
+    fn embed(&self, _inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        Err(SemanticError::Provider("adapter not yet implemented (Task 3)".into()))
+    }
+    fn fingerprint(&self) -> &str {
+        &self._fingerprint
+    }
+}

--- a/src/transform/chunker/semantic/adapter.rs
+++ b/src/transform/chunker/semantic/adapter.rs
@@ -1,20 +1,126 @@
-//! Placeholder for Task 3.
+//! Sync-over-async adapter bridging [`SemanticSignalProvider`] to the
+//! async [`crate::embed::EmbeddingProvider`] used by the ingestion pipeline.
+//!
+//! # Why
+//! `Chunker::chunk` is synchronous (Phase 2 contract) but the pipeline's
+//! embedding backends are async. Rather than breaking the trait, we funnel
+//! async calls through a captured Tokio `Handle` with `block_in_place`.
+//! When no multi-thread runtime is available (e.g. plain unit tests), we
+//! fall back to an owned current-thread runtime.
 
 use std::sync::Arc;
 
+use tokio::runtime::{Handle, Runtime, RuntimeFlavor};
+
 use super::signal::{SemanticError, SemanticSignalProvider};
 
-/// Placeholder — real struct ships in Task 3.
 pub struct EmbeddingProviderAdapter {
-    _provider: Arc<dyn crate::embed::EmbeddingProvider + Send + Sync>,
-    _fingerprint: String,
+    provider: Arc<dyn crate::embed::EmbeddingProvider + Send + Sync>,
+    fingerprint: String,
+    runtime: AdapterRuntime,
+}
+
+enum AdapterRuntime {
+    /// Use the caller's multi-thread runtime. Safe with `block_in_place`.
+    External(Handle),
+    /// Own a dedicated runtime. Used when no compatible ambient runtime exists.
+    Owned(Runtime),
+}
+
+impl EmbeddingProviderAdapter {
+    pub fn new(
+        provider: Arc<dyn crate::embed::EmbeddingProvider + Send + Sync>,
+        fingerprint: impl Into<String>,
+    ) -> Self {
+        let runtime = match Handle::try_current() {
+            Ok(h) if h.runtime_flavor() == RuntimeFlavor::MultiThread => {
+                AdapterRuntime::External(h)
+            }
+            _ => AdapterRuntime::Owned(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build owned adapter runtime"),
+            ),
+        };
+        Self {
+            provider,
+            fingerprint: fingerprint.into(),
+            runtime,
+        }
+    }
 }
 
 impl SemanticSignalProvider for EmbeddingProviderAdapter {
-    fn embed(&self, _inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
-        Err(SemanticError::Provider("adapter not yet implemented (Task 3)".into()))
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        let provider = Arc::clone(&self.provider);
+        let inputs = inputs.to_vec();
+        let fut = async move { provider.embed(&inputs).await };
+        let result = match &self.runtime {
+            AdapterRuntime::External(h) => {
+                tokio::task::block_in_place(|| h.block_on(fut))
+            }
+            AdapterRuntime::Owned(rt) => rt.block_on(fut),
+        };
+        result.map_err(|e| SemanticError::Provider(format!("{e}")))
     }
+
     fn fingerprint(&self) -> &str {
-        &self._fingerprint
+        &self.fingerprint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use crate::embed::EmbeddingProvider;
+    use crate::error::RagloomError;
+
+    struct FakeEmbed(usize);
+    #[async_trait]
+    impl EmbeddingProvider for FakeEmbed {
+        async fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, RagloomError> {
+            Ok(inputs.iter().map(|s| vec![s.len() as f32; self.0]).collect())
+        }
+    }
+
+    #[test]
+    fn owned_runtime_fallback_embeds_in_plain_context() {
+        let adapter = EmbeddingProviderAdapter::new(
+            Arc::new(FakeEmbed(4)),
+            "fake:test",
+        );
+        let out = adapter.embed(&["abc".into(), "defg".into()]).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], vec![3.0, 3.0, 3.0, 3.0]);
+        assert_eq!(out[1], vec![4.0, 4.0, 4.0, 4.0]);
+        assert_eq!(adapter.fingerprint(), "fake:test");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn external_runtime_bridges_through_block_on() {
+        let adapter = EmbeddingProviderAdapter::new(
+            Arc::new(FakeEmbed(2)),
+            "fake:multi",
+        );
+        let out = tokio::task::spawn_blocking(move || adapter.embed(&["xy".into()]))
+            .await.unwrap().unwrap();
+        assert_eq!(out, vec![vec![2.0, 2.0]]);
+    }
+
+    #[test]
+    fn propagates_provider_error() {
+        struct Broken;
+        #[async_trait]
+        impl EmbeddingProvider for Broken {
+            async fn embed(&self, _: &[String]) -> Result<Vec<Vec<f32>>, RagloomError> {
+                Err(RagloomError::from_kind(crate::error::RagloomErrorKind::Internal)
+                    .with_context("boom"))
+            }
+        }
+        let adapter = EmbeddingProviderAdapter::new(Arc::new(Broken), "x");
+        let err = adapter.embed(&["a".into()]).expect_err("must propagate");
+        assert!(matches!(err, SemanticError::Provider(_)));
     }
 }

--- a/src/transform/chunker/semantic/adapter.rs
+++ b/src/transform/chunker/semantic/adapter.rs
@@ -57,9 +57,7 @@ impl SemanticSignalProvider for EmbeddingProviderAdapter {
         let inputs = inputs.to_vec();
         let fut = async move { provider.embed(&inputs).await };
         let result = match &self.runtime {
-            AdapterRuntime::External(h) => {
-                tokio::task::block_in_place(|| h.block_on(fut))
-            }
+            AdapterRuntime::External(h) => tokio::task::block_in_place(|| h.block_on(fut)),
             AdapterRuntime::Owned(rt) => rt.block_on(fut),
         };
         result.map_err(|e| SemanticError::Provider(format!("{e}")))
@@ -73,24 +71,24 @@ impl SemanticSignalProvider for EmbeddingProviderAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use crate::embed::EmbeddingProvider;
     use crate::error::RagloomError;
+    use async_trait::async_trait;
 
     struct FakeEmbed(usize);
     #[async_trait]
     impl EmbeddingProvider for FakeEmbed {
         async fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, RagloomError> {
-            Ok(inputs.iter().map(|s| vec![s.len() as f32; self.0]).collect())
+            Ok(inputs
+                .iter()
+                .map(|s| vec![s.len() as f32; self.0])
+                .collect())
         }
     }
 
     #[test]
     fn owned_runtime_fallback_embeds_in_plain_context() {
-        let adapter = EmbeddingProviderAdapter::new(
-            Arc::new(FakeEmbed(4)),
-            "fake:test",
-        );
+        let adapter = EmbeddingProviderAdapter::new(Arc::new(FakeEmbed(4)), "fake:test");
         let out = adapter.embed(&["abc".into(), "defg".into()]).unwrap();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0], vec![3.0, 3.0, 3.0, 3.0]);
@@ -100,12 +98,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn external_runtime_bridges_through_block_on() {
-        let adapter = EmbeddingProviderAdapter::new(
-            Arc::new(FakeEmbed(2)),
-            "fake:multi",
-        );
+        let adapter = EmbeddingProviderAdapter::new(Arc::new(FakeEmbed(2)), "fake:multi");
         let out = tokio::task::spawn_blocking(move || adapter.embed(&["xy".into()]))
-            .await.unwrap().unwrap();
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(out, vec![vec![2.0, 2.0]]);
     }
 
@@ -115,8 +112,10 @@ mod tests {
         #[async_trait]
         impl EmbeddingProvider for Broken {
             async fn embed(&self, _: &[String]) -> Result<Vec<Vec<f32>>, RagloomError> {
-                Err(RagloomError::from_kind(crate::error::RagloomErrorKind::Internal)
-                    .with_context("boom"))
+                Err(
+                    RagloomError::from_kind(crate::error::RagloomErrorKind::Internal)
+                        .with_context("boom"),
+                )
             }
         }
         let adapter = EmbeddingProviderAdapter::new(Arc::new(Broken), "x");

--- a/src/transform/chunker/semantic/fastembed.rs
+++ b/src/transform/chunker/semantic/fastembed.rs
@@ -1,0 +1,19 @@
+//! Placeholder for Task 5 — real `FastembedSignalProvider` lands later.
+
+use super::signal::{SemanticError, SemanticSignalProvider};
+
+/// Placeholder — real struct ships in Task 5.
+pub struct FastembedSignalProvider {
+    _fingerprint: String,
+}
+
+impl SemanticSignalProvider for FastembedSignalProvider {
+    fn embed(&self, _inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        Err(SemanticError::Provider(
+            "fastembed provider not yet implemented (Task 5)".into(),
+        ))
+    }
+    fn fingerprint(&self) -> &str {
+        &self._fingerprint
+    }
+}

--- a/src/transform/chunker/semantic/fastembed.rs
+++ b/src/transform/chunker/semantic/fastembed.rs
@@ -42,7 +42,7 @@ impl SemanticSignalProvider for FastembedSignalProvider {
             .lock()
             .map_err(|e| SemanticError::Provider(format!("fastembed lock poisoned: {e}")))?;
         guard
-            .embed(inputs.to_vec(), None)
+            .embed(inputs, None)
             .map_err(|e| SemanticError::Provider(format!("fastembed embed: {e}")))
     }
 

--- a/src/transform/chunker/semantic/fastembed.rs
+++ b/src/transform/chunker/semantic/fastembed.rs
@@ -1,19 +1,52 @@
-//! Placeholder for Task 5 — real `FastembedSignalProvider` lands later.
+//! Local ONNX-based signal provider backed by the `fastembed` crate.
+//!
+//! # Why
+//! Calling the pipeline's hosted `EmbeddingProvider` once per sentence inflates
+//! API cost for semantic chunking. `fastembed` runs a small ONNX model locally
+//! (default: `sentence-transformers/all-MiniLM-L6-v2`, 384 dim), giving zero
+//! per-call cost at the price of ~25 MB of model weights and an ort runtime.
+
+use std::sync::Mutex;
+
+// NOTE: `InitOptions` is the deprecated alias for `TextInitOptions` in
+// fastembed 5.x; we use `TextInitOptions` directly to avoid the deprecation
+// warning.
+use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 
 use super::signal::{SemanticError, SemanticSignalProvider};
 
-/// Placeholder — real struct ships in Task 5.
 pub struct FastembedSignalProvider {
-    _fingerprint: String,
+    // `TextEmbedding::embed` requires `&mut self` (it mutates internal ORT
+    // session state), while `SemanticSignalProvider::embed` takes `&self`.
+    // A blocking `Mutex` is fine: semantic chunking serialises embedding
+    // calls per-document, and the inner work is CPU-bound.
+    model: Mutex<TextEmbedding>,
+    fingerprint: &'static str,
+}
+
+impl FastembedSignalProvider {
+    pub fn new() -> Result<Self, SemanticError> {
+        let model = TextEmbedding::try_new(TextInitOptions::new(EmbeddingModel::AllMiniLML6V2))
+            .map_err(|e| SemanticError::Provider(format!("fastembed init: {e}")))?;
+        Ok(Self {
+            model: Mutex::new(model),
+            fingerprint: "fastembed:all-MiniLM-L6-v2",
+        })
+    }
 }
 
 impl SemanticSignalProvider for FastembedSignalProvider {
-    fn embed(&self, _inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
-        Err(SemanticError::Provider(
-            "fastembed provider not yet implemented (Task 5)".into(),
-        ))
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        let mut guard = self
+            .model
+            .lock()
+            .map_err(|e| SemanticError::Provider(format!("fastembed lock poisoned: {e}")))?;
+        guard
+            .embed(inputs.to_vec(), None)
+            .map_err(|e| SemanticError::Provider(format!("fastembed embed: {e}")))
     }
+
     fn fingerprint(&self) -> &str {
-        &self._fingerprint
+        self.fingerprint
     }
 }

--- a/src/transform/chunker/semantic/mod.rs
+++ b/src/transform/chunker/semantic/mod.rs
@@ -190,8 +190,9 @@ impl Chunker for SemanticChunker {
         let groups = merge_for_min_size(
             groups,
             &sentence_list,
+            text,
             self.config.min_size,
-            self.config.metric,
+            self.counter.as_ref(),
         );
 
         let mut chunks: Vec<Chunk> = Vec::new();
@@ -296,15 +297,16 @@ fn build_groups(sentences: &[Sentence<'_>], splits: &[usize]) -> Vec<(usize, usi
 fn merge_for_min_size(
     groups: Vec<(usize, usize)>,
     sentences: &[Sentence<'_>],
+    text: &str,
     min_size: usize,
-    metric: SizeMetric,
+    counter: &dyn crate::transform::chunker::size::TokenCounter,
 ) -> Vec<(usize, usize)> {
     if min_size == 0 {
         return groups;
     }
     let mut merged: Vec<(usize, usize)> = Vec::new();
     for g in groups {
-        let size = group_size(g, sentences, metric);
+        let size = group_size(g, sentences, text, counter);
         if size < min_size
             && let Some(prev) = merged.last_mut()
         {
@@ -316,12 +318,15 @@ fn merge_for_min_size(
     merged
 }
 
-fn group_size(g: (usize, usize), sentences: &[Sentence<'_>], metric: SizeMetric) -> usize {
-    let _ = metric; // chars metric only for now
-    sentences
-        .get(g.0..=g.1)
-        .map(|ss| ss.iter().map(|s| s.text.chars().count()).sum::<usize>())
-        .unwrap_or(0)
+fn group_size(
+    g: (usize, usize),
+    sentences: &[Sentence<'_>],
+    text: &str,
+    counter: &dyn crate::transform::chunker::size::TokenCounter,
+) -> usize {
+    let start = sentences[g.0].start_byte;
+    let end = sentences[g.1].end_byte;
+    counter.count(&text[start..end])
 }
 
 #[cfg(test)]

--- a/src/transform/chunker/semantic/mod.rs
+++ b/src/transform/chunker/semantic/mod.rs
@@ -5,15 +5,437 @@
 //! `EmbeddingProvider`, and a [`SemanticChunker`] that splits text at
 //! percentile-threshold peaks in adjacent-sentence cosine distance.
 
-pub mod signal;
 pub mod adapter;
 pub mod sentence;
+pub mod signal;
 
 #[cfg(feature = "fastembed")]
 pub mod fastembed;
 
-pub use signal::{SemanticError, SemanticSignalProvider};
 pub use adapter::EmbeddingProviderAdapter;
+pub use signal::{SemanticError, SemanticSignalProvider};
 
 #[cfg(feature = "fastembed")]
 pub use fastembed::FastembedSignalProvider;
+
+use std::sync::Arc;
+
+use super::error::{ChunkError, ChunkResult};
+use super::fingerprint::StrategyFingerprint;
+use super::recursive::{RecursiveChunker, RecursiveConfig};
+use super::size::SizeMetric;
+use super::{Chunk, ChunkHint, ChunkedDocument, Chunker};
+
+use self::sentence::{sentences, Sentence};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticConfig {
+    pub metric: SizeMetric,
+    pub max_size: usize,
+    pub min_size: usize,
+    /// 1..=99. 95 means "split where adjacent-sentence distance is in the top 5 %".
+    pub percentile: u8,
+}
+
+impl SemanticConfig {
+    pub fn validate(&self) -> Result<(), SemanticError> {
+        if self.percentile == 0 || self.percentile > 99 {
+            return Err(SemanticError::InvalidConfig(format!(
+                "percentile must be in 1..=99, got {}",
+                self.percentile
+            )));
+        }
+        if self.min_size > self.max_size {
+            return Err(SemanticError::InvalidConfig(format!(
+                "min_size ({}) > max_size ({})",
+                self.min_size, self.max_size
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub struct SemanticChunker {
+    signal: Arc<dyn SemanticSignalProvider>,
+    inner: Arc<RecursiveChunker>,
+    counter: Arc<dyn super::size::TokenCounter>,
+    config: SemanticConfig,
+    fingerprint: StrategyFingerprint,
+}
+
+impl SemanticChunker {
+    pub fn new(
+        signal: Arc<dyn SemanticSignalProvider>,
+        size_cfg: RecursiveConfig,
+        percentile: u8,
+    ) -> ChunkResult<Self> {
+        let config = SemanticConfig {
+            metric: size_cfg.metric,
+            max_size: size_cfg.max_size,
+            min_size: size_cfg.min_size,
+            percentile,
+        };
+        config.validate().map_err(ChunkError::Semantic)?;
+
+        let inner = Arc::new(RecursiveChunker::new(size_cfg)?);
+        let counter = super::size::counter_for(size_cfg.metric)?;
+        let metric_str = match config.metric {
+            SizeMetric::Chars => "chars",
+            SizeMetric::Tokens => "tokens",
+        };
+        let fp = format!(
+            "semantic:v1|signal={}|metric={}|max={}|min={}|percentile={}",
+            signal.fingerprint(),
+            metric_str,
+            config.max_size,
+            config.min_size,
+            config.percentile,
+        );
+        Ok(Self {
+            signal,
+            inner,
+            counter,
+            config,
+            fingerprint: StrategyFingerprint::new(fp),
+        })
+    }
+
+    pub fn fingerprint(&self) -> &StrategyFingerprint {
+        &self.fingerprint
+    }
+
+    fn finalise(&self, chunks: Vec<Chunk>) -> ChunkResult<ChunkedDocument> {
+        Ok(ChunkedDocument {
+            chunks,
+            strategy_fingerprint: self.fingerprint.clone(),
+        })
+    }
+
+    fn fallback_recursive(&self, text: &str) -> ChunkResult<ChunkedDocument> {
+        // If the whole text already fits the size budget, emit it as a single
+        // semantic chunk so fallback for tiny inputs doesn't trigger
+        // RecursiveChunker's greedy whitespace splitting.
+        if self.counter.count(text) <= self.config.max_size {
+            let char_len = text.chars().count();
+            let chunk = Chunk {
+                index: 0,
+                text: text.to_string(),
+                boundary: super::BoundaryKind::Forced,
+                start_byte: 0,
+                end_byte: text.len(),
+                char_len,
+            };
+            return self.finalise(vec![chunk]);
+        }
+        let chunks = self.inner.chunk_raw(text)?;
+        self.finalise(chunks)
+    }
+}
+
+impl Chunker for SemanticChunker {
+    #[tracing::instrument(
+        name = "ragloom.chunker.semantic.chunk",
+        skip(self, text, _hint),
+        fields(bytes = text.len(), strategy = %self.fingerprint)
+    )]
+    fn chunk(&self, text: &str, _hint: &ChunkHint<'_>) -> ChunkResult<ChunkedDocument> {
+        if text.is_empty() {
+            return self.finalise(Vec::new());
+        }
+
+        let sentence_list = sentences(text);
+        if sentence_list.len() < 2 {
+            return self.fallback_recursive(text);
+        }
+
+        let inputs: Vec<String> = sentence_list
+            .iter()
+            .map(|s| s.text.to_string())
+            .collect();
+        let embeds = self.signal.embed(&inputs).map_err(ChunkError::Semantic)?;
+        if embeds.len() != sentence_list.len() {
+            return Err(ChunkError::Semantic(SemanticError::Provider(format!(
+                "count mismatch: expected {}, got {}",
+                sentence_list.len(),
+                embeds.len()
+            ))));
+        }
+
+        let unit: Vec<Vec<f32>> = embeds.into_iter().map(normalise_vector).collect();
+
+        let distances: Vec<f32> = unit
+            .windows(2)
+            .map(|w| 1.0_f32 - dot(&w[0], &w[1]))
+            .collect();
+        if distances.is_empty() {
+            return self.fallback_recursive(text);
+        }
+
+        let threshold = percentile(&distances, self.config.percentile);
+        // Strict `>` so uniformly-similar distances (threshold equal to the
+        // minimum) don't trigger spurious splits at every sentence boundary.
+        let split_at: Vec<usize> = distances
+            .iter()
+            .enumerate()
+            .filter(|(_, d)| **d > threshold)
+            .map(|(i, _)| i + 1)
+            .collect();
+
+        tracing::debug!(
+            event.name = "ragloom.chunker.semantic.thresholded",
+            sentences = sentence_list.len(),
+            splits = split_at.len(),
+            threshold = threshold as f64,
+            "ragloom.chunker.semantic.thresholded"
+        );
+
+        let groups = build_groups(&sentence_list, &split_at);
+        let groups = merge_for_min_size(groups, &sentence_list, self.config.min_size, self.config.metric);
+
+        let mut chunks: Vec<Chunk> = Vec::new();
+        let mut next_index = 0usize;
+
+        for range in groups {
+            let start_byte = sentence_list[range.0].start_byte;
+            let end_byte = sentence_list[range.1].end_byte;
+            let slab = &text[start_byte..end_byte];
+            if slab.trim().is_empty() {
+                continue;
+            }
+            // If the semantic group already fits the size budget, emit it as
+            // a single chunk. Re-running it through RecursiveChunker would
+            // greedily split on whitespace even when the group is small,
+            // which defeats the semantic grouping we just computed.
+            if self.counter.count(slab) <= self.config.max_size {
+                chunks.push(Chunk {
+                    index: next_index,
+                    text: slab.to_string(),
+                    boundary: super::BoundaryKind::Paragraph,
+                    start_byte,
+                    end_byte,
+                    char_len: slab.chars().count(),
+                });
+                next_index += 1;
+                continue;
+            }
+            let doc = self.inner.chunk(slab, &ChunkHint::none())?;
+            for chunk in doc.chunks {
+                chunks.push(Chunk {
+                    index: next_index,
+                    text: chunk.text,
+                    boundary: chunk.boundary,
+                    start_byte: start_byte + chunk.start_byte,
+                    end_byte: start_byte + chunk.end_byte,
+                    char_len: chunk.char_len,
+                });
+                next_index += 1;
+            }
+        }
+
+        self.finalise(chunks)
+    }
+}
+
+fn normalise_vector(v: Vec<f32>) -> Vec<f32> {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm == 0.0 {
+        return v;
+    }
+    v.into_iter().map(|x| x / norm).collect()
+}
+
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    let n = a.len().min(b.len());
+    let mut s = 0.0_f32;
+    for i in 0..n {
+        s += a[i] * b[i];
+    }
+    s
+}
+
+/// Linear-interpolation percentile.
+fn percentile(values: &[f32], p: u8) -> f32 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0];
+    }
+    let rank = (p as f32 / 100.0) * (n as f32 - 1.0);
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let frac = rank - lo as f32;
+        sorted[lo] + frac * (sorted[hi] - sorted[lo])
+    }
+}
+
+fn build_groups(sentences: &[Sentence<'_>], splits: &[usize]) -> Vec<(usize, usize)> {
+    let mut groups: Vec<(usize, usize)> = Vec::new();
+    let mut start = 0usize;
+    for &split in splits {
+        if split == 0 || split >= sentences.len() {
+            continue;
+        }
+        groups.push((start, split - 1));
+        start = split;
+    }
+    if start < sentences.len() {
+        groups.push((start, sentences.len() - 1));
+    }
+    groups
+}
+
+fn merge_for_min_size(
+    groups: Vec<(usize, usize)>,
+    sentences: &[Sentence<'_>],
+    min_size: usize,
+    metric: SizeMetric,
+) -> Vec<(usize, usize)> {
+    if min_size == 0 {
+        return groups;
+    }
+    let mut merged: Vec<(usize, usize)> = Vec::new();
+    for g in groups {
+        let size = group_size(g, sentences, metric);
+        if size < min_size {
+            if let Some(prev) = merged.last_mut() {
+                prev.1 = g.1;
+                continue;
+            }
+        }
+        merged.push(g);
+    }
+    merged
+}
+
+fn group_size(
+    g: (usize, usize),
+    sentences: &[Sentence<'_>],
+    metric: SizeMetric,
+) -> usize {
+    let _ = metric; // chars metric only for now
+    sentences
+        .get(g.0..=g.1)
+        .map(|ss| ss.iter().map(|s| s.text.chars().count()).sum::<usize>())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockSignal {
+        vectors: Vec<Vec<f32>>,
+        fingerprint: &'static str,
+    }
+
+    impl MockSignal {
+        fn new(vectors: Vec<Vec<f32>>) -> Self {
+            Self { vectors, fingerprint: "mock:test" }
+        }
+    }
+
+    impl SemanticSignalProvider for MockSignal {
+        fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+            assert_eq!(inputs.len(), self.vectors.len(), "mock got wrong count");
+            Ok(self.vectors.clone())
+        }
+        fn fingerprint(&self) -> &str { self.fingerprint }
+    }
+
+    fn cfg(max: usize, min: usize) -> RecursiveConfig {
+        RecursiveConfig { metric: SizeMetric::Chars, max_size: max, min_size: min, overlap: 0 }
+    }
+
+    #[test]
+    fn empty_input_produces_no_chunks() {
+        let mock = Arc::new(MockSignal::new(vec![]));
+        let c = SemanticChunker::new(mock, cfg(1000, 0), 95).unwrap();
+        let doc = c.chunk("", &ChunkHint::none()).unwrap();
+        assert!(doc.chunks.is_empty());
+        assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
+    }
+
+    #[test]
+    fn single_sentence_falls_back_with_semantic_fingerprint() {
+        let mock = Arc::new(MockSignal::new(vec![]));
+        let c = SemanticChunker::new(mock, cfg(1000, 0), 95).unwrap();
+        let doc = c.chunk("one lonely sentence", &ChunkHint::none()).unwrap();
+        assert_eq!(doc.chunks.len(), 1);
+        assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
+    }
+
+    #[test]
+    fn highly_similar_sentences_remain_one_group() {
+        let vectors = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![1.0, 0.0, 0.0],
+            vec![1.0, 0.0, 0.0],
+        ];
+        let mock = Arc::new(MockSignal::new(vectors));
+        let c = SemanticChunker::new(mock, cfg(1000, 0), 95).unwrap();
+        let doc = c.chunk("A. B. C.", &ChunkHint::none()).unwrap();
+        assert_eq!(doc.chunks.len(), 1, "got: {:?}", doc.chunks);
+    }
+
+    #[test]
+    fn topic_shift_produces_two_chunks() {
+        let vectors = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+        ];
+        let mock = Arc::new(MockSignal::new(vectors));
+        let c = SemanticChunker::new(mock, cfg(1000, 0), 50).unwrap();
+        let doc = c.chunk("First A. First B. Second A. Second B.", &ChunkHint::none()).unwrap();
+        assert_eq!(doc.chunks.len(), 2, "got: {:?}", doc.chunks);
+    }
+
+    #[test]
+    fn fingerprint_contains_signal_and_percentile() {
+        let mock = Arc::new(MockSignal::new(vec![]));
+        let c = SemanticChunker::new(mock, cfg(1000, 0), 77).unwrap();
+        let fp = c.fingerprint().as_str();
+        assert!(fp.contains("signal=mock:test"));
+        assert!(fp.contains("percentile=77"));
+        assert!(fp.contains("metric=chars"));
+    }
+
+    #[test]
+    fn invalid_percentile_rejected() {
+        let mock = Arc::new(MockSignal::new(vec![]));
+        let e0 = SemanticChunker::new(mock.clone(), cfg(1000, 0), 0);
+        assert!(e0.is_err());
+        let e100 = SemanticChunker::new(mock, cfg(1000, 0), 100);
+        assert!(e100.is_err());
+    }
+
+    #[test]
+    fn provider_count_mismatch_surfaces_as_error() {
+        struct LooseMock;
+        impl SemanticSignalProvider for LooseMock {
+            fn embed(&self, _: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+                Ok(vec![vec![1.0, 0.0]])
+            }
+            fn fingerprint(&self) -> &str { "loose" }
+        }
+        let c = SemanticChunker::new(Arc::new(LooseMock), cfg(1000, 0), 50).unwrap();
+        let err = c.chunk("A. B. C.", &ChunkHint::none()).expect_err("mismatch");
+        assert!(matches!(err, ChunkError::Semantic(_)));
+    }
+
+    #[test]
+    fn percentile_linear_interpolation_matches_known_values() {
+        let v = vec![0.0_f32, 0.25, 0.5, 0.75, 1.0];
+        assert!((percentile(&v, 50) - 0.5).abs() < 1e-6);
+        assert!((percentile(&v, 25) - 0.25).abs() < 1e-6);
+        assert!((percentile(&v, 95) - 0.95).abs() < 1e-6);
+    }
+}

--- a/src/transform/chunker/semantic/mod.rs
+++ b/src/transform/chunker/semantic/mod.rs
@@ -26,7 +26,7 @@ use super::recursive::{RecursiveChunker, RecursiveConfig};
 use super::size::SizeMetric;
 use super::{Chunk, ChunkHint, ChunkedDocument, Chunker};
 
-use self::sentence::{sentences, Sentence};
+use self::sentence::{Sentence, sentences};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SemanticConfig {
@@ -148,10 +148,7 @@ impl Chunker for SemanticChunker {
             return self.fallback_recursive(text);
         }
 
-        let inputs: Vec<String> = sentence_list
-            .iter()
-            .map(|s| s.text.to_string())
-            .collect();
+        let inputs: Vec<String> = sentence_list.iter().map(|s| s.text.to_string()).collect();
         let embeds = self.signal.embed(&inputs).map_err(ChunkError::Semantic)?;
         if embeds.len() != sentence_list.len() {
             return Err(ChunkError::Semantic(SemanticError::Provider(format!(
@@ -190,7 +187,12 @@ impl Chunker for SemanticChunker {
         );
 
         let groups = build_groups(&sentence_list, &split_at);
-        let groups = merge_for_min_size(groups, &sentence_list, self.config.min_size, self.config.metric);
+        let groups = merge_for_min_size(
+            groups,
+            &sentence_list,
+            self.config.min_size,
+            self.config.metric,
+        );
 
         let mut chunks: Vec<Chunk> = Vec::new();
         let mut next_index = 0usize;
@@ -303,22 +305,18 @@ fn merge_for_min_size(
     let mut merged: Vec<(usize, usize)> = Vec::new();
     for g in groups {
         let size = group_size(g, sentences, metric);
-        if size < min_size {
-            if let Some(prev) = merged.last_mut() {
-                prev.1 = g.1;
-                continue;
-            }
+        if size < min_size
+            && let Some(prev) = merged.last_mut()
+        {
+            prev.1 = g.1;
+            continue;
         }
         merged.push(g);
     }
     merged
 }
 
-fn group_size(
-    g: (usize, usize),
-    sentences: &[Sentence<'_>],
-    metric: SizeMetric,
-) -> usize {
+fn group_size(g: (usize, usize), sentences: &[Sentence<'_>], metric: SizeMetric) -> usize {
     let _ = metric; // chars metric only for now
     sentences
         .get(g.0..=g.1)
@@ -337,7 +335,10 @@ mod tests {
 
     impl MockSignal {
         fn new(vectors: Vec<Vec<f32>>) -> Self {
-            Self { vectors, fingerprint: "mock:test" }
+            Self {
+                vectors,
+                fingerprint: "mock:test",
+            }
         }
     }
 
@@ -346,11 +347,18 @@ mod tests {
             assert_eq!(inputs.len(), self.vectors.len(), "mock got wrong count");
             Ok(self.vectors.clone())
         }
-        fn fingerprint(&self) -> &str { self.fingerprint }
+        fn fingerprint(&self) -> &str {
+            self.fingerprint
+        }
     }
 
     fn cfg(max: usize, min: usize) -> RecursiveConfig {
-        RecursiveConfig { metric: SizeMetric::Chars, max_size: max, min_size: min, overlap: 0 }
+        RecursiveConfig {
+            metric: SizeMetric::Chars,
+            max_size: max,
+            min_size: min,
+            overlap: 0,
+        }
     }
 
     #[test]
@@ -394,7 +402,9 @@ mod tests {
         ];
         let mock = Arc::new(MockSignal::new(vectors));
         let c = SemanticChunker::new(mock, cfg(1000, 0), 50).unwrap();
-        let doc = c.chunk("First A. First B. Second A. Second B.", &ChunkHint::none()).unwrap();
+        let doc = c
+            .chunk("First A. First B. Second A. Second B.", &ChunkHint::none())
+            .unwrap();
         assert_eq!(doc.chunks.len(), 2, "got: {:?}", doc.chunks);
     }
 
@@ -424,10 +434,14 @@ mod tests {
             fn embed(&self, _: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
                 Ok(vec![vec![1.0, 0.0]])
             }
-            fn fingerprint(&self) -> &str { "loose" }
+            fn fingerprint(&self) -> &str {
+                "loose"
+            }
         }
         let c = SemanticChunker::new(Arc::new(LooseMock), cfg(1000, 0), 50).unwrap();
-        let err = c.chunk("A. B. C.", &ChunkHint::none()).expect_err("mismatch");
+        let err = c
+            .chunk("A. B. C.", &ChunkHint::none())
+            .expect_err("mismatch");
         assert!(matches!(err, ChunkError::Semantic(_)));
     }
 

--- a/src/transform/chunker/semantic/mod.rs
+++ b/src/transform/chunker/semantic/mod.rs
@@ -1,0 +1,19 @@
+//! Semantic (similarity-based) chunking.
+//!
+//! Phase 3 adds a sync [`SemanticSignalProvider`] abstraction, a sync-over-async
+//! [`EmbeddingProviderAdapter`] that bridges to the existing async
+//! `EmbeddingProvider`, and a [`SemanticChunker`] that splits text at
+//! percentile-threshold peaks in adjacent-sentence cosine distance.
+
+pub mod signal;
+pub mod adapter;
+pub mod sentence;
+
+#[cfg(feature = "fastembed")]
+pub mod fastembed;
+
+pub use signal::{SemanticError, SemanticSignalProvider};
+pub use adapter::EmbeddingProviderAdapter;
+
+#[cfg(feature = "fastembed")]
+pub use fastembed::FastembedSignalProvider;

--- a/src/transform/chunker/semantic/sentence.rs
+++ b/src/transform/chunker/semantic/sentence.rs
@@ -1,1 +1,77 @@
-//! Placeholder for Task 4.
+//! UAX #29 sentence segmentation for [`super::SemanticChunker`].
+//!
+//! # Why
+//! Semantic chunking hinges on high-quality sentence boundaries. Rust's
+//! `unicode-segmentation` crate implements Unicode Standard Annex #29 and
+//! handles CJK / Arabic / abbreviations consistently without runtime deps.
+
+use unicode_segmentation::UnicodeSegmentation;
+
+/// A sentence slice with its byte offsets into the original string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Sentence<'a> {
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub text: &'a str,
+}
+
+/// Segment `text` into sentences. Empty or whitespace-only segments are
+/// skipped. Returned offsets refer to the original string.
+pub fn sentences(text: &str) -> Vec<Sentence<'_>> {
+    text.split_sentence_bound_indices()
+        .filter_map(|(start, s)| {
+            if s.trim().is_empty() {
+                return None;
+            }
+            Some(Sentence {
+                start_byte: start,
+                end_byte: start + s.len(),
+                text: s,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_plain_english() {
+        let text = "One sentence. Two sentences! Three?";
+        let got = sentences(text);
+        assert_eq!(got.len(), 3, "got: {:?}", got);
+        assert!(got[0].text.starts_with("One"));
+        assert!(got[1].text.starts_with("Two"));
+        assert!(got[2].text.starts_with("Three"));
+    }
+
+    #[test]
+    fn handles_chinese() {
+        let text = "你好。今天天气不错。我们走吧！";
+        let got = sentences(text);
+        assert!(got.len() >= 3, "got: {:?}", got);
+    }
+
+    #[test]
+    fn handles_empty_and_whitespace() {
+        assert!(sentences("").is_empty());
+        assert!(sentences("   \n  \t  ").is_empty());
+    }
+
+    #[test]
+    fn single_sentence_without_terminator() {
+        let got = sentences("no final period");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].text.trim_end(), "no final period");
+    }
+
+    #[test]
+    fn byte_offsets_align_with_original_text() {
+        let text = "A. 你好。C.";
+        let got = sentences(text);
+        for s in &got {
+            assert_eq!(&text[s.start_byte..s.end_byte], s.text);
+        }
+    }
+}

--- a/src/transform/chunker/semantic/sentence.rs
+++ b/src/transform/chunker/semantic/sentence.rs
@@ -1,0 +1,1 @@
+//! Placeholder for Task 4.

--- a/src/transform/chunker/semantic/signal.rs
+++ b/src/transform/chunker/semantic/signal.rs
@@ -1,0 +1,28 @@
+//! Sync signal-source trait for semantic chunking.
+//!
+//! # Why
+//! The async `EmbeddingProvider` used by the pipeline cannot be called from
+//! the sync `Chunker::chunk` method directly. A dedicated synchronous trait
+//! keeps the chunker agnostic to async runtimes and lets us plug in local
+//! ONNX models (via the `fastembed` feature) without an async interface.
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SemanticError {
+    #[error("signal provider failed: {0}")]
+    Provider(String),
+    #[error("sentence segmentation produced zero sentences for non-empty input")]
+    NoSentences,
+    #[error("config invalid: {0}")]
+    InvalidConfig(String),
+}
+
+/// Blocking embedding source used by [`super::SemanticChunker`].
+pub trait SemanticSignalProvider: Send + Sync {
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError>;
+
+    /// Stable provider identity embedded into strategy fingerprints.
+    /// Examples: `"openai:text-embedding-3-small"`, `"fastembed:all-MiniLM-L6-v2"`.
+    fn fingerprint(&self) -> &str;
+}

--- a/tests/chunker_properties.rs
+++ b/tests/chunker_properties.rs
@@ -5,12 +5,16 @@
 //! boundary bugs on arbitrary UTF-8 inputs.
 
 use proptest::prelude::*;
+use ragloom::transform::chunker::semantic::{
+    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+};
 use ragloom::transform::chunker::{
     ChunkHint, Chunker, CodeChunker, MarkdownChunker,
     code::Language,
     recursive::{RecursiveChunker, RecursiveConfig},
     size::SizeMetric,
 };
+use std::sync::Arc;
 
 fn chunker(max: usize) -> RecursiveChunker {
     RecursiveChunker::new(RecursiveConfig {
@@ -136,6 +140,39 @@ proptest! {
     ) {
         let doc = rust_chunker(max).chunk(&text, &ChunkHint::none()).unwrap();
         prop_assert!(doc.strategy_fingerprint.as_str().contains("lang=rust"));
+        for ch in doc.chunks {
+            prop_assert!(ch.char_len <= max);
+        }
+    }
+}
+
+struct ConstantSignal;
+impl SemanticSignalProvider for ConstantSignal {
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
+    }
+    fn fingerprint(&self) -> &str { "const:proptest" }
+}
+
+fn semantic_chunker(max: usize) -> SemanticChunker {
+    SemanticChunker::new(
+        Arc::new(ConstantSignal),
+        RecursiveConfig { metric: SizeMetric::Chars, max_size: max, min_size: 0, overlap: 0 },
+        95,
+    ).unwrap()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 48, .. ProptestConfig::default() })]
+
+    #[test]
+    fn semantic_never_panics_on_arbitrary_text(
+        text in ".{0,512}",
+        max in 16usize..128,
+    ) {
+        let c = semantic_chunker(max);
+        let doc = c.chunk(&text, &ChunkHint::none()).unwrap();
+        prop_assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
         for ch in doc.chunks {
             prop_assert!(ch.char_len <= max);
         }

--- a/tests/chunker_properties.rs
+++ b/tests/chunker_properties.rs
@@ -6,7 +6,7 @@
 
 use proptest::prelude::*;
 use ragloom::transform::chunker::semantic::{
-    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+    SemanticChunker, SemanticSignalProvider, signal::SemanticError,
 };
 use ragloom::transform::chunker::{
     ChunkHint, Chunker, CodeChunker, MarkdownChunker,
@@ -151,15 +151,23 @@ impl SemanticSignalProvider for ConstantSignal {
     fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
         Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
     }
-    fn fingerprint(&self) -> &str { "const:proptest" }
+    fn fingerprint(&self) -> &str {
+        "const:proptest"
+    }
 }
 
 fn semantic_chunker(max: usize) -> SemanticChunker {
     SemanticChunker::new(
         Arc::new(ConstantSignal),
-        RecursiveConfig { metric: SizeMetric::Chars, max_size: max, min_size: 0, overlap: 0 },
+        RecursiveConfig {
+            metric: SizeMetric::Chars,
+            max_size: max,
+            min_size: 0,
+            overlap: 0,
+        },
         95,
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 proptest! {

--- a/tests/chunker_semantic.rs
+++ b/tests/chunker_semantic.rs
@@ -15,11 +15,7 @@ use ragloom::transform::chunker::{
 struct KeywordSignal;
 
 fn bucket(s: &str) -> [f32; 3] {
-    let first = s
-        .split_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_lowercase();
+    let first = s.split_whitespace().next().unwrap_or("").to_lowercase();
     if first.starts_with("cat") || first.starts_with("the") {
         [1.0, 0.0, 0.0]
     } else if first.starts_with("rust") || first.starts_with("its") || first.starts_with("many") {

--- a/tests/chunker_semantic.rs
+++ b/tests/chunker_semantic.rs
@@ -6,16 +6,20 @@
 use std::sync::Arc;
 
 use ragloom::transform::chunker::semantic::{
-    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+    SemanticChunker, SemanticSignalProvider, signal::SemanticError,
 };
 use ragloom::transform::chunker::{
-    recursive::RecursiveConfig, size::SizeMetric, ChunkHint, Chunker,
+    ChunkHint, Chunker, recursive::RecursiveConfig, size::SizeMetric,
 };
 
 struct KeywordSignal;
 
 fn bucket(s: &str) -> [f32; 3] {
-    let first = s.trim_start().split_whitespace().next().unwrap_or("").to_lowercase();
+    let first = s
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_lowercase();
     if first.starts_with("cat") || first.starts_with("the") {
         [1.0, 0.0, 0.0]
     } else if first.starts_with("rust") || first.starts_with("its") || first.starts_with("many") {
@@ -29,11 +33,18 @@ impl SemanticSignalProvider for KeywordSignal {
     fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
         Ok(inputs.iter().map(|s| bucket(s).to_vec()).collect())
     }
-    fn fingerprint(&self) -> &str { "keyword:test" }
+    fn fingerprint(&self) -> &str {
+        "keyword:test"
+    }
 }
 
 fn cfg() -> RecursiveConfig {
-    RecursiveConfig { metric: SizeMetric::Chars, max_size: 2000, min_size: 0, overlap: 0 }
+    RecursiveConfig {
+        metric: SizeMetric::Chars,
+        max_size: 2000,
+        min_size: 0,
+        overlap: 0,
+    }
 }
 
 #[test]
@@ -43,9 +54,17 @@ fn three_topics_produce_multiple_chunks() {
     let c = SemanticChunker::new(signal, cfg(), 60).unwrap();
     let doc = c.chunk(&text, &ChunkHint::none()).unwrap();
 
-    assert!(doc.chunks.len() >= 2, "expected multi-chunk split, got: {:?}", doc.chunks);
+    assert!(
+        doc.chunks.len() >= 2,
+        "expected multi-chunk split, got: {:?}",
+        doc.chunks
+    );
     assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
-    assert!(doc.strategy_fingerprint.as_str().contains("signal=keyword:test"));
+    assert!(
+        doc.strategy_fingerprint
+            .as_str()
+            .contains("signal=keyword:test")
+    );
     assert!(doc.strategy_fingerprint.as_str().contains("percentile=60"));
 }
 

--- a/tests/chunker_semantic.rs
+++ b/tests/chunker_semantic.rs
@@ -1,0 +1,59 @@
+//! End-to-end SemanticChunker integration using a deterministic mock provider.
+//!
+//! Verifies that topic shifts in the sample document produce distinct chunks
+//! and the strategy fingerprint is always `semantic:v1|…`.
+
+use std::sync::Arc;
+
+use ragloom::transform::chunker::semantic::{
+    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+};
+use ragloom::transform::chunker::{
+    recursive::RecursiveConfig, size::SizeMetric, ChunkHint, Chunker,
+};
+
+struct KeywordSignal;
+
+fn bucket(s: &str) -> [f32; 3] {
+    let first = s.trim_start().split_whitespace().next().unwrap_or("").to_lowercase();
+    if first.starts_with("cat") || first.starts_with("the") {
+        [1.0, 0.0, 0.0]
+    } else if first.starts_with("rust") || first.starts_with("its") || first.starts_with("many") {
+        [0.0, 1.0, 0.0]
+    } else {
+        [0.0, 0.0, 1.0]
+    }
+}
+
+impl SemanticSignalProvider for KeywordSignal {
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        Ok(inputs.iter().map(|s| bucket(s).to_vec()).collect())
+    }
+    fn fingerprint(&self) -> &str { "keyword:test" }
+}
+
+fn cfg() -> RecursiveConfig {
+    RecursiveConfig { metric: SizeMetric::Chars, max_size: 2000, min_size: 0, overlap: 0 }
+}
+
+#[test]
+fn three_topics_produce_multiple_chunks() {
+    let text = std::fs::read_to_string("tests/fixtures/semantic/sample.txt").unwrap();
+    let signal: Arc<dyn SemanticSignalProvider> = Arc::new(KeywordSignal);
+    let c = SemanticChunker::new(signal, cfg(), 60).unwrap();
+    let doc = c.chunk(&text, &ChunkHint::none()).unwrap();
+
+    assert!(doc.chunks.len() >= 2, "expected multi-chunk split, got: {:?}", doc.chunks);
+    assert!(doc.strategy_fingerprint.as_str().starts_with("semantic:v1"));
+    assert!(doc.strategy_fingerprint.as_str().contains("signal=keyword:test"));
+    assert!(doc.strategy_fingerprint.as_str().contains("percentile=60"));
+}
+
+#[test]
+fn fingerprint_changes_with_percentile() {
+    let signal1: Arc<dyn SemanticSignalProvider> = Arc::new(KeywordSignal);
+    let signal2: Arc<dyn SemanticSignalProvider> = Arc::new(KeywordSignal);
+    let c1 = SemanticChunker::new(signal1, cfg(), 50).unwrap();
+    let c2 = SemanticChunker::new(signal2, cfg(), 95).unwrap();
+    assert_ne!(c1.fingerprint().as_str(), c2.fingerprint().as_str());
+}

--- a/tests/fixtures/semantic/sample.txt
+++ b/tests/fixtures/semantic/sample.txt
@@ -1,0 +1,5 @@
+The cat sat on the mat. The cat was very fluffy. The cat enjoyed the sun.
+
+Rust is a systems programming language. Its ownership model is unique. Many engineers appreciate Rust.
+
+Cooking is an art and a science. Temperature control matters. Timing matters too.

--- a/tests/pipeline_semantic_flag.rs
+++ b/tests/pipeline_semantic_flag.rs
@@ -1,36 +1,45 @@
 //! Verifies that `semantic_router` and `default_router` produce disjoint
 //! point-ID sets for the same `.md` / `.txt` input.
 
+use async_trait::async_trait;
 use std::collections::HashSet;
 use std::sync::Arc;
-use async_trait::async_trait;
 
-use ragloom::ids::FileFingerprint;
-use ragloom::transform::chunker::semantic::{
-    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
-};
-use ragloom::transform::chunker::{
-    default_router, recursive::RecursiveConfig, semantic_router,
-    size::SizeMetric, Chunker,
-};
+use ragloom::RagloomError;
 use ragloom::doc::DocumentLoader;
 use ragloom::embed::EmbeddingProvider;
+use ragloom::ids::FileFingerprint;
 use ragloom::sink::{Sink, VectorPoint};
-use ragloom::RagloomError;
+use ragloom::transform::chunker::semantic::{
+    SemanticChunker, SemanticSignalProvider, signal::SemanticError,
+};
+use ragloom::transform::chunker::{
+    Chunker, default_router, recursive::RecursiveConfig, semantic_router, size::SizeMetric,
+};
 
-#[derive(Default)] struct FakeEmbedding;
-#[async_trait] impl EmbeddingProvider for FakeEmbedding {
+#[derive(Default)]
+struct FakeEmbedding;
+#[async_trait]
+impl EmbeddingProvider for FakeEmbedding {
     async fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, RagloomError> {
         Ok(inputs.iter().map(|_| vec![0.0; 4]).collect())
     }
 }
-#[derive(Default)] struct FakeSink;
-#[async_trait] impl Sink for FakeSink {
-    async fn upsert_points(&self, _: Vec<VectorPoint>) -> Result<(), RagloomError> { Ok(()) }
+#[derive(Default)]
+struct FakeSink;
+#[async_trait]
+impl Sink for FakeSink {
+    async fn upsert_points(&self, _: Vec<VectorPoint>) -> Result<(), RagloomError> {
+        Ok(())
+    }
 }
-#[derive(Default)] struct FakeLoader;
-#[async_trait] impl DocumentLoader for FakeLoader {
-    async fn load_utf8(&self, _: &str) -> Result<String, RagloomError> { Ok(String::new()) }
+#[derive(Default)]
+struct FakeLoader;
+#[async_trait]
+impl DocumentLoader for FakeLoader {
+    async fn load_utf8(&self, _: &str) -> Result<String, RagloomError> {
+        Ok(String::new())
+    }
 }
 
 struct StubSignal;
@@ -38,32 +47,51 @@ impl SemanticSignalProvider for StubSignal {
     fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
         Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
     }
-    fn fingerprint(&self) -> &str { "stub:flag" }
+    fn fingerprint(&self) -> &str {
+        "stub:flag"
+    }
 }
 
 fn cfg() -> RecursiveConfig {
-    RecursiveConfig { metric: SizeMetric::Chars, max_size: 64, min_size: 0, overlap: 0 }
+    RecursiveConfig {
+        metric: SizeMetric::Chars,
+        max_size: 64,
+        min_size: 0,
+        overlap: 0,
+    }
 }
 
 fn exec(router: Arc<dyn Chunker>) -> ragloom::pipeline::runtime::PipelineExecutor {
     ragloom::pipeline::runtime::PipelineExecutor::with_chunker(
-        Arc::new(FakeEmbedding), Arc::new(FakeSink), Arc::new(FakeLoader), router,
+        Arc::new(FakeEmbedding),
+        Arc::new(FakeSink),
+        Arc::new(FakeLoader),
+        router,
     )
 }
 
 #[tokio::test]
 async fn default_and_semantic_routers_produce_disjoint_ids_for_md() {
     let text = "# hi\n\nFirst sentence. Second sentence. Third sentence.\n";
-    let fp = FileFingerprint { canonical_path: "/tmp/n.md".into(), size_bytes: 1, mtime_unix_secs: 1 };
+    let fp = FileFingerprint {
+        canonical_path: "/tmp/n.md".into(),
+        size_bytes: 1,
+        mtime_unix_secs: 1,
+    };
 
     let default: Arc<dyn Chunker> = Arc::new(default_router(cfg()).unwrap());
-    let semantic_c: Arc<dyn Chunker> = Arc::new(
-        SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap()
-    );
+    let semantic_c: Arc<dyn Chunker> =
+        Arc::new(SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap());
     let semantic: Arc<dyn Chunker> = Arc::new(semantic_router(cfg(), semantic_c).unwrap());
 
-    let default_pts = exec(default).build_points_from_text(&fp, text).await.unwrap();
-    let semantic_pts = exec(semantic).build_points_from_text(&fp, text).await.unwrap();
+    let default_pts = exec(default)
+        .build_points_from_text(&fp, text)
+        .await
+        .unwrap();
+    let semantic_pts = exec(semantic)
+        .build_points_from_text(&fp, text)
+        .await
+        .unwrap();
 
     let a: HashSet<String> = default_pts.iter().map(|p| format!("{:?}", p.id)).collect();
     let b: HashSet<String> = semantic_pts.iter().map(|p| format!("{:?}", p.id)).collect();

--- a/tests/pipeline_semantic_flag.rs
+++ b/tests/pipeline_semantic_flag.rs
@@ -1,0 +1,73 @@
+//! Verifies that `semantic_router` and `default_router` produce disjoint
+//! point-ID sets for the same `.md` / `.txt` input.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use async_trait::async_trait;
+
+use ragloom::ids::FileFingerprint;
+use ragloom::transform::chunker::semantic::{
+    signal::SemanticError, SemanticChunker, SemanticSignalProvider,
+};
+use ragloom::transform::chunker::{
+    default_router, recursive::RecursiveConfig, semantic_router,
+    size::SizeMetric, Chunker,
+};
+use ragloom::doc::DocumentLoader;
+use ragloom::embed::EmbeddingProvider;
+use ragloom::sink::{Sink, VectorPoint};
+use ragloom::RagloomError;
+
+#[derive(Default)] struct FakeEmbedding;
+#[async_trait] impl EmbeddingProvider for FakeEmbedding {
+    async fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, RagloomError> {
+        Ok(inputs.iter().map(|_| vec![0.0; 4]).collect())
+    }
+}
+#[derive(Default)] struct FakeSink;
+#[async_trait] impl Sink for FakeSink {
+    async fn upsert_points(&self, _: Vec<VectorPoint>) -> Result<(), RagloomError> { Ok(()) }
+}
+#[derive(Default)] struct FakeLoader;
+#[async_trait] impl DocumentLoader for FakeLoader {
+    async fn load_utf8(&self, _: &str) -> Result<String, RagloomError> { Ok(String::new()) }
+}
+
+struct StubSignal;
+impl SemanticSignalProvider for StubSignal {
+    fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, SemanticError> {
+        Ok(inputs.iter().map(|_| vec![1.0_f32, 0.0]).collect())
+    }
+    fn fingerprint(&self) -> &str { "stub:flag" }
+}
+
+fn cfg() -> RecursiveConfig {
+    RecursiveConfig { metric: SizeMetric::Chars, max_size: 64, min_size: 0, overlap: 0 }
+}
+
+fn exec(router: Arc<dyn Chunker>) -> ragloom::pipeline::runtime::PipelineExecutor {
+    ragloom::pipeline::runtime::PipelineExecutor::with_chunker(
+        Arc::new(FakeEmbedding), Arc::new(FakeSink), Arc::new(FakeLoader), router,
+    )
+}
+
+#[tokio::test]
+async fn default_and_semantic_routers_produce_disjoint_ids_for_md() {
+    let text = "# hi\n\nFirst sentence. Second sentence. Third sentence.\n";
+    let fp = FileFingerprint { canonical_path: "/tmp/n.md".into(), size_bytes: 1, mtime_unix_secs: 1 };
+
+    let default: Arc<dyn Chunker> = Arc::new(default_router(cfg()).unwrap());
+    let semantic_c: Arc<dyn Chunker> = Arc::new(
+        SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap()
+    );
+    let semantic: Arc<dyn Chunker> = Arc::new(semantic_router(cfg(), semantic_c).unwrap());
+
+    let default_pts = exec(default).build_points_from_text(&fp, text).await.unwrap();
+    let semantic_pts = exec(semantic).build_points_from_text(&fp, text).await.unwrap();
+
+    let a: HashSet<String> = default_pts.iter().map(|p| format!("{:?}", p.id)).collect();
+    let b: HashSet<String> = semantic_pts.iter().map(|p| format!("{:?}", p.id)).collect();
+
+    assert!(!a.is_empty() && !b.is_empty());
+    assert!(a.is_disjoint(&b), "expected disjoint: a={a:?} b={b:?}");
+}


### PR DESCRIPTION
## Summary

Phase 3 of the smart-chunking roadmap. Adds **opt-in semantic (similarity-based) chunking** on top of Phase 2:

- **`SemanticSignalProvider`** — new **sync** trait decoupled from async I/O. `EmbeddingProviderAdapter` bridges the existing async `EmbeddingProvider` via `tokio::Handle::block_on` + `block_in_place`, with owned-runtime fallback for non-multi-thread contexts.
- **`SemanticChunker`** — segments via `unicode-segmentation` (UAX #29), embeds per-sentence, splits at **p95 cosine-distance peaks** (strict `>`, configurable percentile). Oversized groups fall back to the internal `RecursiveChunker` but **the returned fingerprint is always `semantic:v1|…`**.
- **`fastembed` Cargo feature** — optional local ONNX signal source (`sentence-transformers/all-MiniLM-L6-v2`). Zero API cost; build with `cargo build --features fastembed`.
- **`semantic_router`** — Router variant replacing Markdown + fallback with the semantic chunker, all 10 Phase 2 code-language mappings retained.
- **CLI**: `--enable-semantic`, `--semantic-provider adapter|fastembed`, `--semantic-percentile 1..=99`, plus `--chunker-single semantic`.
- Fingerprint `semantic:v1|signal=<fp>|metric=…|max=…|min=…|percentile=…` gives each signal provider + percentile combo its own Qdrant point-ID space.

**Opt-in**: default behavior unchanged from Phase 2. Enabling `--enable-semantic` moves `.md` / `.txt` documents into a fresh ID space.

## Verification

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero (default)
- [x] `cargo clippy --all-targets --features fastembed -- -D warnings` — zero
- [x] `cargo test` — 146/146 pass (Phase 2 baseline + 25 new tests)
- [x] `cargo test --features fastembed --no-run` — compiles
- [x] `cargo build --release` — clean (~20.5 MB binary)
- [x] Integration test proves `default_router` vs `semantic_router` produce **disjoint** point-ID sets for the same `.md` input
- [x] Whole-branch code review: Approved for merge (post-review fixups I-2, I-3 applied)

## Non-breaking

- `Chunker::chunk(&str, &ChunkHint)` signature unchanged from Phase 2.
- Default binary behavior unchanged (Router with Markdown/Code/Recursive).
- Legacy shims (`chunk_text`, `chunk_document`, `ChunkerConfig`) still work.

## Migration

- `--enable-semantic` puts `.md` / `.txt` into a new ID space. Phase 2 points remain but won't be re-associated. Drop/GC if desired.
- Same applies when changing `--semantic-provider`, `--semantic-percentile`, or the underlying embedding model — any fingerprint delta opens a new ID space by design.

## Stats

14 commits on top of Phase 2 main. ~3117 insertions / 209 deletions across 18 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)