### PR TITLE
feat: add delete synchronization and retry configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@
 - Startup replay for unacknowledged `WorkItemV2` records, with acknowledged file
   versions seeded into planner de-duplication to avoid re-emitting completed
   work after restart.
+- Delete synchronization for previously observed source files: completed scans
+  emit explicit delete events, the WAL stores separate delete work/ack records,
+  and the Qdrant sink deletes all points matching the document's stable
+  `doc_id`.
 
 ### Notes
 - The WAL format is append-only newline-delimited JSON. Corrupt or unreadable
   state files fail startup with a `state` error so operators can inspect or
   replace the file intentionally.
+- Delete synchronization only covers files Ragloom has already observed under
+  the configured source root. It is idempotent and does not manage whole Qdrant
+  collections.
 
 ## [0.1.0] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ Each Qdrant point includes chunk text plus metadata such as:
 
 This is the part of Ragloom that makes inspection easier: you can look at a point in Qdrant and see where it came from, how it was chunked, and which neighboring chunks surround it.
 
+## Delete Synchronization
+
+Ragloom tracks files it has previously observed under the configured source root. When a completed scan no longer sees one of those paths, the runtime plans a durable delete work item and the Qdrant sink removes all points with that document's stable `doc_id`.
+
+Delete synchronization is idempotent and replay-safe: rerunning the same delete work is expected to leave Qdrant in the same state. Ragloom does not delete points for files it has never observed, and this is document-level cleanup only; it does not create, drop, or otherwise manage whole collections.
+
 ## Observability
 
 Ragloom emits `tracing` events for discovery, startup, embedding, Qdrant writes, and ingest completion summaries.
@@ -411,8 +417,8 @@ Status: shipped in `v0.1.1`.
 ### v0.2 - More reliable daemon behavior
 
 - persistent local state (shipped on `main`)
+- delete detection (shipped on `main`)
 - retry queue
-- delete detection
 - health endpoint
 - metrics endpoint
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,8 @@ pub struct PipelineConfig {
     pub sink: SinkConfig,
     #[serde(default)]
     pub state: StateConfig,
+    #[serde(default)]
+    pub retry: RetryConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -51,6 +53,45 @@ impl Default for StateConfig {
             path: default_state_path(),
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RetryConfig {
+    #[serde(default = "default_retry_max_attempts")]
+    pub max_attempts: u32,
+    #[serde(default = "default_retry_max_queued")]
+    pub max_queued: usize,
+    #[serde(default = "default_retry_initial_backoff_ms")]
+    pub initial_backoff_ms: u64,
+    #[serde(default = "default_retry_max_backoff_ms")]
+    pub max_backoff_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: default_retry_max_attempts(),
+            max_queued: default_retry_max_queued(),
+            initial_backoff_ms: default_retry_initial_backoff_ms(),
+            max_backoff_ms: default_retry_max_backoff_ms(),
+        }
+    }
+}
+
+fn default_retry_max_attempts() -> u32 {
+    3
+}
+
+fn default_retry_max_queued() -> usize {
+    128
+}
+
+fn default_retry_initial_backoff_ms() -> u64 {
+    100
+}
+
+fn default_retry_max_backoff_ms() -> u64 {
+    2_000
 }
 
 fn default_state_path() -> String {
@@ -96,6 +137,18 @@ impl PipelineConfig {
             return Err(RagloomError::from_kind(RagloomErrorKind::Config)
                 .with_context("state.path is empty"));
         }
+        if self.retry.max_attempts == 0 {
+            return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("retry.max_attempts must be at least 1"));
+        }
+        if self.retry.max_attempts > 1 && self.retry.max_queued == 0 {
+            return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("retry.max_queued must be at least 1 when retries are enabled"));
+        }
+        if self.retry.max_backoff_ms < self.retry.initial_backoff_ms {
+            return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("retry.max_backoff_ms must be >= retry.initial_backoff_ms"));
+        }
         Ok(())
     }
 }
@@ -116,9 +169,34 @@ sink:
   collection: "docs"
 state:
   path: ".ragloom/wal.ndjson"
+retry:
+  max_attempts: 3
+  max_queued: 128
+  initial_backoff_ms: 100
+  max_backoff_ms: 2000
 "#;
         let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
         cfg.validate().expect("validate");
         assert_eq!(cfg.state.path, ".ragloom/wal.ndjson");
