### PR TITLE
feat(ci): support manual dispatch and version verification in release workflows

### DIFF
--- a/.github/scripts/verify-release-version.py
+++ b/.github/scripts/verify-release-version.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def append_output(name: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+
+    with open(github_output, "a", encoding="utf-8") as handle:
+        handle.write(f"{name}={value}\n")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cargo_toml = repo_root / "Cargo.toml"
+    manifest = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+
+    try:
+        crate_version = str(manifest["package"]["version"]).strip()
+    except KeyError as error:
+        fail(f"failed to read package.version from {cargo_toml}: {error}")
+
+    expected_version = os.environ.get("EXPECTED_VERSION", "").strip()
+    expected_tag = os.environ.get("EXPECTED_TAG", "").strip()
+
+    if expected_tag:
+        if not expected_tag.startswith("v"):
+            fail(
+                f"release tag must start with 'v'; got '{expected_tag}' while "
+                f"verifying Cargo.toml version {crate_version}"
+            )
+
+        tag_version = expected_tag.removeprefix("v")
+        if expected_version and expected_version != tag_version:
+            fail(
+                f"release version '{expected_version}' does not match tag "
+                f"'{expected_tag}' derived version '{tag_version}'"
+            )
+        expected_version = tag_version
+
+    if not expected_version:
+        fail("EXPECTED_VERSION or EXPECTED_TAG must be provided")
+
+    if crate_version != expected_version:
+        fail(
+            f"Cargo.toml package.version '{crate_version}' does not match "
+            f"expected release version '{expected_version}'"
+        )
+
+    tag = expected_tag or f"v{expected_version}"
+    append_output("crate_version", crate_version)
+    append_output("version", expected_version)
+    append_output("tag", tag)
+
+    print(
+        f"verified Cargo.toml package.version '{crate_version}' for release tag '{tag}'",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -41,6 +41,11 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -2,7 +2,30 @@ name: publish-crate
 
 on:
   workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      version:
+        description: Crate version from Cargo.toml (for example 0.1.0)
+        required: true
+        type: string
+      tag:
+        description: Release tag to verify before publishing (for example v0.1.0)
+        required: true
+        type: string
+      ref:
+        description: Git ref to checkout before publishing (for example v0.1.0)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,12 +37,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
+
+      - name: Verify release version
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: python .github/scripts/verify-release-version.py
 
       - name: Package crate
         run: cargo package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Verify release version
         id: verify
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Crate version from Cargo.toml (for example 0.1.0)
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,17 +17,54 @@ permissions:
   attestations: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
+  prepare-release:
+    name: prepare-release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.verify.outputs.version }}
+      tag: ${{ steps.verify.outputs.tag }}
+      release_ref: ${{ steps.plan.outputs.release_ref }}
+      create_tag: ${{ steps.plan.outputs.create_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release version
+        id: verify
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_TAG: ${{ github.event_name == 'push' && github.ref_name || '' }}
+        run: python .github/scripts/verify-release-version.py
+
+      - name: Plan release ref
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "release_ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "create_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
+            echo "create_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
   deep-quality:
     name: deep-quality
+    needs: prepare-release
     uses: ./.github/workflows/quality-deep.yml
 
   release-binaries:
     name: release-binaries (${{ matrix.target }})
-    needs: deep-quality
+    needs:
+      - prepare-release
+      - deep-quality
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -45,6 +88,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_ref }}
+          fetch-depth: 0
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable
@@ -88,9 +134,29 @@ jobs:
 
   publish-release:
     name: publish-release
-    needs: release-binaries
+    needs:
+      - prepare-release
+      - release-binaries
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_ref }}
+          fetch-depth: 0
+
+      - name: Create release tag
+        if: needs.prepare-release.outputs.create_tag == 'true'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+          git push origin "${RELEASE_TAG}"
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
@@ -99,10 +165,20 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare-release.outputs.tag }}
+          name: ${{ needs.prepare-release.outputs.tag }}
+          target_commitish: ${{ needs.prepare-release.outputs.release_ref }}
+          generate_release_notes: true
           files: release-artifacts/**/*
 
   publish-crate:
     name: publish-crate
-    needs: publish-release
+    needs:
+      - prepare-release
+      - publish-release
     uses: ./.github/workflows/publish-crate.yml
