### PR TITLE
feat(cli): add --config flag for YAML pipeline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,26 @@ ragloom \
 	--collection docs
 ```
 
+Run with a YAML config file (typed `PipelineConfig`) plus backend-specific CLI flags:
+
+```yaml
+# ragloom.yaml
+source:
+  root: "./docs"
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+```
+
+```bash
+ragloom \
+	--config ./ragloom.yaml \
+	--embed-backend http \
+	--embed-model default
+```
+
 On Windows PowerShell, the same command looks like this:
 
 ```powershell
@@ -207,19 +227,27 @@ The process runs until interrupted with Ctrl+C.
 - `--qdrant-url <url>`: Qdrant base URL
 - `--collection <name>`: Qdrant collection name
 
+Use `--config <path>` to load a YAML file and satisfy these required values via:
+
+- `source.root`
+- `sink.qdrant_url`
+- `sink.collection`
+
+CLI flags override values loaded from `--config`.
+
 ### Embedding backend selection
 
 `--embed-backend` defaults to `openai`.
 
 OpenAI backend options:
 
-- `--openai-endpoint <url>`: defaults to `https://api.openai.com/v1/embeddings`
+- `--openai-endpoint <url>`: defaults to `https://api.openai.com/v1/embeddings` (or `embed.endpoint` from `--config` when present)
 - `--openai-api-key <key>`: required when using the OpenAI backend
 - `--openai-model <model>`: defaults to `text-embedding-3-small`
 
 Generic HTTP backend options:
 
-- `--embed-url <url>`: required when `--embed-backend http`
+- `--embed-url <url>`: required when `--embed-backend http` unless `embed.endpoint` is provided by `--config`
 - `--embed-model <model>`: defaults to `default`
 
 Flags support both `--flag value` and `--flag=value` forms.
@@ -349,7 +377,6 @@ cargo llvm-cov --all --lcov --output-path lcov.info
 - File change detection uses path, size, and mtime rather than content hashing.
 - The built-in loader only reads UTF-8 files.
 - The WAL is in memory, so it does not survive process restarts.
-- The binary is currently CLI-driven; the typed YAML config module is present in the library but is not wired into the executable path.
 - There is no built-in collection management, health endpoint, retry queue, or dead-letter handling.
 
 ## Roadmap Ideas

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use ragloom::config::PipelineConfig;
 use ragloom::doc::FsUtf8Loader;
 use ragloom::embed::http_client::{HttpEmbeddingClient, HttpEmbeddingConfig};
 use ragloom::error::{RagloomError, RagloomErrorKind};
@@ -64,6 +65,7 @@ pub enum EmbedBackend {
 /// Using `std::env::args` keeps the binary dependency-free while still allowing
 /// deterministic unit tests for argument handling.
 pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
+    let mut config_path: Option<String> = None;
     let mut dir: Option<String> = None;
     let mut embed_backend: Option<String> = None;
 
@@ -103,6 +105,7 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
         };
 
         match flag {
+            "--config" => config_path = next_value(),
             "--dir" => dir = next_value(),
 
             "--embed-backend" => embed_backend = next_value(),
@@ -132,7 +135,7 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
             "--semantic-percentile" => semantic_percentile = next_value(),
             "--help" | "-h" => {
                 return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(
-                    "usage: ragloom --dir <path> --qdrant-url <url> --collection <name> [--embed-backend <openai|http>]",
+                    "usage: ragloom [--config <path>] --dir <path> --qdrant-url <url> --collection <name> [--embed-backend <openai|http>]",
                 ));
             }
             unknown => {
@@ -142,19 +145,30 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
         }
     }
 
-    let dir = dir.ok_or_else(|| {
-        RagloomError::from_kind(RagloomErrorKind::Config)
-            .with_context("missing required flag: --dir")
-    })?;
+    let file_config = config_path
+        .as_deref()
+        .map(load_pipeline_config)
+        .transpose()?;
 
-    let qdrant_url = qdrant_url.ok_or_else(|| {
-        RagloomError::from_kind(RagloomErrorKind::Config)
-            .with_context("missing required flag: --qdrant-url")
-    })?;
-    let collection = collection.ok_or_else(|| {
-        RagloomError::from_kind(RagloomErrorKind::Config)
-            .with_context("missing required flag: --collection")
-    })?;
+    let dir = dir
+        .or_else(|| file_config.as_ref().map(|c| c.source.root.clone()))
+        .ok_or_else(|| {
+            RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("missing required value: --dir or source.root in --config")
+        })?;
+
+    let qdrant_url = qdrant_url
+        .or_else(|| file_config.as_ref().map(|c| c.sink.qdrant_url.clone()))
+        .ok_or_else(|| {
+            RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("missing required value: --qdrant-url or sink.qdrant_url in --config")
+        })?;
+    let collection = collection
+        .or_else(|| file_config.as_ref().map(|c| c.sink.collection.clone()))
+        .ok_or_else(|| {
+            RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("missing required value: --collection or sink.collection in --config")
+        })?;
 
     let backend = embed_backend.unwrap_or_else(|| "openai".to_string());
 
