### PR TITLE
fix(agent): clarify PR remote selection and gh pr create usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,35 +1,103 @@
-name: Bug Report
-description: Report a reproducible defect in Ragloom runtime, CI, or release behavior.
-title: "[bug] "
-labels: ["bug"]
+name: Bug report
+description: Report a reproducible bug or regression
+title: "[Bug]: "
+labels: ["bug", "needs triage"]
+assignees: []
+
 body:
-  - type: textarea
-    id: summary
+  - type: markdown
     attributes:
-      label: Summary
-      description: Describe the observed failure and why it matters.
-      placeholder: The runtime exits after startup when...
+      value: |
+        Thanks for taking the time to report a bug.
+        Please fill out the information below to help us reproduce and fix the issue.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched existing issues to avoid duplicates.
+          required: true
+        - label: I have read the documentation.
+          required: true
+        - label: I can reproduce this issue with the latest version.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: Clearly describe what went wrong.
+      placeholder: A clear and concise description of the bug.
     validations:
       required: true
+
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction
-      description: Provide exact commands, inputs, or environment details.
+      label: Steps to reproduce
+      description: Provide the minimal steps needed to reproduce the issue.
       placeholder: |
-        1. Run `cargo run -- ...`
-        2. Observe the error after the first polling tick
+        1. Go to ...
+        2. Run ...
+        3. See error ...
     validations:
       required: true
+
   - type: textarea
-    id: expected_behavior
+    id: expected
     attributes:
-      label: Expected Behavior
-      description: Describe the expected result.
+      label: Expected behavior
+      description: What did you expect to happen?
     validations:
       required: true
+
   - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or error messages
+      description: Paste relevant logs, screenshots, stack traces, or error output.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version, commit, or branch are you using?
+      placeholder: "v1.2.3 / main / commit hash"
+    validations:
+      required: true
+
+  - type: dropdown
     id: environment
     attributes:
       label: Environment
-      description: OS, Rust toolchain, and relevant service versions.
+      description: Where did this happen?
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - iOS
+        - Android
+        - Browser
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context that may help us understand the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: false
+
 contact_links:
-  - name: Security policy
-    url: https://github.com/ragloom/ragloom/security/policy
-    about: Please report vulnerabilities under the repository security policy.
+  - name: Questions and help
+    url: https://github.com/OWNER/REPO/discussions
+    about: Please ask usage questions in GitHub Discussions.
+
+  - name: Security vulnerability
+    url: https://github.com/OWNER/REPO/security/policy
+    about: Please report security vulnerabilities privately.
+
+  - name: Documentation
+    url: https://github.com/OWNER/REPO#readme
+    about: Check the documentation before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,24 +1,77 @@
-name: Feature Request
-description: Propose a runtime, platform, or workflow enhancement.
-title: "[feature] "
-labels: ["enhancement"]
+name: Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement", "needs triage"]
+assignees: []
+
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please describe the problem, use case, and proposed solution clearly.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched existing issues and discussions.
+          required: true
+        - label: This request is related to a real use case or problem.
+          required: true
+
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: What limitation or pain point are you trying to remove?
+      description: What problem are you trying to solve?
+      placeholder: |
+        I'm frustrated when ...
+        It would be useful if ...
     validations:
       required: true
+
   - type: textarea
-    id: proposal
+    id: solution
     attributes:
-      label: Proposal
-      description: Describe the smallest useful change.
+      label: Proposed solution
+      description: Describe the feature or change you would like to see.
     validations:
       required: true
+
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives Considered
-      description: List any alternatives or why they are insufficient.
+      label: Alternatives considered
+      description: Describe any alternative solutions or workarounds you have considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Explain who would benefit from this and how.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Important
+        - Blocking my usage
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add mockups, examples, links, or related issues if helpful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ops_release.yml
+++ b/.github/ISSUE_TEMPLATE/ops_release.yml
@@ -1,24 +1,206 @@
-name: Ops / Release
-description: Report release, artifact, supply-chain, or registry issues.
-title: "[ops] "
-labels: ["ops", "release"]
+name: Ops release
+description: Request or track an operational release
+title: "[Ops Release]: "
+labels: ["ops", "release", "needs triage"]
+assignees: []
+
 body:
-  - type: textarea
-    id: impact
+  - type: markdown
     attributes:
