### PR TITLE
test(chunker): ignore tree-sitter FFI tests in Miri

### DIFF
--- a/src/transform/chunker/router.rs
+++ b/src/transform/chunker/router.rs
@@ -232,6 +232,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]
     fn rust_extension_routes_to_code_rust() {
         let router = default_router(cfg()).unwrap();
         let hint = ChunkHint::from_path("/tmp/main.rs");
@@ -240,6 +241,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]
     fn extension_is_case_insensitive() {
         let router = default_router(cfg()).unwrap();
         let hint = ChunkHint::from_path("/tmp/MAIN.RS");
@@ -287,6 +289,7 @@ mod semantic_tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]
     fn rs_keeps_code_rust_chunker() {
         let semantic: Arc<dyn Chunker> =
             Arc::new(SemanticChunker::new(Arc::new(StubSignal), cfg(), 95).unwrap());


### PR DESCRIPTION
## Summary

为使用 tree-sitter FFI 的测试添加 Miri 忽略属性。这些测试在 Miri 下无法运行，因为 Miri 不支持 tree-sitter 的外部函数接口调用。

## Related issue

Closes #

## Type of change

- [x] Test update

## Changes made

- 为 `router.rs` 中的三个测试函数添加 `#[cfg_attr(miri, ignore = "Miri does not support tree-sitter FFI tests")]` 属性
- 受影响的测试：`rust_extension_routes_to_code_rust`、`extension_is_case_insensitive`、`rs_keeps_code_rust_chunker`

## How to test

1. 运行 `cargo test` 确认所有测试通过
2. 运行 `cargo +nightly miri test` 确认 Miri 测试跳过 tree-sitter 相关测试
3. 确认被忽略的测试在 Miri 下不再报错

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

此更改是为了配合之前的 Miri 修复工作（PR #25），确保 Miri 测试能够正确运行。

## Summary by Sourcery

Tests:
- Configure three chunker router tests that rely on tree-sitter FFI to be skipped in Miri runs to prevent unsupported execution errors.