@@ -169,6 +183,7 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
     let embed_backend = match backend.as_str() {
         "openai" => {
             let endpoint = openai_endpoint
+                .or_else(|| file_config.as_ref().map(|c| c.embed.endpoint.clone()))
                 .unwrap_or_else(|| "https://api.openai.com/v1/embeddings".to_string());
             let api_key = openai_api_key.ok_or_else(|| {
                 RagloomError::from_kind(RagloomErrorKind::Config)
@@ -182,10 +197,13 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
             }
         }
         "http" => {
-            let url = embed_url.ok_or_else(|| {
-                RagloomError::from_kind(RagloomErrorKind::Config)
-                    .with_context("missing required flag for http backend: --embed-url")
-            })?;
+            let url = embed_url
+                .or_else(|| file_config.as_ref().map(|c| c.embed.endpoint.clone()))
+                .ok_or_else(|| {
+                    RagloomError::from_kind(RagloomErrorKind::Config).with_context(
+                        "missing required value for http backend: --embed-url or embed.endpoint in --config",
+                    )
+                })?;
             let model = embed_model.unwrap_or_else(|| "default".to_string());
             EmbedBackend::Http { url, model }
         }
@@ -346,6 +364,21 @@ pub fn parse_args(args: &[String]) -> Result<RunConfig, RagloomError> {
         semantic_provider,
         semantic_percentile,
     })
+}
+
+fn load_pipeline_config(path: &str) -> Result<PipelineConfig, RagloomError> {
+    let yaml = std::fs::read_to_string(path).map_err(|e| {
+        RagloomError::new(RagloomErrorKind::Io, e)
+            .with_context(format!("failed to read config file: {path}"))
+    })?;
+
+    let cfg = PipelineConfig::from_yaml_str(&yaml)
+        .map_err(|e| e.with_context(format!("failed to parse config file: {path}")))?;
+
+    cfg.validate()
+        .map_err(|e| e.with_context(format!("invalid config file: {path}")))?;
+
+    Ok(cfg)
 }
 
 fn parse_code_lang(s: &str) -> Result<ragloom::transform::chunker::code::Language, RagloomError> {
@@ -610,13 +643,15 @@ async fn try_main() -> Result<(), RagloomError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn parse_args_returns_error_when_required_flags_missing() {
         let args = vec!["ragloom".to_string()];
         let err = parse_args(&args).expect_err("expected error");
         assert_eq!(err.kind, RagloomErrorKind::Config);
-        assert!(err.to_string().contains("missing required flag"));
+        assert!(err.to_string().contains("missing required value"));
     }
 
     #[test]
@@ -707,5 +742,100 @@ mod tests {
         ];
         let err = parse_args(&args).expect_err("must reject");
         assert!(err.to_string().contains("--enable-semantic"));
+    }
+
+    #[test]
+    fn parse_args_loads_required_values_from_yaml_config() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/from-config"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        assert_eq!(cfg.dir, "/tmp/from-config");
+        assert_eq!(cfg.qdrant_url, "http://qdrant-from-config");
+        assert_eq!(cfg.collection, "from-config");
+        assert_eq!(
+            cfg.embed_backend,
+            EmbedBackend::Http {
+                url: "http://embed-from-config".to_string(),
+                model: "default".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_surfaces_yaml_validation_context() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: ""
+embed:
+  endpoint: "http://embed"
+sink:
+  qdrant_url: "http://qdrant"
+  collection: "docs"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail validation");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("invalid config file"));
+    }
+
+    #[test]
+    fn parse_args_surfaces_yaml_parse_context() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/docs"
+embed:
+  endpoint "missing-colon"
+sink:
+  qdrant_url: "http://qdrant"
+  collection: "docs"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail parse");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("failed to parse config file"));
     }
 }


### PR DESCRIPTION
## Summary

Add --config <path> CLI flag to load a typed PipelineConfig from a YAML file, allowing users to specify required values (dir, qdrant_url, collection) and embedding endpoint via a config file instead of CLI flags alone. CLI flags take precedence over config file values.

## Related issue

Closes #16 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- Add --config <path> flag parsing in parse_args
- Add load_pipeline_config helper that reads, parses, and validates YAML config via PipelineConfig
- Make --dir, --qdrant-url, --collection fall back to source.root, sink.qdrant_url, sink.collection from config
- Make --openai-endpoint and --embed-url fall back to mbed.endpoint from config
- Update error messages to reference both CLI flags and config file keys
- Update README with --config usage examples and updated embedding backend docs
- Remove outdated limitation note about YAML config not being wired into the binary
- Add tests for config loading, validation error surfacing, and parse error surfacing

## How to test

1. Create a 
agloom.yaml with source.root, sink.qdrant_url, sink.collection
2. Run cargo run -- --config ./ragloom.yaml --embed-backend http
3. Verify values are loaded from config
4. Run with CLI overrides to verify CLI flags take precedence
5. Run cargo test to verify all tests pass

## Screenshots or recordings

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This change also includes the prior commits on this branch that add AGENTS.md, issue templates, PR template, and commit specialist agent — all part of improving the project's contribution infrastructure.

## Summary by Sourcery

Add support for loading pipeline configuration from a YAML file via a new CLI flag while keeping CLI options as overrides.

New Features:
- Introduce a --config <path> CLI flag to load a typed PipelineConfig from a YAML YAML file.
- Allow required pipeline values (source root, Qdrant URL, collection, and embedding endpoint) to be supplied via YAML config instead of only CLI flags.

Enhancements:
- Fall back to YAML config values when required CLI flags or embedding endpoint flags are not provided, with CLI flags taking precedence.
- Improve CLI usage and error messages to reference both CLI flags and YAML config keys for required values.

Documentation:
- Document the new --config flag, YAML PipelineConfig structure, and precedence rules between config and CLI flags in the README, and remove the note claiming YAML config is not wired into the binary.

Tests:
- Add tests covering config loading from YAML, validation and parse error propagation, and end-to-end use of the new --config flag in argument parsing.