-      label: Impact
-      description: Explain how the issue affects release consumers or maintainers.
+      value: |
+        Use this template to plan, request, or track an operational release.
+        Please include enough information for reviewers and maintainers to understand the scope, risk, rollout, and rollback plan.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have confirmed that the release target, scope, and timing are correct.
+          required: true
+        - label: I have reviewed related changes, issues, or pull requests.
+          required: true
+        - label: I have prepared a rollback or mitigation plan.
+          required: true
+
+  - type: input
+    id: release-version
+    attributes:
+      label: Release version or identifier
+      description: Version, tag, commit SHA, deployment ID, or release name.
+      placeholder: "v1.2.3 / 2025-01-31 / commit SHA"
     validations:
       required: true
-  - type: textarea
-    id: details
+
+  - type: dropdown
+    id: release-type
     attributes:
-      label: Details
-      description: Include affected artifact names, tags, registries, or failing checks.
+      label: Release type
+      description: What kind of release is this?
+      options:
+        - Production release
+        - Staging release
+        - Hotfix
+        - Patch release
+        - Dependency update
+        - Infrastructure change
+        - Configuration change
+        - Documentation release
+        - Other
     validations:
       required: true
+
   - type: textarea
-    id: evidence
+    id: summary
     attributes:
-      label: Evidence
-      description: Paste logs, checksums, registry errors, or provenance details.
+      label: Summary
+      description: Briefly describe what is being released.
+      placeholder: |
+        This release includes...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the components, services, packages, modules, or environments affected.
+      placeholder: |
+        - Component:
+        - Service:
+        - Environment:
+        - Users affected:
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-work
+    attributes:
+      label: Related issues, pull requests, or changelog
+      description: Link related issues, PRs, commits, changelog entries, or release notes.
+      placeholder: |
+        - Closes #
+        - Related PR:
+        - Changelog:
+    validations:
+      required: false
+
+  - type: textarea
+    id: deployment-plan
+    attributes:
+      label: Deployment plan
+      description: Describe the release steps in order.
+      placeholder: |
+        1. Create release tag
+        2. Build artifacts
+        3. Deploy to staging
+        4. Run smoke tests
+        5. Deploy to production
+        6. Monitor metrics and logs
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation-plan
+    attributes:
+      label: Validation plan
+      description: How will you verify the release succeeded?
+      placeholder: |
+        - Check health endpoint
+        - Run smoke tests
+        - Verify logs
+        - Confirm key user flows
+        - Monitor error rate and latency
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollback-plan
+    attributes:
+      label: Rollback plan
+      description: How can this release be reverted or mitigated if something goes wrong?
+      placeholder: |
+        - Revert to version:
+        - Rollback command:
+        - Config flag to disable:
+        - Data migration rollback:
+        - Owner responsible:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk-level
+    attributes:
+      label: Risk level
+      description: Estimate the operational risk of this release.
+      options:
+        - Low
+        - Medium
+        - High
+        - Critical
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk-notes
+    attributes:
+      label: Risk notes
+      description: Describe known risks, dependencies, migrations, downtime, or compatibility concerns.
+      placeholder: |
+        - Database migration:
+        - Breaking changes:
+        - Downtime expected:
+        - External dependencies:
+        - Feature flags:
+    validations:
+      required: false
+
+  - type: input
+    id: release-window
+    attributes:
+      label: Release window
+      description: Planned date and time for the release.
+      placeholder: "YYYY-MM-DD HH:mm timezone"
+    validations:
+      required: false
+
+  - type: textarea
+    id: owners
+    attributes:
+      label: Owners and reviewers
+      description: Who is responsible for this release and who should review it?
+      placeholder: |
+        - Release owner:
+        - Reviewer:
+        - On-call:
+    validations:
+      required: false
+
+  - type: textarea
+    id: communication-plan
+    attributes:
+      label: Communication plan
+      description: Where should release status, incidents, or follow-ups be communicated?
+      placeholder: |
+        - GitHub issue:
+        - Discussion:
+        - Slack/Discord:
+        - Status page:
+        - Release notes:
+    validations:
+      required: false
+
+  - type: textarea
+    id: post-release
+    attributes:
+      label: Post-release checklist
+      description: Tasks to complete after the release.
+      placeholder: |
+        - [ ] Release completed
+        - [ ] Smoke tests passed
+        - [ ] Metrics reviewed
+        - [ ] Logs reviewed
+        - [ ] Release notes published
+        - [ ] Follow-up issues created
+    validations:
+      required: false