+    with:
+      version: ${{ needs.prepare-release.outputs.version }}
+      tag: ${{ needs.prepare-release.outputs.tag }}
+      ref: ${{ needs.prepare-release.outputs.tag }}
     secrets: inherit

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -38,7 +38,7 @@ Manual `push` of a `v*` tag is still supported, but it goes through the same
 steps run.
 
 GitHub Release notes are generated automatically by the release workflow so the
-published notes come from the repository event history rather than ad-hoc local
+published notes come from the repository event history rather than ad hoc local
 release text.
 
 ## Support Scope

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,6 +21,26 @@ Ragloom publishes artifacts through:
 - crates.io crate releases
 - GHCR container images for Linux targets only
 
+## Release Runbook
+
+Maintainers should start releases from `.github/workflows/release.yml` using
+`workflow_dispatch` with an explicit crate version from `Cargo.toml`
+(for example `0.1.0`).
+
+The release workflow verifies that:
+
+- the requested version matches `Cargo.toml` `package.version`
+- any pushed tag matches the same crate version
+- the crate publish workflow re-checks that version/tag pair before `cargo publish`
+
+Manual `push` of a `v*` tag is still supported, but it goes through the same
+`Cargo.toml` consistency guard before release artifacts or crates.io publish
+steps run.
+
+GitHub Release notes are generated automatically by the release workflow so the
+published notes come from the repository event history rather than ad-hoc local
+release text.
+
 ## Support Scope
 
 The project treats Linux and Windows release targets as the formal support boundary for CI, release verification, and issue triage priority.

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -8,24 +8,52 @@ fn read_repo_file(path: &str) -> String {
 
 #[test]
 fn release_workflow_supports_version_dispatch_and_release_notes() {
-    let workflow = read_repo_file(".github/workflows/release.yml");
+    let workflow_yaml = read_repo_file(".github/workflows/release.yml");
+    let workflow: serde_yaml::Value =
+        serde_yaml::from_str(&workflow_yaml).expect("release workflow is valid YAML");
+
+    let on = workflow
+        .get("on")
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected release workflow to define an `on` mapping");
+
+    let workflow_dispatch = on
+        .get(serde_yaml::Value::String("workflow_dispatch".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected release workflow to support manual `workflow_dispatch`");
+
+    let inputs = workflow_dispatch
+        .get(serde_yaml::Value::String("inputs".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected `workflow_dispatch` to define `inputs`");
+
+    let version_input = inputs
+        .get(serde_yaml::Value::String("version".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected `workflow_dispatch.inputs` to define a `version` input");
 
     assert!(
-        workflow.contains("workflow_dispatch:"),
-        "expected release workflow to support manual dispatch"
+        version_input
+            .get(serde_yaml::Value::String("required".to_string()))
+            .and_then(serde_yaml::Value::as_bool)
+            .unwrap_or(false),
+        "expected `workflow_dispatch.inputs.version.required` to be true"
     );
     assert!(
-        workflow.contains("version:"),
-        "expected release workflow to declare a version input"
+        matches!(
+            version_input.get(serde_yaml::Value::String("type".to_string())),
+            Some(serde_yaml::Value::String(kind)) if kind == "string"
+        ),
+        "expected `workflow_dispatch.inputs.version.type` to be `string`"
     );
     assert!(
-        workflow.contains("generate_release_notes: true"),
+        workflow_yaml.contains("generate_release_notes: true"),
         "expected release workflow to generate release notes deterministically"
     );
 }
 
 #[test]
-fn release_workflows_verify_tag_and_crate_version_consistency() {
+fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
     let release_workflow = read_repo_file(".github/workflows/release.yml");
     let publish_workflow = read_repo_file(".github/workflows/publish-crate.yml");
 
@@ -36,6 +64,22 @@ fn release_workflows_verify_tag_and_crate_version_consistency() {
     assert!(
         publish_workflow.contains("verify-release-version"),
         "expected publish workflow to verify crate and tag versions before cargo publish"
+    );
+    assert!(
+        release_workflow.contains("actions/setup-python@v5"),
+        "expected release workflow to pin Python for the verification script"
+    );
+    assert!(
+        release_workflow.contains("python-version: \"3.11\""),
+        "expected release workflow to require Python 3.11 for tomllib"
+    );
+    assert!(
+        publish_workflow.contains("actions/setup-python@v5"),
+        "expected publish workflow to pin Python for the verification script"
+    );
+    assert!(
+        publish_workflow.contains("python-version: \"3.11\""),
+        "expected publish workflow to require Python 3.11 for tomllib"
     );
 }
 

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::Path;
+
+fn read_repo_file(path: &str) -> String {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(repo_root.join(path)).expect("read repository file")
+}
+
+#[test]
+fn release_workflow_supports_version_dispatch_and_release_notes() {
+    let workflow = read_repo_file(".github/workflows/release.yml");
+
+    assert!(
+        workflow.contains("workflow_dispatch:"),
+        "expected release workflow to support manual dispatch"
+    );
+    assert!(
+        workflow.contains("version:"),
+        "expected release workflow to declare a version input"
+    );
+    assert!(
+        workflow.contains("generate_release_notes: true"),
+        "expected release workflow to generate release notes deterministically"
+    );
+}
+
+#[test]
+fn release_workflows_verify_tag_and_crate_version_consistency() {
+    let release_workflow = read_repo_file(".github/workflows/release.yml");
+    let publish_workflow = read_repo_file(".github/workflows/publish-crate.yml");
+
+    assert!(
+        release_workflow.contains("verify-release-version"),
+        "expected release workflow to verify crate and tag versions before publishing"
+    );
+    assert!(
+        publish_workflow.contains("verify-release-version"),
+        "expected publish workflow to verify crate and tag versions before cargo publish"
+    );
+}
+
+#[test]
+fn support_docs_describe_release_dispatch_runbook() {
+    let support = read_repo_file("SUPPORT.md");
+
+    assert!(
+        support.contains("workflow_dispatch"),
+        "expected support docs to describe the manual release workflow entrypoint"
+    );
+    assert!(
+        support.contains("Cargo.toml"),
+        "expected support docs to document crate-version verification"
+    );
+}


### PR DESCRIPTION
## Summary

Add support for manual workflow dispatch in release workflows with version verification. This change allows maintainers to trigger releases manually by specifying the version from Cargo.toml, and adds verification to ensure version consistency between Cargo.toml, git tags, and release artifacts.

## Related issue

Fixes #18

## Type of change

- [x] New feature
- [x] Build / CI change
- [x] Documentation update

## Changes made

- Add `verify-release-version.py` script to validate version consistency between Cargo.toml and git tags
- Update `release.yml` to support `workflow_dispatch` with version input
- Update `publish-crate.yml` to support `workflow_dispatch` and verify version before publishing
- Add `prepare-release` job to coordinate version verification and release ref planning
- Add tests in `release_workflow_contract.rs` to verify workflow contract
- Update `SUPPORT.md` with release runbook documentation

## How to test

1. Trigger a manual release from the GitHub Actions tab with a valid version from Cargo.toml
2. Verify that the version verification step passes
3. Check that release artifacts are built and published correctly
4. Run `cargo test --test release_workflow_contract` to verify workflow contract tests pass

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

The release workflow now supports both tag-based triggers (existing behavior) and manual dispatch. Manual dispatch requires explicit version input and goes through the same version verification guards.

## Summary by Sourcery

Add manual release dispatch support with strict version verification across Cargo.toml, git tags, and release artifacts, and document the new release workflow.

New Features:
- Allow manual triggering of the release workflow and crate publishing via workflow_dispatch with explicit version and tag inputs.
- Introduce a verify-release-version script to validate consistency between Cargo.toml version, git tags, and release versions before publishing.
- Automatically generate GitHub release notes from repository history during releases.

Enhancements:
- Coordinate release version verification, tag planning, and target ref selection through a new prepare-release job in the release workflow.
- Ensure release and publish jobs check out the correct release ref and optionally create annotated tags when running from manual dispatch.

Build:
- Extend release and publish-crate GitHub Actions workflows to support versioned manual dispatch and enforce version consistency before building and publishing artifacts.

Documentation:
- Update SUPPORT.md with a release runbook describing the manual release entrypoint and version verification guarantees.

Tests:
- Add workflow contract tests to assert manual dispatch support, deterministic release notes, and version verification in release and publish workflows.