### PR TITLE
feat: implement persistent local WAL state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+- Persistent local WAL state via `FileWal`, stored by default at
+  `.ragloom/wal.ndjson` and configurable with `--state-path` or `state.path`.
+- Startup replay for unacknowledged `WorkItemV2` records, with acknowledged file
+  versions seeded into planner de-duplication to avoid re-emitting completed
+  work after restart.
+
+### Notes
+- The WAL format is append-only newline-delimited JSON. Corrupt or unreadable
+  state files fail startup with a `state` error so operators can inspect or
+  replace the file intentionally.
+
 ## [0.1.0] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Supported today:
 - OpenAI and generic HTTP embedding APIs
 - Qdrant sink
 - deterministic point IDs
+- persistent local WAL state
 - pretty and JSON structured logs
 
 Not supported yet:
 
 - PDF or DOCX parsing
-- persistent WAL
 - production retry or dead-letter queues
 - built-in collection lifecycle management
 
@@ -70,6 +70,7 @@ cargo run --release -- \
   --dir ./docs \
   --qdrant-url http://localhost:6333 \
   --collection docs \
+  --state-path ./.ragloom/wal.ndjson \
   --create-collection-if-missing \
   --openai-api-key "$OPENAI_API_KEY"
 ```
@@ -184,6 +185,9 @@ embed:
 sink:
   qdrant_url: "http://localhost:6333"
   collection: "docs"
+
+state:
+  path: ".ragloom/wal.ndjson"
 ```
 
 Run with:
@@ -208,6 +212,7 @@ ragloom --config ./ragloom.yaml --embed-backend http --embed-model default
 ### Configuration notes
 
 - `--config` can provide `source.root`, `embed.endpoint`, `sink.qdrant_url`, and `sink.collection`
+- `--config` can also provide `state.path`; the CLI flag is `--state-path`
 - backend-specific auth still comes from CLI flags, such as `--openai-api-key`
 - chunker settings are currently configured by CLI flags, not by YAML
 - flags support both `--flag value` and `--flag=value`
@@ -263,7 +268,17 @@ Writes vectors and metadata into a destination such as Qdrant.
 
 ### State
 
-Tracks discovered work and acknowledgements in an in-memory WAL.
+Tracks discovered work and acknowledgements in an append-only local WAL.
+
+By default, Ragloom stores state at `.ragloom/wal.ndjson` relative to the
+current working directory. Pass `--state-path <path>` or set `state.path` in the
+YAML config to choose another file.
+
+The WAL is newline-delimited JSON and records planned `WorkItemV2` entries plus
+`SinkAckV2` acknowledgements. On startup, Ragloom replays work items that do not
+have a matching acknowledgement and seeds planner de-duplication from the WAL so
+already acknowledged file versions are not planned again. Corrupt or unreadable
+state files fail startup with a `state` error instead of being ignored.
 
 ## Architecture
 
@@ -395,7 +410,7 @@ Status: shipped in `v0.1.1`.
 
 ### v0.2 - More reliable daemon behavior
 
-- persistent local state
+- persistent local state (shipped on `main`)
 - retry queue
 - delete detection
 - health endpoint
@@ -499,7 +514,6 @@ curl https://api.openai.com/v1/embeddings \
 - only local filesystem input
 - only Qdrant as a built-in sink
 - only UTF-8 file loading