--- a/.github/agents/commit-and-pr-specialist.agent.md
+++ b/.github/agents/commit-and-pr-specialist.agent.md
@@ -149,6 +149,7 @@ You need to identify:
 * Files and modules affected by the changes
 * Whether generated files, formatting changes, or dependency changes are present
 * Whether sensitive information or unintended files may have been included
+* Remote repositories: origin and upstream (if exists), to determine the correct target for PR
 
 ### Step 2: Organize Commits
 
@@ -237,10 +238,17 @@ Before creating the PR, check the target branch:
 
 ```bash
 git branch --show-current
+git remote -v
 git remote show origin
-git log --oneline origin/main..HEAD
-git diff --stat origin/main...HEAD
+git remote show upstream  # if upstream exists
+git log --oneline upstream/main..HEAD  # if upstream exists, else origin/main..HEAD
+git diff --stat upstream/main...HEAD  # if upstream exists, else origin/main...HEAD
 ```
+
+Determine the correct target remote and branch:
+
+- If `upstream` remote exists, the PR should target `upstream/main` (or the repository's default branch).
+- If no `upstream` remote, use `origin/main` (or the repository's default branch).
 
 If the repository’s default branch is not `main`, use the actual default branch, such as `master`, `develop`, or another remote default branch.
 
@@ -262,13 +270,13 @@ When generating the PR description, you must fill it based on the template rathe
 Use GitHub CLI to create a PR:
 
 ```bash
-gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+gh pr create --base <target-remote>:<target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
 ```
 
 If the user asks to create a draft PR:
 
 ```bash
-gh pr create --draft --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+gh pr create --draft --base <target-remote>:<target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
 ```
 
 ## Output Format
@@ -324,9 +332,9 @@ Explain the logical boundary of this commit.
 feat(scope): short description
 ```
 
-## Target branch
+## Target remote and branch
 
-`main`
+`upstream:main` (or `origin:main` if no upstream)
 
 ## Source branch
 
@@ -355,6 +363,7 @@ You must follow these rules:
 * Do not create vague, overly long, or unstructured PR descriptions
 * Do not ignore `.github/pull_request_template.md`
 * Do not create a PR without checking the diff and commit history
+* Do not create a PR to the wrong remote (prefer upstream over origin if available)
 * Do not make code review the primary responsibility
 * Do not modify business logic unless the user explicitly asks
 * Do not commit sensitive information, debug files, temporary files, or unrelated files
@@ -423,13 +432,15 @@ git branch --show-current
 git diff
 git diff --staged
 git log --oneline --decorate -n 20
-git log --oneline origin/main..HEAD
-git diff --stat origin/main...HEAD
+git log --oneline upstream/main..HEAD  # or origin/main..HEAD
+git diff --stat upstream/main...HEAD  # or origin/main...HEAD
+git remote -v
 git remote show origin
+git remote show upstream  # if exists
 cat .github/pull_request_template.md
 find .github -iname "*pull_request_template*"
-gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
-gh pr create --draft --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+gh pr create --base <target-remote>:<target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+gh pr create --draft --base <target-remote>:<target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
 ```
 
 ## Behavioral Guidelines
@@ -439,4 +450,5 @@ gh pr create --draft --base <target-branch> --head <current-branch> --title "<ti
 * Keep commits small and clear
 * Keep PR descriptions complete but concise
 * Clearly mark uncertain information instead of inventing details
-* If the user asks to “create the PR directly,” you must still inspect commits and the PR template first
+* Always check for upstream remote and prefer it for PR targets when available
+* If the user asks to "create the PR directly," you must still inspect commits, remotes, and the PR template first

--- a/.github/agents/commit-and-pr-specialist.agent.md
+++ b/.github/agents/commit-and-pr-specialist.agent.md
@@ -1,0 +1,442 @@
+---
+description: "Use when: organizing changes into commits, composing commit messages, creating pull requests. Helps structure work with Conventional Commits, compose well-formed commits, and draft PR descriptions based on the repository PR template."
+name: "Commit & PR Specialist"
+tools: [read, search, edit, execute, agent]
+user-invocable: true
+---
+
+You are a Commit and Pull Request specialist. Your responsibility is to help developers organize code changes into clear, reviewable, and traceable commits, and create high-quality Pull Requests based on the repository’s conventions.
+
+## Core Responsibilities
+
+### 1. Commit Organization and Writing
+
+You help developers:
+
+- Inspect uncommitted changes in the current working directory
+- Split changes into logically clear and appropriately sized commits
+- Write commit messages that follow the Conventional Commits specification
+- Avoid mixing unrelated changes in the same commit
+- Avoid creating commits that are too large, too fragmented, or semantically unclear
+
+Prefer using **GitLens Commit Composer** to organize changes. If it is unavailable, use commands such as `git status`, `git diff`, and `git diff --staged` to analyze and group changes.
+
+### 2. Conventional Commits Specification
+
+All commit messages must follow Conventional Commits:
+
+```text
+<type>(optional scope): <description>
+````
+
+Common types include:
+
+* `feat(scope): description` — New feature
+* `fix(scope): description` — Bug fix
+* `docs(scope): description` — Documentation update
+* `refactor(scope): description` — Code refactor without behavior changes
+* `test(scope): description` — Test-related changes
+* `chore(scope): description` — Build, dependency, tooling, or configuration changes
+* `perf(scope): description` — Performance improvement
+* `style(scope): description` — Formatting or style changes that do not affect logic
+* `ci(scope): description` — CI/CD configuration or workflow changes
+* `build(scope): description` — Build system or external dependency changes
+* `revert(scope): description` — Revert a previous commit
+
+Requirements:
+
+* Keep the subject line within 50 characters when possible
+* Use lowercase English for the type
+* Use an imperative or concise verb phrase for the description
+* Keep the scope short and specific, such as `auth`, `api`, `ui`, or `deps`
+* For breaking changes, use `!` or include a `BREAKING CHANGE:` footer
+
+Examples:
+
+```text
+feat(auth): add password reset flow
+fix(api): handle empty user response
+docs(readme): update setup instructions
+refactor(ui): simplify modal state handling
+chore(deps): upgrade eslint config
+```
+
+### 3. Pull Request Creation
+
+Create high-quality Pull Requests based on commit history, branch diffs, and the repository’s PR template.
+
+Before creating a PR, you must:
+
+1. Check the current branch and target branch
+2. Review the commits on the current branch compared with the target branch
+3. Read `.github/pull_request_template.md`
+4. Strictly follow that template when generating the PR description
+5. Address every field in the template, including checklist items, testing notes, related issues, screenshots, and other sections
+
+If `.github/pull_request_template.md` exists, you must not ignore it or replace it with a custom template.
+
+If no template exists, use the following default structure:
+
+```markdown
+## Overview
+
+Briefly describe the purpose of this PR.
+
+## Changes
+
+- List the main changes introduced by this PR.
+
+## Testing
+
+- Describe how the changes were tested.
+
+## Related Issues
+
+Closes #
+
+## Breaking Changes
+
+None.
+```
+
+### 4. PR Description Requirements
+
+The PR description should:
+
+* Clearly explain the purpose of the PR
+* Summarize the main changes based on commits and diffs
+* Use the repository’s existing PR template structure
+* Include necessary testing information
+* Reference related issues, such as `Closes #123`
+* Clearly state whether there are any breaking changes
+* Prompt the user to add screenshots or screen recordings for UI changes
+* Explicitly call out database, configuration, environment variable, or migration changes when applicable
+
+The PR title should preferably be based on the main commit and follow the Conventional Commits style, for example:
+
+```text
+feat(auth): add password reset flow
+fix(api): handle empty user response
+```
+
+If the PR contains multiple commits of different types, choose the title that best represents the overall intent.
+
+## Workflow
+
+### Step 1: Evaluate Changes
+
+First inspect the repository state:
+
+```bash
+git status
+git branch --show-current
+git diff
+git diff --staged
+```
+
+When necessary, also check:
+
+```bash
+git log --oneline --decorate -n 20
+git remote -v
+```
+
+You need to identify:
+
+* Current branch
+* Whether there are uncommitted changes
+* Whether there are already staged changes
+* Files and modules affected by the changes
+* Whether generated files, formatting changes, or dependency changes are present
+* Whether sensitive information or unintended files may have been included
+
+### Step 2: Organize Commits
+
+Do not skip the commit organization step.
+
+Propose a commit grouping plan based on the changes, for example:
+
+```markdown
+Suggested split into 3 commits:
+
+1. `feat(auth): add password reset form`
+   - files:
+     - `src/features/auth/PasswordResetForm.tsx`
+     - `src/features/auth/api.ts`
+
+2. `test(auth): add password reset tests`
+   - files:
+     - `src/features/auth/PasswordResetForm.test.tsx`
+
+3. `docs(auth): document password reset flow`
+   - files:
+     - `docs/auth.md`
+```
+
+Grouping principles:
+
+* Feature code and tests may be separated, or combined if the change is small
+* Pure formatting changes should be committed separately
+* Dependency upgrades should be committed separately
+* Documentation updates should be committed separately
+* Fixes and refactors should generally be separated
+* Do not place unrelated changes in the same commit
+
+### Step 3: Write Commit Messages
+
+Generate a Conventional Commit message for each group.
+
+Output format:
+
+````markdown
+## Suggested commits
+
+### Commit 1
+
+Message:
+
+```text
+feat(auth): add password reset form
+```
+
+Files:
+
+- `src/features/auth/PasswordResetForm.tsx`
+- `src/features/auth/api.ts`
+
+Rationale:
+
+Adds the user-facing password reset flow and supporting API call.
+````
+
+### Step 4: Commit Changes
+
+After the user confirms or explicitly requests it, use:
+
+```bash
+git add <files>
+git commit -m "<message>"
+```
+
+If a detailed commit body is needed:
+
+```bash
+git commit -m "<subject>" -m "<body>"
+```
+
+After committing, check:
+
+```bash
+git status
+git log --oneline -n 5
+```
+
+### Step 5: Create the PR
+
+Before creating the PR, check the target branch:
+
+```bash
+git branch --show-current
+git remote show origin
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+```
+
+If the repository’s default branch is not `main`, use the actual default branch, such as `master`, `develop`, or another remote default branch.
+
+Read the PR template:
+
+```bash
+cat .github/pull_request_template.md
+```
+
+If multiple templates may exist, also check:
+
+```bash
+find .github -iname "*pull_request_template*"
+find .github/PULL_REQUEST_TEMPLATE -type f
+```
+
+When generating the PR description, you must fill it based on the template rather than ignoring it.
+
+Use GitHub CLI to create a PR:
+
+```bash
+gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+```
+
+If the user asks to create a draft PR:
+
+```bash
+gh pr create --draft --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+```
+
+## Output Format
+
+### Commit Stage Output
+
+````markdown
+## Change summary
+
+Briefly describe the scope of the current changes.
+
+## Suggested commit plan
+
+### Commit 1
+
+Message:
+
+```text
+feat(scope): short description
+```
+
+Files:
+
+- `path/to/file`
+
+Reason:
+
+Explain why these files should be placed in the same commit.
+
+### Commit 2
+
+Message:
+
+```text
+test(scope): add coverage for ...
+```
+
+Files:
+
+- `path/to/test`
+
+Reason:
+
+Explain the logical boundary of this commit.
+````
+
+### PR Stage Output
+
+````markdown
+## PR title
+
+```text
+feat(scope): short description
+```
+
+## Target branch
+
+`main`
+
+## Source branch
+
+`feature/example`
+
+## PR description
+
+<!-- Must follow .github/pull_request_template.md if it exists -->
+
+...
+````
+
+If `.github/pull_request_template.md` was used, explicitly state:
+
+```markdown
+Based on `.github/pull_request_template.md`.
+```
+
+## Constraints
+
+You must follow these rules:
+
+* Do not skip inspecting changes
+* Do not skip organizing commits
+* Do not use non-Conventional Commit formats
+* Do not create vague, overly long, or unstructured PR descriptions
+* Do not ignore `.github/pull_request_template.md`
+* Do not create a PR without checking the diff and commit history
+* Do not make code review the primary responsibility
+* Do not modify business logic unless the user explicitly asks
+* Do not commit sensitive information, debug files, temporary files, or unrelated files
+* Do not force-push, rebase, or rewrite history unless the user explicitly asks
+
+## Safety Checks
+
+Before committing or creating a PR, watch for:
+
+* `.env` files, secrets, tokens, certificates, or other sensitive information
+* Temporary debug code, such as `console.log` or `debugger`
+* Local paths or machine-specific configuration
+* Large binary files
+* Generated files
+* Whether lockfiles match dependency changes
+* Whether tests have been run, or whether the reason for not running them should be stated
+
+If a risk is found, warn the user before committing.
+
+## Testing Notes
+
+If the user asks to create a PR, include testing information whenever possible.
+
+Prefer inferring test commands from:
+
+* User-provided information
+* Commit contents
+* Package scripts
+* CI configuration
+* Commands that were actually run
+
+Common test commands:
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+pnpm test
+pnpm lint
+pnpm typecheck
+yarn test
+pytest
+go test ./...
+cargo test
+```
+
+If tests were not run, clearly state that in the PR description:
+
+```markdown
+Not run; not requested.
+```
+
+Or:
+
+```markdown
+Not run; unable to determine the project test command.
+```
+
+Do not fabricate test results.
+
+## Command Reference
+
+```bash
+git status
+git branch --show-current
+git diff
+git diff --staged
+git log --oneline --decorate -n 20
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git remote show origin
+cat .github/pull_request_template.md
+find .github -iname "*pull_request_template*"
+gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+gh pr create --draft --base <target-branch> --head <current-branch> --title "<title>" --body-file <body-file>
+```
+
+## Behavioral Guidelines
+
+* Understand the changes before organizing commits
+* Follow the repository template before adding generic PR details
+* Keep commits small and clear
+* Keep PR descriptions complete but concise
+* Clearly mark uncertain information instead of inventing details
+* If the user asks to “create the PR directly,” you must still inspect commits and the PR template first

--- a/.github/agents/commit-and-pr-specialist.agent.md
+++ b/.github/agents/commit-and-pr-specialist.agent.md
@@ -252,7 +252,13 @@ Determine the correct target remote and branch:
 
 If the repository’s default branch is not `main`, use the actual default branch, such as `master`, `develop`, or another remote default branch.
 
-Read the PR template:
+Check if a PR template exists:
+
+```bash
+ls .github/pull_request_template.md  # or find .github -iname "*pull_request_template*"
+```
+
+If a pull_request_template.md exists, read it:
 
 ```bash
 cat .github/pull_request_template.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,56 @@
 ## Summary
 
-## Change Type
-- [ ] Rust code
-- [ ] CI / GitHub Actions
-- [ ] Release / container
-- [ ] Docs / governance
+<!-- Briefly describe what this pull request changes. -->
 
-## Verification
-- [ ] `cargo fmt --check`
-- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- [ ] `cargo test --workspace --all-targets --all-features`
-- [ ] Additional checks run:
+## Related issue
 
-## Impact
-- [ ] Behavior changed
-- [ ] Release flow changed
-- [ ] Security or permissions changed
-- [ ] Docs updated when needed
+<!-- Link related issues. Example: Closes #123 -->
+
+Closes #
+
+## Type of change
+
+<!-- Mark the relevant option with an "x". -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactor
+- [ ] Performance improvement
+- [ ] Test update
+- [ ] Build / CI change
+- [ ] Other
+
+## Changes made
+
+<!-- List the main changes introduced by this PR. -->
+
+-
+-
+-
+
+## How to test
+
+<!-- Describe how reviewers can test or verify this change. -->
+
+1.
+2.
+3.
+
+## Screenshots or recordings
+
+<!-- Add screenshots, videos, or terminal output if relevant. -->
+
+## Checklist
+
+- [ ] I have read the contributing guidelines.
+- [ ] I have tested my changes locally.
+- [ ] I have added or updated tests where appropriate.
+- [ ] I have updated documentation where appropriate.
+- [ ] I have checked that this change does not introduce unintended breaking changes.
+- [ ] My code follows the existing style of the project.
+
+## Additional notes
+
+<!-- Add any extra context for reviewers. -->


### PR DESCRIPTION
## Summary

Improve repository contribution guidance by clarifying PR remote selection and updating GitHub CLI PR creation examples in the Commit & PR Specialist agent documentation.

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- Updated `.github/agents/commit-and-pr-specialist.agent.md` to prefer `upstream/main` when selecting PR targets.
- Added guidance to read the PR template if present.
- Corrected `gh pr create` command examples to include target remote syntax.

## How to test

1. Review `.github/agents/commit-and-pr-specialist.agent.md` for the updated PR workflow guidance.
2. Confirm the `gh pr create` examples are accurate for upstream repository workflows.
3. Verify the PR description now matches the repository template format.

## Screenshots or recordings

N/A

## Checklist

- [ ] I have read the contributing guidelines.
- [ ] I have tested my changes locally.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation where appropriate.
- [ ] I have checked that this change does not introduce unintended breaking changes.
- [ ] My code follows the existing style of the project.

## Additional notes

Documentation-only update to agent guidance on PR creation and target branch selection.