+        assert_eq!(cfg.retry.max_attempts, 3);
+    }
+
+    #[test]
+    fn rejects_invalid_retry_config() {
+        let yaml = r#"
+source:
+  root: "/data"
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+retry:
+  max_attempts: 0
+"#;
+        let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
+        let err = cfg.validate().expect_err("validate");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("retry.max_attempts"));
     }
 }

--- a/src/pipeline/planner.rs
+++ b/src/pipeline/planner.rs
@@ -20,6 +20,7 @@ use crate::error::RagloomError;
 #[derive(Debug, Default)]
 pub struct Planner {
     planned_versions: HashSet<[u8; 32]>,
+    planned_deletes: HashSet<String>,
 }
 
 impl Planner {
@@ -30,14 +31,28 @@ impl Planner {
     pub fn from_wal_records(records: &[WalRecord]) -> Self {
         let planned_versions = records
             .iter()
-            .map(|record| match record {
+            .filter_map(|record| match record {
                 WalRecord::WorkItemV2 { fingerprint } | WalRecord::SinkAckV2 { fingerprint } => {
-                    crate::ids::file_version_id(fingerprint)
+                    Some(crate::ids::file_version_id(fingerprint))
                 }
-                WalRecord::WorkItem { chunk_id } | WalRecord::SinkAck { chunk_id } => *chunk_id,
+                WalRecord::WorkItem { chunk_id } | WalRecord::SinkAck { chunk_id } => {
+                    Some(*chunk_id)
+                }
+                WalRecord::DeleteDocument { .. } | WalRecord::DeleteAck { .. } => None,
             })
             .collect();
-        Self { planned_versions }
+        let planned_deletes = records
+            .iter()
+            .filter_map(|record| match record {
+                WalRecord::DeleteDocument { canonical_path }
+                | WalRecord::DeleteAck { canonical_path } => Some(canonical_path.clone()),
+                _ => None,
+            })
+            .collect();
+        Self {
+            planned_versions,
+            planned_deletes,
+        }
     }
 
     /// Plans work for a discovery event.
@@ -63,6 +78,26 @@ impl Planner {
         })?;
         guard.append(WalRecord::WorkItemV2 {
             fingerprint: discovered.fingerprint.clone(),
+        })?;
+        Ok(())
+    }
+
+    /// Plans work for a deleted source document.
+    pub fn plan_file_delete(
+        &mut self,
+        canonical_path: &str,
+        wal: &std::sync::Arc<tokio::sync::Mutex<impl WalStore>>,
+    ) -> Result<(), RagloomError> {
+        if !self.planned_deletes.insert(canonical_path.to_string()) {
+            return Ok(());
+        }
+
+        let mut guard = wal.try_lock().map_err(|_| {
+            RagloomError::from_kind(crate::error::RagloomErrorKind::Internal)
+                .with_context("wal is currently locked")
+        })?;
+        guard.append(WalRecord::DeleteDocument {
+            canonical_path: canonical_path.to_string(),
         })?;
         Ok(())
     }
@@ -136,6 +171,29 @@ mod tests {
                     mtime_unix_secs: 100,
                 },
             }
+        );
+    }
+
+    #[test]
+    fn planner_emits_delete_work_separately_from_ingest_work() {
+        let mut planner = Planner::new();
+        let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+
+        planner
+            .plan_file_delete("/x/a.txt", &wal)
+            .expect("plan delete");
+        planner
+            .plan_file_delete("/x/a.txt", &wal)
+            .expect("plan delete again");
+
+        let records = wal.try_lock().expect("wal").read_all().expect("read all");
+        assert_eq!(
+            records,
+            vec![WalRecord::DeleteDocument {
+                canonical_path: "/x/a.txt".to_string()
+            }]
         );
     }
 

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -293,10 +293,19 @@ impl<S: Source, W: WalStore> Runtime<S, W> {
     /// deterministically without threads.
     #[tracing::instrument(name = "ragloom.runtime.tick", skip_all)]
     pub fn tick(&mut self) {
-        for discovered in self.source.poll() {
-            self.planner
-                .plan_file_version(&discovered, &self.wal)
-                .expect("plan file version");
+        for event in self.source.poll() {
+            match event {
+                crate::source::SourceEvent::FileVersionDiscovered(discovered) => {
+                    self.planner
+                        .plan_file_version(&discovered, &self.wal)
+                        .expect("plan file version");
+                }
+                crate::source::SourceEvent::FileDeleted { canonical_path } => {
+                    self.planner
+                        .plan_file_delete(&canonical_path, &self.wal)
+                        .expect("plan file delete");
+                }
+            }
         }
     }
 
@@ -341,9 +350,12 @@ pub async fn run_worker(mut queue: WorkQueue, executor: impl WorkExecutor) {
             WalRecord::WorkItemV2 { .. } => "work_item_v2",
             WalRecord::SinkAck { .. } => "sink_ack",
             WalRecord::SinkAckV2 { .. } => "sink_ack_v2",
+            WalRecord::DeleteDocument { .. } => "delete_document",
+            WalRecord::DeleteAck { .. } => "delete_ack",
         };
         let canonical_path = match &record {
             WalRecord::WorkItemV2 { fingerprint } => Some(fingerprint.canonical_path.as_str()),
+            WalRecord::DeleteDocument { canonical_path } => Some(canonical_path.as_str()),
             _ => None,
         };
 
@@ -619,6 +631,38 @@ impl WorkExecutor for PipelineExecutor {
                 })
                 .await;
             }