-- no persistent WAL yet
 - no general collection lifecycle management beyond optional first-run bootstrap
 - no production retry queue yet
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,6 +19,8 @@ pub struct PipelineConfig {
     pub source: SourceConfig,
     pub embed: EmbedConfig,
     pub sink: SinkConfig,
+    #[serde(default)]
+    pub state: StateConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -35,6 +37,24 @@ pub struct EmbedConfig {
 pub struct SinkConfig {
     pub qdrant_url: String,
     pub collection: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StateConfig {
+    #[serde(default = "default_state_path")]
+    pub path: String,
+}
+
+impl Default for StateConfig {
+    fn default() -> Self {
+        Self {
+            path: default_state_path(),
+        }
+    }
+}
+
+fn default_state_path() -> String {
+    ".ragloom/wal.ndjson".to_string()
 }
 
 impl PipelineConfig {
@@ -72,6 +92,10 @@ impl PipelineConfig {
             return Err(RagloomError::from_kind(RagloomErrorKind::Config)
                 .with_context("sink.collection is empty"));
         }
+        if self.state.path.trim().is_empty() {
+            return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("state.path is empty"));
+        }
         Ok(())
     }
 }
@@ -90,8 +114,11 @@ embed:
 sink:
   qdrant_url: "http://localhost:6333"
   collection: "docs"
+state:
+  path: ".ragloom/wal.ndjson"
 "#;
         let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
         cfg.validate().expect("validate");
+        assert_eq!(cfg.state.path, ".ragloom/wal.ndjson");
     }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -15,7 +15,7 @@ use blake3::Hasher;
 ///
 /// This type is intentionally small and explicit so it can be constructed from
 /// multiple sources (filesystem scan, file watcher events, tests).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, std::hash::Hash, serde::Serialize, serde::Deserialize)]
 pub struct FileFingerprint {
     pub canonical_path: String,
     pub size_bytes: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ pub struct RunConfig {
     pub embed_backend: EmbedBackend,
     pub qdrant_url: String,
     pub collection: String,
+    pub state_path: String,
     pub create_collection_if_missing: bool,
     pub collection_vector_size: Option<usize>,
     pub chunker_strategy: String,
@@ -43,7 +44,8 @@ pub struct RunConfig {
     pub semantic_percentile: u8,
 }
 
-const USAGE: &str = "usage: ragloom [--config <path>] --dir <path> --qdrant-url <url> --collection <name> [--embed-backend <openai|http>]";
+const DEFAULT_STATE_PATH: &str = ".ragloom/wal.ndjson";
+const USAGE: &str = "usage: ragloom [--config <path>] --dir <path> --qdrant-url <url> --collection <name> [--state-path <path>] [--embed-backend <openai|http>]";
 
 /// Top-level CLI command selected by argument parsing.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -92,6 +94,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
 
     let mut qdrant_url: Option<String> = None;
     let mut collection: Option<String> = None;
+    let mut state_path: Option<String> = None;
     let mut create_collection_if_missing = false;
     let mut collection_vector_size: Option<String> = None;
 
@@ -135,6 +138,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
 
             "--qdrant-url" => qdrant_url = next_value(),
             "--collection" => collection = next_value(),
+            "--state-path" => state_path = next_value(),
             "--create-collection-if-missing" => {
                 if inline_value.is_some() {
                     return Err(cli_invalid_input(
@@ -189,6 +193,12 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         .ok_or_else(|| {
             cli_config_error("missing required value: --collection or sink.collection in --config")
         })?;
+    let state_path = state_path
+        .or_else(|| file_config.as_ref().map(|c| c.state.path.clone()))
+        .unwrap_or_else(|| DEFAULT_STATE_PATH.to_string());
+    if state_path.trim().is_empty() {
+        return Err(cli_config_error("--state-path or state.path is empty"));
+    }
     let collection_vector_size = collection_vector_size
         .map(|s| {
             s.parse::<usize>().map_err(|e| {
@@ -375,6 +385,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         embed_backend,
         qdrant_url,
         collection,
+        state_path,
         create_collection_if_missing,
         collection_vector_size,
         chunker_strategy,
@@ -717,7 +728,8 @@ async fn try_main() -> Result<(), RagloomError> {
     } = prepare_startup(&cfg).await?;
 
     let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
-        ragloom::state::wal::InMemoryWal::new(),
+        ragloom::state::wal::FileWal::open(&cfg.state_path)
+            .map_err(|e| e.with_context("failed to initialize persistent WAL"))?,
     ));
 
     let runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
@@ -956,6 +968,7 @@ mod tests {
                 },
                 qdrant_url: "http://qdrant".to_string(),
                 collection: "docs".to_string(),
+                state_path: DEFAULT_STATE_PATH.to_string(),
                 create_collection_if_missing: false,
                 collection_vector_size: None,
                 chunker_strategy: "recursive".to_string(),
@@ -971,6 +984,57 @@ mod tests {
                 semantic_percentile: 95,
             }))
         );
+    }
+
+    #[test]
+    fn parse_args_defaults_state_path() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.state_path, DEFAULT_STATE_PATH);
+    }
+
+    #[test]
+    fn parse_args_accepts_state_path_inline_value() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+            "--state-path=.state/ragloom.ndjson".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.state_path, ".state/ragloom.ndjson");
     }
 
     #[test]
@@ -1196,6 +1260,7 @@ mod tests {
             },
             qdrant_url: "http://qdrant".to_string(),
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: Some(768),
             chunker_strategy: "recursive".to_string(),
