### PR TITLE
chore: ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lcov.info
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VS Code local settings
+.vscode/


### PR DESCRIPTION
## Summary

Add `.vscode/` to `.gitignore` to prevent VS Code local settings from being tracked in the repository.

## Related issue

Closes #

## Type of change

<!-- Mark the relevant option with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI change
- [x] Other

## Changes made

<!-- List the main changes introduced by this PR. -->

- Add `.vscode/` to `.gitignore` to exclude VS Code local configuration files

## How to test

<!-- Describe how reviewers can test or verify this change. -->

1. Verify that `.vscode/` directory is now ignored by git
2. Run `git status` to confirm `.vscode/` files no longer appear as untracked

## Screenshots or recordings

<!-- Add screenshots, videos, or terminal output if relevant. -->

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.

## Summary by Sourcery

Build:
- Add .vscode/ directory to .gitignore so VS Code settings are not tracked.