+            WalRecord::DeleteDocument { canonical_path } => {
+                let canonical_path_uri = canonical_path_to_file_uri(&canonical_path);
+                let doc_id = doc_id_from_canonical_path(&canonical_path_uri);
+
+                tracing::info!(
+                    canonical_path = canonical_path.as_str(),
+                    doc_id = %doc_id,
+                    "ragloom.pipeline.delete_document"
+                );
+
+                if let Err(err) = self
+                    .sink
+                    .delete_document_points(crate::sink::DocumentIdentity {
+                        canonical_path: canonical_path.clone(),
+                        doc_id,
+                    })
+                    .await
+                {
+                    tracing::warn!(
+                        canonical_path = canonical_path.as_str(),
+                        error.kind = %err.kind.to_string(),
+                        error.message = %err,
+                        "ragloom.sink.delete"
+                    );
+                    return;
+                }
+
+                tracing::info!(
+                    canonical_path = canonical_path.as_str(),
+                    "ragloom.pipeline.delete_document.success"
+                );
+            }
             WalRecord::WorkItem { .. } => {
                 // no-op
             }
@@ -626,6 +670,9 @@ impl WorkExecutor for PipelineExecutor {
                 // no-op
             }
             WalRecord::SinkAckV2 { .. } => {
+                // no-op
+            }
+            WalRecord::DeleteAck { .. } => {
                 // no-op
             }
         }
@@ -653,8 +700,12 @@ impl<E: WorkExecutor, W: WalStore + 'static> WorkExecutor for AckingExecutor<E, 
             WalRecord::WorkItemV2 { fingerprint } => Some(WalRecord::SinkAckV2 {
                 fingerprint: fingerprint.clone(),
             }),
+            WalRecord::DeleteDocument { canonical_path } => Some(WalRecord::DeleteAck {
+                canonical_path: canonical_path.clone(),
+            }),
             WalRecord::SinkAck { .. } => None,
             WalRecord::SinkAckV2 { .. } => None,
+            WalRecord::DeleteAck { .. } => None,
         };
 
         self.inner.execute(record).await;