@@ -1226,6 +1291,7 @@ mod tests {
             },
             qdrant_url: "http://qdrant".to_string(),
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1255,6 +1321,7 @@ mod tests {
             },
             qdrant_url: "http://qdrant".to_string(),
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1291,6 +1358,7 @@ mod tests {
             },
             qdrant_url: base_url,
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1346,6 +1414,7 @@ mod tests {
             },
             qdrant_url: base_url.clone(),
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1402,6 +1471,7 @@ mod tests {
             },
             qdrant_url: base_url.clone(),
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: Some(768),
             chunker_strategy: "recursive".to_string(),
@@ -1446,6 +1516,7 @@ mod tests {
             },
             qdrant_url: "http://127.0.0.1:1".to_string(),
             collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1523,6 +1594,8 @@ embed:
 sink:
   qdrant_url: "http://qdrant-from-config"
   collection: "from-config"
+state:
+  path: ".state/from-config.ndjson"
 "#,
         )
         .expect("write config");
@@ -1542,6 +1615,7 @@ sink:
         assert_eq!(cfg.dir, "/tmp/from-config");
         assert_eq!(cfg.qdrant_url, "http://qdrant-from-config");
         assert_eq!(cfg.collection, "from-config");
+        assert_eq!(cfg.state_path, ".state/from-config.ndjson");
         assert_eq!(
             cfg.embed_backend,
             EmbedBackend::Http {

--- a/src/pipeline/planner.rs
+++ b/src/pipeline/planner.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 
 use crate::source::FileVersionDiscovered;
-use crate::state::wal::WalRecord;
+use crate::state::wal::{WalRecord, WalStore};
 
 use crate::error::RagloomError;
 
@@ -27,6 +27,19 @@ impl Planner {
         Self::default()
     }
 
+    pub fn from_wal_records(records: &[WalRecord]) -> Self {
+        let planned_versions = records
+            .iter()
+            .map(|record| match record {
+                WalRecord::WorkItemV2 { fingerprint } | WalRecord::SinkAckV2 { fingerprint } => {
+                    crate::ids::file_version_id(fingerprint)
+                }
+                WalRecord::WorkItem { chunk_id } | WalRecord::SinkAck { chunk_id } => *chunk_id,
+            })
+            .collect();
+        Self { planned_versions }
+    }
+
     /// Plans work for a discovery event.
     ///
     /// # Why
@@ -35,7 +48,7 @@ impl Planner {
     pub fn plan_file_version(
         &mut self,
         discovered: &FileVersionDiscovered,
-        wal: &std::sync::Arc<tokio::sync::Mutex<crate::state::wal::InMemoryWal>>,
+        wal: &std::sync::Arc<tokio::sync::Mutex<impl WalStore>>,
     ) -> Result<(), RagloomError> {
         if !self.planned_versions.insert(discovered.file_version_id) {
             return Ok(());

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -8,7 +8,7 @@
 use crate::error::{RagloomError, RagloomErrorKind};
 use crate::pipeline::planner::Planner;
 use crate::source::Source;
-use crate::state::wal::{InMemoryWal, WalRecord};
+use crate::state::wal::{InMemoryWal, WalRecord, WalStore, unacked_work_items};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct IngestionSummarySnapshot {
@@ -255,13 +255,13 @@ fn file_extension_from_canonical_path(canonical_path: &str) -> String {
 /// The MVP does not require distributed execution. Keeping the runtime small
 /// makes it easier to reason about crash recovery and idempotency.
 #[derive(Debug)]
-pub struct Runtime<S: Source> {
+pub struct Runtime<S: Source, W: WalStore = InMemoryWal> {
     source: S,
     planner: Planner,
-    wal: std::sync::Arc<tokio::sync::Mutex<InMemoryWal>>,
+    wal: std::sync::Arc<tokio::sync::Mutex<W>>,
 }
 
-impl<S: Source> Runtime<S> {
+impl<S: Source> Runtime<S, InMemoryWal> {
     pub fn new(source: S) -> Self {
         Self::with_wal(source, InMemoryWal::new())
     }
@@ -269,14 +269,19 @@ impl<S: Source> Runtime<S> {
     pub fn with_wal(source: S, wal: InMemoryWal) -> Self {
         Self::with_shared_wal(source, std::sync::Arc::new(tokio::sync::Mutex::new(wal)))
     }
+}
 
-    pub fn with_shared_wal(
-        source: S,
-        wal: std::sync::Arc<tokio::sync::Mutex<InMemoryWal>>,
-    ) -> Self {
+impl<S: Source, W: WalStore> Runtime<S, W> {
+    pub fn with_shared_wal(source: S, wal: std::sync::Arc<tokio::sync::Mutex<W>>) -> Self {
+        let planner = wal
+            .try_lock()
+            .ok()
+            .and_then(|guard| guard.read_all().ok())
+            .map(|records| Planner::from_wal_records(&records))
+            .unwrap_or_default();
         Self {
             source,
-            planner: Planner::new(),
+            planner,
             wal,
         }
     }
@@ -633,13 +638,13 @@ impl WorkExecutor for PipelineExecutor {
 /// Acking at the boundary (after side effects) is the minimal WAL signal we need
 /// for replay and near exactly-once semantics.
 #[derive(Debug, Clone)]
-pub struct AckingExecutor<E: WorkExecutor> {
+pub struct AckingExecutor<E: WorkExecutor, W: WalStore = InMemoryWal> {
     pub inner: E,
-    pub wal: std::sync::Arc<tokio::sync::Mutex<crate::state::wal::InMemoryWal>>,
+    pub wal: std::sync::Arc<tokio::sync::Mutex<W>>,
 }
 
 #[async_trait::async_trait]
-impl<E: WorkExecutor> WorkExecutor for AckingExecutor<E> {
+impl<E: WorkExecutor, W: WalStore + 'static> WorkExecutor for AckingExecutor<E, W> {
     async fn execute(&self, record: WalRecord) {
         let ack = match &record {
             WalRecord::WorkItem { chunk_id } => Some(WalRecord::SinkAck {
@@ -690,14 +695,14 @@ impl ShutdownHandle {
 /// add an async runner that turns planned WAL records into a bounded stream for
 /// downstream workers.
 #[derive(Debug)]
-pub struct AsyncRuntime<S: Source + Send + 'static> {
-    runtime: Runtime<S>,
+pub struct AsyncRuntime<S: Source + Send + 'static, W: WalStore = InMemoryWal> {
+    runtime: Runtime<S, W>,
     capacity: usize,
     summary: Option<IngestionSummary>,
 }
 
-impl<S: Source + Send + 'static> AsyncRuntime<S> {
-    pub fn new(runtime: Runtime<S>, capacity: usize) -> Self {
+impl<S: Source + Send + 'static, W: WalStore + 'static> AsyncRuntime<S, W> {
+    pub fn new(runtime: Runtime<S, W>, capacity: usize) -> Self {
         Self {
             runtime,
             capacity,
@@ -720,6 +725,30 @@ impl<S: Source + Send + 'static> AsyncRuntime<S> {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
         tokio::spawn(async move {
+            let replay_records = match self.runtime.try_wal_records() {
+                Ok(records) => unacked_work_items(&records),
+                Err(err) if err.kind == RagloomErrorKind::Internal => Vec::new(),
+                Err(_) => return,
+            };
+            let mut replayed_files = 0usize;
+            for record in replay_records {
+                if matches!(
+                    record,
+                    WalRecord::WorkItem { .. } | WalRecord::WorkItemV2 { .. }
+                ) {
+                    replayed_files += 1;
+                }
+                if tx.send(record).await.is_err() {
+                    return;
+                }
+                if shutdown_rx.has_changed().unwrap_or(false) && *shutdown_rx.borrow() {
+                    return;
+                }
+            }
+            if let Some(summary) = &self.summary {
+                summary.record_discovered(replayed_files);
+            }
+
             loop {
                 if *shutdown_rx.borrow() {
                     return;
@@ -1018,6 +1047,99 @@ mod tests {
         );
 
         shutdown.shutdown();
+    }
+
+    #[tokio::test]
+    async fn async_runtime_replays_unacked_work_before_new_discovery() {
+        let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+        let replayed = crate::ids::FileFingerprint {
+            canonical_path: "/x/replayed.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+        };
+        let acked = crate::ids::FileFingerprint {
+            canonical_path: "/x/acked.txt".to_string(),
+            size_bytes: 20,
+            mtime_unix_secs: 200,
+        };
+        {
+            let mut guard = wal.lock().await;
+            guard
+                .append(WalRecord::WorkItemV2 {
+                    fingerprint: replayed.clone(),
+                })
+                .expect("append replayed work");
+            guard
+                .append(WalRecord::WorkItemV2 {
+                    fingerprint: acked.clone(),
+                })
+                .expect("append acked work");
+            guard
+                .append(WalRecord::SinkAckV2 {
+                    fingerprint: acked.clone(),
+                })
+                .expect("append ack");
+        }
+
+        let source = FakeSource::default();
+        let runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
+        let (mut rx, shutdown) = AsyncRuntime::new(runtime, 4).start();
+
+        let item = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("should replay")
+            .expect("record");
+        assert_eq!(
+            item,
+            WalRecord::WorkItemV2 {
+                fingerprint: replayed
+            }
+        );
+
+        let no_acked_replay =
+            tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(no_acked_replay.is_err());
+
+        shutdown.shutdown();
+    }
+
+    #[tokio::test]
+    async fn runtime_does_not_replan_file_versions_already_in_wal() {
+        let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+        let fingerprint = crate::ids::FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+        };
+        {
+            let mut guard = wal.lock().await;
+            guard
+                .append(WalRecord::WorkItemV2 {
+                    fingerprint: fingerprint.clone(),
+                })
+                .expect("append work");
+            guard
+                .append(WalRecord::SinkAckV2 {
+                    fingerprint: fingerprint.clone(),
+                })
+                .expect("append ack");
+        }
+
+        let mut source = FakeSource::default();
+        source.pending.push(FileVersionDiscovered {
+            file_version_id: crate::ids::file_version_id(&fingerprint),
+            fingerprint,
+        });
+        let mut runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
+
+        runtime.tick();
+
+        let records = wal.lock().await.read_all().expect("read");
+        assert_eq!(records.len(), 2);
     }
 
     #[tokio::test]

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -5,14 +5,18 @@
 //! us replay un-acked work after crashes without requiring complex distributed
 //! coordination.
 
-use crate::error::RagloomError;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::error::{RagloomError, RagloomErrorKind};
 
 /// A durable record representing progress at the pipeline boundaries.
 ///
 /// # Why
 /// Only boundary events (enqueue work, acknowledge sink write) need to be
 /// persisted to enable replay.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum WalRecord {
     /// A chunk has been enqueued for processing.
     WorkItem { chunk_id: [u8; 32] },
@@ -40,6 +44,17 @@ pub enum WalRecord {
     },
 }
 
+/// Minimal WAL storage contract.
+///
+/// # Why
+/// Runtime code only needs ordered append and replay. Keeping this surface tiny
+/// lets us add durable local storage without binding the pipeline to a database.
+pub trait WalStore: Send {
+    fn append(&mut self, record: WalRecord) -> Result<(), RagloomError>;
+    fn read_all(&self) -> Result<Vec<WalRecord>, RagloomError>;
+    fn is_empty(&self) -> bool;
+}
+
 /// A minimal WAL implementation for unit tests.
 ///
 /// # Why
@@ -58,22 +73,180 @@ impl InMemoryWal {
     }
 
     pub fn append(&mut self, record: WalRecord) -> Result<(), RagloomError> {
+        <Self as WalStore>::append(self, record)
+    }
+
+    pub fn read_all(&self) -> Result<Vec<WalRecord>, RagloomError> {
+        <Self as WalStore>::read_all(self)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        <Self as WalStore>::is_empty(self)
+    }
+}
+
+impl WalStore for InMemoryWal {
+    fn append(&mut self, record: WalRecord) -> Result<(), RagloomError> {
         self.records.push(record);
         Ok(())
     }
 
-    pub fn read_all(&self) -> Result<Vec<WalRecord>, RagloomError> {
+    fn read_all(&self) -> Result<Vec<WalRecord>, RagloomError> {
         Ok(self.records.clone())
     }
 
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.records.is_empty()
     }
+}
+
+/// Durable newline-delimited JSON WAL.
+///
+/// # Why
+/// A line-oriented JSON format stays inspectable, append-only, and deterministic
+/// while being enough to replay work/ack boundaries after a local restart.
+#[derive(Debug)]
+pub struct FileWal {
+    path: PathBuf,
+}
+
+impl FileWal {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, RagloomError> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to create WAL directory: {}",
+                    parent.display()
+                ))
+            })?;
+        }
+
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e)
+                    .with_context(format!("failed to open WAL file: {}", path.display()))
+            })?;
+
+        let wal = Self { path };
+        wal.read_all().map_err(|e| {
+            RagloomError::new(e.kind, e).with_context("failed to validate WAL file")
+        })?;
+        Ok(wal)
+    }
+
+    pub fn append(&mut self, record: WalRecord) -> Result<(), RagloomError> {
+        <Self as WalStore>::append(self, record)
+    }
+
+    pub fn read_all(&self) -> Result<Vec<WalRecord>, RagloomError> {
+        <Self as WalStore>::read_all(self)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        <Self as WalStore>::is_empty(self)
+    }
+}
+
+impl WalStore for FileWal {
+    fn append(&mut self, record: WalRecord) -> Result<(), RagloomError> {
+        let encoded = serde_json::to_string(&record).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e)
+                .with_context("failed to encode WAL record")
+        })?;
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e)
+                    .with_context(format!("failed to open WAL file: {}", self.path.display()))
+            })?;
+        writeln!(file, "{encoded}").map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to append WAL file: {}",
+                self.path.display()
+            ))
+        })?;
+        file.sync_data().map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e)
+                .with_context(format!("failed to sync WAL file: {}", self.path.display()))
+        })?;
+        Ok(())
+    }
+
+    fn read_all(&self) -> Result<Vec<WalRecord>, RagloomError> {
+        let contents = std::fs::read_to_string(&self.path).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e)
+                .with_context(format!("failed to read WAL file: {}", self.path.display()))
+        })?;
+
+        let mut records = Vec::new();
+        for (idx, line) in contents.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let record = serde_json::from_str::<WalRecord>(line).map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to parse WAL record at line {} in {}",
+                    idx + 1,
+                    self.path.display()
+                ))
+            })?;
+            records.push(record);
+        }
+        Ok(records)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.read_all()
+            .map(|records| records.is_empty())
+            .unwrap_or(false)
+    }
+}
+
+/// Returns unacked work in original append order.
+pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
+    let mut acked_chunks = std::collections::HashSet::<[u8; 32]>::new();
+    let mut acked_files = std::collections::HashSet::<crate::ids::FileFingerprint>::new();
+
+    for record in records {
+        match record {
+            WalRecord::SinkAck { chunk_id } => {
+                acked_chunks.insert(*chunk_id);
+            }
+            WalRecord::SinkAckV2 { fingerprint } => {
+                acked_files.insert(fingerprint.clone());
+            }
+            WalRecord::WorkItem { .. } | WalRecord::WorkItemV2 { .. } => {}
+        }
+    }
+
+    records
+        .iter()
+        .filter_map(|record| match record {
+            WalRecord::WorkItem { chunk_id } if !acked_chunks.contains(chunk_id) => {
+                Some(record.clone())
+            }
+            WalRecord::WorkItemV2 { fingerprint } if !acked_files.contains(fingerprint) => {
+                Some(record.clone())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::FileFingerprint;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn wal_roundtrips_records_in_order() {
@@ -135,5 +308,93 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn file_wal_roundtrips_records_in_order_after_reopen() {
+        let file = NamedTempFile::new().expect("temp wal");
+        let path = file.path().to_path_buf();
+
+        let mut wal = FileWal::open(&path).expect("open");
+        wal.append(WalRecord::WorkItemV2 {
+            fingerprint: FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+            },
+        })
+        .expect("append work");
+        wal.append(WalRecord::SinkAckV2 {
+            fingerprint: FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+            },
+        })
+        .expect("append ack");
+
+        let reopened = FileWal::open(&path).expect("reopen");
+        assert_eq!(
+            reopened.read_all().expect("read"),
+            vec![
+                WalRecord::WorkItemV2 {
+                    fingerprint: FileFingerprint {
+                        canonical_path: "/x/a.txt".to_string(),
+                        size_bytes: 10,
+                        mtime_unix_secs: 100,
+                    },
+                },
+                WalRecord::SinkAckV2 {
+                    fingerprint: FileFingerprint {
+                        canonical_path: "/x/a.txt".to_string(),
+                        size_bytes: 10,
+                        mtime_unix_secs: 100,
+                    },
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn unacked_work_items_filters_acknowledged_file_versions() {
+        let a = FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+        };
+        let b = FileFingerprint {
+            canonical_path: "/x/b.txt".to_string(),
+            size_bytes: 20,
+            mtime_unix_secs: 200,
+        };
+
+        let records = vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: a.clone(),
+            },
+            WalRecord::WorkItemV2 {
+                fingerprint: b.clone(),
+            },
+            WalRecord::SinkAckV2 {
+                fingerprint: a.clone(),
+            },
+        ];
+
+        assert_eq!(
+            unacked_work_items(&records),
+            vec![WalRecord::WorkItemV2 { fingerprint: b }]
+        );
+    }
+
+    #[test]
+    fn file_wal_reports_invalid_state_with_context() {
+        let mut file = NamedTempFile::new().expect("temp wal");
+        file.write_all(b"{not json}\n").expect("write");
+
+        let err = FileWal::open(file.path()).expect_err("invalid wal should fail");
+        assert_eq!(err.kind, RagloomErrorKind::State);
+        assert!(err.to_string().contains("failed to validate WAL file"));
+        let source = std::error::Error::source(&err).expect("source");
+        assert!(source.to_string().contains("failed to parse WAL record"));
     }
 }


### PR DESCRIPTION
## Summary

Implement persistent local WAL (Write-Ahead Log) state for Ragloom using newline-delimited JSON. This replaces the previous in-memory-only WAL with a durable `FileWal` that persists `WorkItemV2` and `SinkAckV2` records to disk, enabling startup replay of unacknowledged work after crashes or restarts.

## Related issue

Closes #42

## Type of change

- [x] New feature
- [ ] Breaking change (see notes below)

## Changes made

- Add `WalStore` trait with `append`, `read_all`, `is_empty` methods
- Implement `FileWal` for append-only newline-delimited JSON persistence at configurable path (default: `.ragloom/wal.ndjson`)
- Add `--state-path` CLI flag and `state.path` YAML config option
- Refactor `Runtime` and `AckingExecutor` to use generic `WalStore` trait
- Seed planner de-duplication from WAL records on startup to avoid re-emitting acknowledged work
- Add `unacked_work_items` helper for replay logic
- Update `FileFingerprint` and `WalRecord` with serde support
- Update documentation (CHANGELOG.md, README.md)

## How to test

1. Run `cargo qa` to verify formatting, clippy, and tests pass
2. Test with default state path:
   ```bash
   cargo run --release -- --dir ./docs --qdrant-url http://localhost:6333 --collection docs --openai-api-key "$OPENAI_API_KEY"
   ```
3. Test with custom state path:
   ```bash
   cargo run --release -- --dir ./docs --qdrant-url http://localhost:6333 --collection docs --state-path ./custom/wal.ndjson --openai-api-key "$OPENAI_API_KEY"
   ```
4. Test with YAML config:
   ```yaml
   state:
     path: ".ragloom/wal.ndjson"
   ```
5. Verify `.ragloom/wal.ndjson` is created and contains newline-delimited JSON after running
6. Stop and restart Ragloom to verify it replays unacknowledged work without re-processing acknowledged files

## Breaking changes

This change replaces the default in-memory WAL with a file-based WAL. If upgrading from a previous version:
- Ragloom will now create a `.ragloom/wal.ndjson` file by default
- To revert to in-memory behavior, users would need to modify the code (not recommended)
- Corrupt or unreadable state files will fail startup with a `state` error instead of being silently ignored

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally (cargo qa passes).
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

- The WAL format is append-only newline-delimited JSON for inspectability
- On startup, Ragloom replays work items that don't have matching acknowledgements
- Planner de-duplication is seeded from WAL to avoid re-emitting completed work
- The implementation follows Ragloom's minimalist design philosophy

## Summary by Sourcery

Introduce a persistent, file-backed WAL and wire it through the runtime and CLI to enable crash-safe replay of unacknowledged work.

New Features:
- Add a pluggable WalStore abstraction with a FileWal implementation that stores WAL records as newline-delimited JSON on disk.
- Add configurable state path via --state-path CLI flag and state.path YAML option, with a default .ragloom/wal.ndjson location.
- Replay unacknowledged work items on startup and seed planner de-duplication from WAL records to avoid reprocessing acknowledged files.

Enhancements:
- Generalize Runtime, AsyncRuntime, Planner, and AckingExecutor to work with any WalStore implementation instead of being tied to an in-memory WAL.
- Validate WAL files at startup and surface state-related errors with contextual messages.
- Extend FileFingerprint and WalRecord with serde support to enable encoding/decoding in the WAL format.

Documentation:
- Document persistent WAL behavior, configuration options, defaults, and limitations in README and CHANGELOG.