### PR TITLE
docs(issue_template): update contact links to ragloom repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,13 +2,13 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Questions and help
-    url: https://github.com/OWNER/REPO/discussions
+    url: https://github.com/ragloom/ragloom/discussions
     about: Please ask usage questions in GitHub Discussions.
 
   - name: Security vulnerability
-    url: https://github.com/OWNER/REPO/security/policy
+    url: https://github.com/ragloom/ragloom/security/policy
     about: Please report security vulnerabilities privately.
 
   - name: Documentation
-    url: https://github.com/OWNER/REPO#readme
+    url: https://github.com/ragloom/ragloom#readme
     about: Check the documentation before opening an issue.


### PR DESCRIPTION
## Summary
Update the issue template contact links to reference the ragloom repository instead of placeholder OWNER/REPO URLs.

## Related issue
Closes #15

## Type of change
- [x] Documentation update

## Changes made
- Replaced placeholder GitHub Discussions URL with https://github.com/ragloom/ragloom/discussions
- Replaced placeholder security policy URL with https://github.com/ragloom/ragloom/security/policy
- Replaced placeholder documentation URL with https://github.com/ragloom/ragloom#readme

## How to test
1. Review .github/ISSUE_TEMPLATE/config.yml
2. Confirm URLs now point to the ragloom repository

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [ ] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.

## Summary by Sourcery

Documentation:
- Update GitHub issue template contact links for discussions, security policy, and documentation to use the ragloom/ragloom repository URLs.