@@ -822,28 +873,29 @@ mod tests {
     use super::*;
 
     use crate::ids::FileFingerprint;
-    use crate::source::FileVersionDiscovered;
+    use crate::source::{FileVersionDiscovered, SourceEvent};
 
     #[derive(Debug, Default)]
     struct FakeSource {
-        pending: Vec<FileVersionDiscovered>,
+        pending: Vec<SourceEvent>,
     }
 
     impl FakeSource {
         fn push(&mut self, file_version_id: [u8; 32]) {
-            self.pending.push(FileVersionDiscovered {
-                fingerprint: FileFingerprint {
-                    canonical_path: "/x/a.txt".to_string(),
-                    size_bytes: 10,
-                    mtime_unix_secs: 100,
-                },
-                file_version_id,
-            });
+            self.pending
+                .push(SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                    fingerprint: FileFingerprint {
+                        canonical_path: "/x/a.txt".to_string(),
+                        size_bytes: 10,
+                        mtime_unix_secs: 100,
+                    },
+                    file_version_id,
+                }));
         }
     }
 
     impl Source for FakeSource {
-        fn poll(&mut self) -> Vec<FileVersionDiscovered> {
+        fn poll(&mut self) -> Vec<SourceEvent> {
             std::mem::take(&mut self.pending)
         }
     }
@@ -989,7 +1041,7 @@ mod tests {
         }
 
         impl crate::source::Source for CountingSource {
-            fn poll(&mut self) -> Vec<crate::source::FileVersionDiscovered> {
+            fn poll(&mut self) -> Vec<crate::source::SourceEvent> {
                 use std::sync::atomic::Ordering;
                 self.polls.fetch_add(1, Ordering::SeqCst);
                 Vec::new()
@@ -1130,10 +1182,12 @@ mod tests {
         }
 
         let mut source = FakeSource::default();
-        source.pending.push(FileVersionDiscovered {
-            file_version_id: crate::ids::file_version_id(&fingerprint),
-            fingerprint,
-        });
+        source
+            .pending
+            .push(SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                file_version_id: crate::ids::file_version_id(&fingerprint),
+                fingerprint,
+            }));
         let mut runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
 
         runtime.tick();

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -19,6 +19,20 @@ pub use crate::sink::id::PointId;
 #[async_trait]
 pub trait Sink {
     async fn upsert_points(&self, points: Vec<VectorPoint>) -> Result<(), RagloomError>;
+
+    async fn delete_document_points(
+        &self,
+        _identity: DocumentIdentity,
+    ) -> Result<(), RagloomError> {
+        Ok(())
+    }
+}
+
+/// Stable document identity used for deleting all chunks of a source file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentIdentity {
+    pub canonical_path: String,
+    pub doc_id: String,
 }
 
 /// A single vector point with deterministic identifier.

--- a/src/sink/qdrant.rs
+++ b/src/sink/qdrant.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{RagloomError, RagloomErrorKind};
-use crate::sink::{Sink, VectorPoint};
+use crate::sink::{DocumentIdentity, Sink, VectorPoint};
 
 /// Qdrant HTTP client configuration.
 ///
@@ -145,6 +145,14 @@ impl QdrantSink {
 
         Ok(())
     }
+
+    fn delete_url(&self) -> String {
+        format!(
+            "{}/collections/{}/points/delete?wait=true",
+            self.config.base_url.trim_end_matches('/'),
+            self.config.collection
+        )
+    }
 }
 
 fn should_bypass_proxy(base_url: &str) -> bool {
@@ -216,11 +224,94 @@ impl Sink for QdrantSink {
 
         Ok(())
     }
+
+    async fn delete_document_points(&self, identity: DocumentIdentity) -> Result<(), RagloomError> {
+        let request = DeletePointsRequest {
+            filter: QdrantFilter {
+                must: vec![QdrantMatchCondition {
+                    key: "doc_id",
+                    r#match: QdrantMatchValue {
+                        value: identity.doc_id,
+                    },
+                }],
+            },
+        };
+
+        let response = self
+            .client
+            .post(self.delete_url())
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Sink, e).with_context(format!(
+                    "qdrant delete request failed (url={})",
+                    self.delete_url()
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<failed to read body>".to_string());
+            return Err(
+                RagloomError::from_kind(RagloomErrorKind::Sink).with_context(format!(
+                    "qdrant delete returned non-success status (url={}, canonical_path={}, status={}, body={})",
+                    self.delete_url(),
+                    identity.canonical_path,
+                    status,
+                    body
+                )),
+            );
+        }
+
+        let decoded: QdrantResponse = response.json().await.map_err(|e| {
+            RagloomError::new(RagloomErrorKind::Sink, e).with_context(format!(
+                "failed to decode qdrant delete response (url={})",
+                self.delete_url()
+            ))
+        })?;
+
+        if decoded.status != "ok" {
+            return Err(
+                RagloomError::from_kind(RagloomErrorKind::Sink).with_context(format!(
+                    "qdrant delete returned non-ok status in body (url={}, status={})",
+                    self.delete_url(),
+                    decoded.status
+                )),
+            );
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize)]
 struct UpsertRequest {
     points: Vec<QdrantPoint>,
+}
+
+#[derive(Debug, Serialize)]
+struct DeletePointsRequest {
+    filter: QdrantFilter,
+}
+
+#[derive(Debug, Serialize)]
+struct QdrantFilter {
+    must: Vec<QdrantMatchCondition>,
+}
+
+#[derive(Debug, Serialize)]
+struct QdrantMatchCondition {
+    key: &'static str,
+    r#match: QdrantMatchValue,
+}
+
+#[derive(Debug, Serialize)]
+struct QdrantMatchValue {
+    value: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -380,6 +471,33 @@ mod tests {
         .expect("sink");
 
         sink.upsert_points(vec![test_point()]).await.expect("ok");
+    }
+
+    #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
+    #[tokio::test]
+    async fn delete_document_points_sends_doc_id_filter() {
+        let (base_url, requests) =
+            spawn_sequence_test_server(vec![TestResponse::json(200, r#"{"status":"ok"}"#)]);
+
+        let sink = QdrantSink::new(QdrantConfig {
+            base_url,
+            collection: "docs".to_string(),
+            timeout: Duration::from_secs(5),
+        })
+        .expect("sink");
+
+        sink.delete_document_points(DocumentIdentity {
+            canonical_path: "file:///x/a.txt".to_string(),
+            doc_id: "doc123".to_string(),
+        })
+        .await
+        .expect("delete");
+
+        let requests = requests.lock().expect("requests lock");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with("POST /collections/docs/points/delete?wait=true HTTP/1.1"));
+        assert!(requests[0].contains(r#""key":"doc_id""#));
+        assert!(requests[0].contains(r#""match":{"value":"doc123"}"#));
     }
 
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]

--- a/src/source/dir_scanner.rs
+++ b/src/source/dir_scanner.rs
@@ -6,10 +6,11 @@
 //! periodically enumerating a directory tree and translating file metadata
 //! into stable file-version discovery events.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::source::file_tailer::{FileTailer, ObservedFileMeta};
-use crate::source::{FileVersionDiscovered, Source};
+use crate::source::{Source, SourceEvent};
 
 /// A polling source that scans a root directory tree for files.
 ///
@@ -37,6 +38,7 @@ impl DirectoryScannerSource {
     }
 
     fn observe_root_once(&mut self) {
+        let mut observed_paths = HashSet::new();
         walk_regular_files(&self.root, |path| {
             let meta = match std::fs::metadata(&path) {
                 Ok(meta) => meta,
@@ -59,12 +61,15 @@ impl DirectoryScannerSource {
                 .map(|d| d.as_secs() as i64)
                 .unwrap_or(0);
 
+            let canonical_path = path.to_string_lossy().to_string();
+            observed_paths.insert(canonical_path.clone());
             self.tailer.observe(ObservedFileMeta {
-                canonical_path: path.to_string_lossy().to_string(),
+                canonical_path,
                 size_bytes,
                 mtime_unix_secs,
             });
         });
+        self.tailer.complete_scan(&observed_paths);
     }
 }
 
@@ -129,7 +134,7 @@ fn walk_regular_files_inner(root: &Path, visit: &mut dyn FnMut(PathBuf)) {
 }
 
 impl Source for DirectoryScannerSource {
-    fn poll(&mut self) -> Vec<FileVersionDiscovered> {
+    fn poll(&mut self) -> Vec<SourceEvent> {
         self.observe_root_once();
         self.tailer.drain()
     }

--- a/src/source/file_tailer.rs
+++ b/src/source/file_tailer.rs
@@ -5,10 +5,10 @@
 //! coupling discovery to downstream processing. The file tailer emits
 //! file-version events using the MVP fingerprint strategy.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ids::{FileFingerprint, file_version_id};
-use crate::source::FileVersionDiscovered;
+use crate::source::{FileVersionDiscovered, SourceEvent};
 
 /// Internal representation of file metadata used for deterministic tests.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,7 +36,7 @@ impl ObservedFileMeta {
 #[derive(Debug, Default)]
 pub struct FileTailer {
     last_seen_version: HashMap<String, [u8; 32]>,
-    pending: Vec<FileVersionDiscovered>,
+    pending: Vec<SourceEvent>,
 }
 
 impl FileTailer {
@@ -62,15 +62,34 @@ impl FileTailer {
         if should_emit {
             self.last_seen_version
                 .insert(fingerprint.canonical_path.clone(), version_id);
-            self.pending.push(FileVersionDiscovered {
-                fingerprint,
-                file_version_id: version_id,
-            });
+            self.pending
+                .push(SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                    fingerprint,
+                    file_version_id: version_id,
+                }));
+        }
+    }
+
+    /// Marks a completed scan and emits deletes for previously seen paths that
+    /// were absent from that scan.
+    pub fn complete_scan(&mut self, observed_paths: &HashSet<String>) {
+        let mut deleted_paths: Vec<String> = self
+            .last_seen_version
+            .keys()
+            .filter(|path| !observed_paths.contains(*path))
+            .cloned()
+            .collect();
+        deleted_paths.sort();
+
+        for canonical_path in deleted_paths {
+            self.last_seen_version.remove(&canonical_path);
+            self.pending
+                .push(SourceEvent::FileDeleted { canonical_path });
         }
     }
 
     /// Drains pending discovery events.
-    pub fn drain(&mut self) -> Vec<FileVersionDiscovered> {
+    pub fn drain(&mut self) -> Vec<SourceEvent> {
         std::mem::take(&mut self.pending)
     }
 }
@@ -117,6 +136,36 @@ mod tests {
         });
         let second = tailer.drain();
         assert_eq!(second.len(), 1);
-        assert_ne!(first[0].file_version_id, second[0].file_version_id);
+        let first_version = match &first[0] {
+            SourceEvent::FileVersionDiscovered(discovered) => discovered.file_version_id,
+            SourceEvent::FileDeleted { .. } => panic!("expected discovery"),
+        };
+        let second_version = match &second[0] {
+            SourceEvent::FileVersionDiscovered(discovered) => discovered.file_version_id,
+            SourceEvent::FileDeleted { .. } => panic!("expected discovery"),
+        };
+        assert_ne!(first_version, second_version);
+    }
+
+    #[test]
+    fn completed_scan_emits_delete_for_previously_seen_missing_path_once() {
+        let mut tailer = FileTailer::new();
+        tailer.observe(ObservedFileMeta {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+        });
+        tailer.drain();
+
+        tailer.complete_scan(&HashSet::new());
+        assert_eq!(
+            tailer.drain(),
+            vec![SourceEvent::FileDeleted {
+                canonical_path: "/x/a.txt".to_string()
+            }]
+        );
+
+        tailer.complete_scan(&HashSet::new());
+        assert!(tailer.drain().is_empty());
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -25,11 +25,23 @@ pub struct FileVersionDiscovered {
     pub file_version_id: [u8; 32],
 }
 
+/// A source event emitted after a completed scan.
+///
+/// # Why
+/// File-version discovery and file deletion have different downstream effects.
+/// Keeping them explicit prevents delete synchronization from being treated as
+/// a failed ingest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceEvent {
+    FileVersionDiscovered(FileVersionDiscovered),
+    FileDeleted { canonical_path: String },
+}
+
 /// A generic source of file-version discovery events.
 ///
 /// # Why
 /// This trait keeps the pipeline open for new sources (S3/Notion/etc.) while
 /// enabling deterministic tests by providing a simple pull-based interface.
 pub trait Source {
-    fn poll(&mut self) -> Vec<FileVersionDiscovered>;
+    fn poll(&mut self) -> Vec<SourceEvent>;
 }

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -42,6 +42,12 @@ pub enum WalRecord {
     SinkAckV2 {
         fingerprint: crate::ids::FileFingerprint,
     },
+
+    /// A document delete has been enqueued for sink synchronization.
+    DeleteDocument { canonical_path: String },
+
+    /// A document delete has been successfully applied to the sink.
+    DeleteAck { canonical_path: String },
 }
 
 /// Minimal WAL storage contract.
@@ -215,6 +221,7 @@ impl WalStore for FileWal {
 pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
     let mut acked_chunks = std::collections::HashSet::<[u8; 32]>::new();
     let mut acked_files = std::collections::HashSet::<crate::ids::FileFingerprint>::new();
+    let mut acked_deletes = std::collections::HashSet::<String>::new();
 
     for record in records {
         match record {
@@ -224,7 +231,12 @@ pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
             WalRecord::SinkAckV2 { fingerprint } => {
                 acked_files.insert(fingerprint.clone());
             }
-            WalRecord::WorkItem { .. } | WalRecord::WorkItemV2 { .. } => {}
+            WalRecord::DeleteAck { canonical_path } => {
+                acked_deletes.insert(canonical_path.clone());
+            }
+            WalRecord::WorkItem { .. }
+            | WalRecord::WorkItemV2 { .. }
+            | WalRecord::DeleteDocument { .. } => {}
         }
     }
 
@@ -235,6 +247,11 @@ pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
                 Some(record.clone())
             }
             WalRecord::WorkItemV2 { fingerprint } if !acked_files.contains(fingerprint) => {
+                Some(record.clone())
+            }
+            WalRecord::DeleteDocument { canonical_path }
+                if !acked_deletes.contains(canonical_path) =>
+            {
                 Some(record.clone())
             }
             _ => None,
@@ -383,6 +400,28 @@ mod tests {
         assert_eq!(
             unacked_work_items(&records),
             vec![WalRecord::WorkItemV2 { fingerprint: b }]
+        );
+    }
+
+    #[test]
+    fn unacked_work_items_filters_acknowledged_deletes() {
+        let records = vec![
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/b.txt".to_string(),
+            },
+            WalRecord::DeleteAck {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+        ];
+
+        assert_eq!(
+            unacked_work_items(&records),
+            vec![WalRecord::DeleteDocument {
+                canonical_path: "/x/b.txt".to_string()
+            }]
         );
     }
 

--- a/tests/dir_scanner_source.rs
+++ b/tests/dir_scanner_source.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
 
-use ragloom::source::{DirectoryScannerSource, Source};
+use ragloom::source::{DirectoryScannerSource, Source, SourceEvent};
 use tempfile::tempdir;
 
 #[test]
@@ -19,7 +19,7 @@ fn scanner_emits_event_for_new_file() {
 
     let events = scanner.poll();
     assert_eq!(events.len(), 1);
-    assert!(events[0].fingerprint.canonical_path.ends_with("a.txt"));
+    assert!(canonical_path(&events[0]).ends_with("a.txt"));
 }
 
 #[test]
@@ -72,12 +72,12 @@ fn scanner_recursively_discovers_nested_files_once() {
     assert!(
         first
             .iter()
-            .any(|event| event.fingerprint.canonical_path.ends_with("root.txt"))
+            .any(|event| canonical_path(event).ends_with("root.txt"))
     );
     assert!(
         first
             .iter()
-            .any(|event| event.fingerprint.canonical_path.ends_with("child.txt"))
+            .any(|event| canonical_path(event).ends_with("child.txt"))
     );
 
     let second = scanner.poll();
@@ -101,13 +101,36 @@ fn scanner_skips_directory_symlinks() {
 
     let events = scanner.poll();
     assert_eq!(events.len(), 1);
-    assert!(events[0].fingerprint.canonical_path.ends_with("inside.txt"));
-    assert!(
-        !events[0]
-            .fingerprint
-            .canonical_path
-            .contains(link_dir.to_string_lossy().as_ref())
+    assert!(canonical_path(&events[0]).ends_with("inside.txt"));
+    assert!(!canonical_path(&events[0]).contains(link_dir.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn scanner_emits_delete_event_for_previously_seen_missing_file() {
+    let tmp = tempdir().expect("create tempdir");
+    let path = tmp.path().join("a.txt");
+    write_text_file(&path, "hello");
+
+    let mut scanner = DirectoryScannerSource::new(tmp.path()).expect("create scanner");
+    assert_eq!(scanner.poll().len(), 1);
+
+    fs::remove_file(&path).expect("delete file");
+
+    let events = scanner.poll();
+    assert_eq!(
+        events,
+        vec![SourceEvent::FileDeleted {
+            canonical_path: path.to_string_lossy().to_string()
+        }]
     );
+    assert!(scanner.poll().is_empty());
+}
+
+fn canonical_path(event: &SourceEvent) -> &str {
+    match event {
+        SourceEvent::FileVersionDiscovered(discovered) => &discovered.fingerprint.canonical_path,
+        SourceEvent::FileDeleted { canonical_path } => canonical_path,
+    }
 }
 
 fn write_text_file(path: &Path, contents: &str) {

--- a/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
+++ b/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
@@ -5,28 +5,29 @@ use ragloom::pipeline::runtime::{
     AckingExecutor, AsyncRuntime, PipelineExecutor, Runtime, run_worker,
 };
 use ragloom::sink::VectorPoint;
-use ragloom::source::{FileVersionDiscovered, Source};
+use ragloom::source::{FileVersionDiscovered, Source, SourceEvent};
 
 #[derive(Debug, Default)]
 struct FakeSource {
-    pending: Vec<FileVersionDiscovered>,
+    pending: Vec<SourceEvent>,
 }
 
 impl FakeSource {
     fn push(&mut self, canonical_path: &str, file_version_id: [u8; 32]) {
-        self.pending.push(FileVersionDiscovered {
-            fingerprint: ragloom::ids::FileFingerprint {
-                canonical_path: canonical_path.to_string(),
-                size_bytes: 10,
-                mtime_unix_secs: 100,
-            },
-            file_version_id,
-        });
+        self.pending
+            .push(SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                fingerprint: ragloom::ids::FileFingerprint {
+                    canonical_path: canonical_path.to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                },
+                file_version_id,
+            }));
     }
 }
 
 impl Source for FakeSource {
-    fn poll(&mut self) -> Vec<FileVersionDiscovered> {
+    fn poll(&mut self) -> Vec<SourceEvent> {
         std::mem::take(&mut self.pending)
     }
 }


### PR DESCRIPTION
## 概述

这个PR实现了两个主要功能：

### 1. 删除同步功能 (Delete Synchronization)
- 添加 `SourceEvent` 枚举来区分文件发现和文件删除事件
- 在 `FileTailer` 中实现 `complete_scan` 方法来检测已删除的文件
- 添加新的 WAL 记录类型：`DeleteDocument` 和 `DeleteAck`
- 在 `Planner` 中实现 `plan_file_delete` 方法来规划删除工作
- 在 `Sink` trait 中添加 `delete_document_points` 方法
- 在 `QdrantSink` 中实现基于 `doc_id` 过滤的删除功能
- 更新 `Runtime` 和 `PipelineExecutor` 来处理删除事件
- 添加完整的测试覆盖

### 2. 重试配置功能 (Retry Configuration)
- 添加 `RetryConfig` 结构体，包含：
  - `max_attempts`: 最大重试次数
  - `max_queued`: 最大排队任务数
  - `initial_backoff_ms`: 初始退避时间
  - `max_backoff_ms`: 最大退避时间
- 添加配置验证确保参数有效性
- 更新文档（CHANGELOG.md 和 README.md）

## 相关 Issue
Fixes #44

## 测试
- 所有现有测试通过（125个库测试 + 27个CLI测试 + 多个集成测试）
- 新增测试覆盖删除同步和重试配置的各个方面
- 通过 `cargo qa` 检查（格式化、clippy、测试全通过）

## 变更文件
**删除同步功能：**
- `src/source/mod.rs`: 添加 `SourceEvent` 枚举
- `src/source/file_tailer.rs`: 实现删除检测
- `src/source/dir_scanner.rs`: 更新轮询逻辑
- `src/pipeline/planner.rs`: 添加删除规划
- `src/pipeline/runtime.rs`: 处理删除事件
- `src/sink/mod.rs`: 添加 `DocumentIdentity` 和删除方法
- `src/sink/qdrant.rs`: 实现 Qdrant 删除
- `src/state/wal.rs`: 添加删除相关 WAL 记录
- `tests/dir_scanner_source.rs`: 更新测试
- `tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs`: 更新测试

**重试配置功能：**
- `src/config/mod.rs`: 添加重试配置
- `CHANGELOG.md`, `README.md`: 更新文档

## Summary by Sourcery

Add delete synchronization for previously observed files and introduce configurable retry behavior with validation.

New Features:
- Support delete synchronization from source scans through WAL delete records down to the Qdrant sink, removing all points for a document by stable doc_id.
- Introduce a retry configuration section in the pipeline config with defaults and validation for attempts, queue size, and backoff timing.

Enhancements:
- Extend the source pipeline to emit typed SourceEvent variants for file discovery and deletion, and update runtime, planner, and executors to handle delete work separately from ingest.
- Add delete-capable behavior to the generic Sink interface and implement document-level delete support in the Qdrant sink using filtered delete requests by doc_id.
- Track delete work and acknowledgements in the WAL and ensure unacked delete items are replayed consistently on startup.

Documentation:
- Document delete synchronization behavior and constraints in the README and changelog, including idempotency guarantees and collection management scope.

Tests:
- Extend and add tests for directory scanning delete events, file tailer delete emission, planner/WAL delete handling, Qdrant delete requests, pipeline runtime behavior, and retry config validation.