### PR TITLE
Fix Miri tests and update rustls-webpki dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/transform/chunker/code/mod.rs
+++ b/src/transform/chunker/code/mod.rs
@@ -179,6 +179,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]
     fn rust_two_functions_produce_at_least_two_chunks() {
         let text = "fn a() { 1; }\n\nfn b() { 2; }\n";
         let c = chunker(Language::Rust, 1000);
@@ -187,6 +188,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]
     fn fingerprint_contains_language_and_grammar() {
         let c = chunker(Language::Rust, 1000);
         let fp = c
@@ -198,6 +200,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]
     fn bash_function_parses() {
         let text = "greet() { echo hi; }\n";
         let c = chunker(Language::Bash, 1000);


### PR DESCRIPTION
## Summary
This PR fixes Miri compatibility issues and updates a dependency.

## Changes
- **Fix Miri tests**: Add `#[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]` attribute to three tests in `src/transform/chunker/code/mod.rs` that use tree-sitter FFI, which Miri cannot handle
- **Update dependency**: Update `rustls-webpki` from 0.103.10 to 0.103.13 in Cargo.lock

## Context
The Miri tests were failing because tree-sitter uses FFI which is not supported under Miri's interpreted execution. The ignore attributes allow the test suite to pass when running with `cargo +nightly miri test`.

## Files Changed
- `src/transform/chunker/code/mod.rs`
- `Cargo.lock`

## Summary by Sourcery

Improve test compatibility with Miri and refresh a TLS-related dependency lockfile entry.

Bug Fixes:
- Disable specific tree-sitter-based chunker tests under Miri to avoid FFI-related failures in the interpreted environment.

Build:
- Update the locked rustls-webpki crate version in Cargo.lock to the latest 0.103.x release.