### PR TITLE
feat: add health endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   `doc_id`.
 - Bounded in-process retry queue for transient loader I/O, embedding, and sink
   failures, configurable with `retry.*` YAML keys or `--retry-*` CLI flags.
+- Opt-in local health endpoint, configurable with `health.addr` or
+  `--health-addr`, returning minimal daemon status and build/version JSON.
 
 ### Notes
 - The WAL format is append-only newline-delimited JSON. Corrupt or unreadable
@@ -25,6 +27,9 @@
 - Retries are deterministic and jitter-free. Configuration and invalid-input
   errors are not retried, and exhausted retries are counted in
   `ragloom.ingest.summary` failures.
+- The health endpoint is disabled by default and only exposes readiness,
+  version, and build metadata. Startup/bootstrap failures and fatal runtime-loop
+  failures report `ready: false`.
 
 ## [0.1.0] - 2026-05-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync", "fs", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync", "fs", "signal", "net", "io-util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chunk = "0.10"

--- a/README.md
+++ b/README.md
@@ -452,6 +452,10 @@ health:
   addr: "127.0.0.1:8080"
 ```
 
+The address must be an IP socket address on a loopback interface, such as
+`127.0.0.1:8080` or `[::1]:8080`. Ragloom rejects non-loopback addresses to
+avoid accidentally exposing the operator endpoint outside the local machine.
+
 Query it with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Supported today:
 - persistent local WAL state
 - bounded in-process retry for transient ingest failures
 - pretty and JSON structured logs
+- opt-in local health endpoint
 
 Not supported yet:
 
@@ -195,6 +196,10 @@ retry:
   max_queued: 128
   initial_backoff_ms: 100
   max_backoff_ms: 2000
+
+# Optional. Omit to keep the health endpoint disabled.
+health:
+  addr: "127.0.0.1:8080"
 ```
 
 Run with:
@@ -221,6 +226,7 @@ ragloom --config ./ragloom.yaml --embed-backend http --embed-model default
 - `--config` can provide `source.root`, `embed.endpoint`, `sink.qdrant_url`, and `sink.collection`
 - `--config` can also provide `state.path`; the CLI flag is `--state-path`
 - `--config` can provide `retry.max_attempts`, `retry.max_queued`, `retry.initial_backoff_ms`, and `retry.max_backoff_ms`
+- `--config` can provide `health.addr`; the CLI flag is `--health-addr`
 - backend-specific auth still comes from CLI flags, such as `--openai-api-key`
 - chunker settings are currently configured by CLI flags, not by YAML
 - flags support both `--flag value` and `--flag=value`
@@ -431,6 +437,47 @@ RAGLOOM_LOG_FORMAT=json RAGLOOM_LOG=info ragloom --config ./ragloom.yaml --opena
 
 Ragloom does not log secrets, API keys, or full document contents.
 
+### Health endpoint
+
+The local health endpoint is disabled by default. Enable it with either:
+
+```bash
+ragloom --config ./ragloom.yaml --health-addr 127.0.0.1:8080 --openai-api-key "$OPENAI_API_KEY"
+```
+
+or:
+
+```yaml
+health:
+  addr: "127.0.0.1:8080"
+```
+
+Query it with:
+
+```bash
+curl http://127.0.0.1:8080/health
+```
+
+Ready responses return HTTP `200` and a small JSON body with daemon status and
+build/version information:
+
+```json
+{
+  "status": "ready",
+  "ready": true,
+  "version": "0.1.1",
+  "build": {
+    "package": "ragloom",
+    "version": "0.1.1"
+  }
+}
+```
+
+Startup/bootstrap failures and fatal runtime-loop failures return HTTP `503`
+with `ready: false` and a short `reason` such as `startup_failed` or
+`runtime_failed`. The endpoint does not include document text, API keys, or
+full local paths.
+
 For first-run validation, look for `ragloom.ingest.summary`. Ragloom emits it after an ingest window goes idle and again on shutdown when there is still unreported work. The summary stays structured and includes counters such as:
 
 - `discovered_files`
@@ -454,7 +501,7 @@ Status: shipped in `v0.1.1`.
 - persistent local state (shipped on `main`)
 - bounded retry queue (shipped on `main`)
 - delete detection (shipped on `main`)
-- health endpoint
+- health endpoint (shipped on `main`)
 - metrics endpoint
 
 ### v0.3 - More document coverage

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,6 +25,8 @@ pub struct PipelineConfig {
     pub state: StateConfig,
     #[serde(default)]
     pub retry: RetryConfig,
+    #[serde(default)]
+    pub health: HealthConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -59,6 +61,12 @@ pub struct RetryConfig {
     pub initial_backoff_ms: u64,
     #[serde(default = "default_retry_max_backoff_ms")]
     pub max_backoff_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct HealthConfig {
+    #[serde(default)]
+    pub addr: Option<String>,
 }
 
 impl Default for StateConfig {
@@ -151,6 +159,15 @@ impl PipelineConfig {
             return Err(RagloomError::from_kind(RagloomErrorKind::Config)
                 .with_context("retry.max_backoff_ms must be >= retry.initial_backoff_ms"));
         }
+        if self
+            .health
+            .addr
+            .as_deref()
+            .is_some_and(|addr| addr.trim().is_empty())
+        {
+            return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("health.addr is empty"));
+        }
         Ok(())
     }
 }
@@ -176,11 +193,14 @@ retry:
   max_queued: 128
   initial_backoff_ms: 100
   max_backoff_ms: 2000
+health:
+  addr: "127.0.0.1:0"
 "#;
         let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
         cfg.validate().expect("validate");
         assert_eq!(cfg.state.path, ".ragloom/wal.ndjson");
         assert_eq!(cfg.retry.max_attempts, 3);
+        assert_eq!(cfg.health.addr.as_deref(), Some("127.0.0.1:0"));
     }
 
     #[test]
@@ -200,5 +220,24 @@ retry:
         let err = cfg.validate().expect_err("validate");
         assert_eq!(err.kind, RagloomErrorKind::Config);
         assert!(err.to_string().contains("retry.max_attempts"));
+    }
+
+    #[test]
+    fn rejects_empty_health_addr() {
+        let yaml = r#"
+source:
+  root: "/data"
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+health:
+  addr: " "
+"#;
+        let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
+        let err = cfg.validate().expect_err("validate");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("health.addr"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -848,7 +848,7 @@ async fn try_main() -> Result<(), RagloomError> {
     let (queue, shutdown) = AsyncRuntime::new(runtime, 128)
         .with_summary(summary.clone())
         .start();
-    let shutdown_for_monitor = shutdown.clone();
+    let mut shutdown_for_monitor = shutdown.clone();
 
     let pipeline = PipelineExecutor::with_chunker(
         embedding,
@@ -877,15 +877,8 @@ async fn try_main() -> Result<(), RagloomError> {
     health_state.mark_ready();
     let health_for_monitor = health_state.clone();
     let health_monitor = tokio::spawn(async move {
-        loop {
-            match shutdown_for_monitor.exit_reason() {
-                Some(reason) => {
-                    mark_health_from_runtime_exit(&health_for_monitor, reason);
-                    return;
-                }
-                None if health_for_monitor.is_shutting_down() => return,
-                None => tokio::time::sleep(Duration::from_millis(20)).await,
-            }
+        if let Some(reason) = shutdown_for_monitor.wait_for_exit().await {
+            mark_health_from_runtime_exit(&health_for_monitor, reason);
         }
     });
 
@@ -900,6 +893,7 @@ async fn try_main() -> Result<(), RagloomError> {
         server.shutdown().await;
     }
     let _ = worker.await;
+    health_monitor.abort();
     let _ = health_monitor.await;
     summary.emit_if_dirty("shutdown");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,10 @@ use ragloom::config::{DEFAULT_STATE_PATH, PipelineConfig};
 use ragloom::doc::FsUtf8Loader;
 use ragloom::embed::http_client::{HttpEmbeddingClient, HttpEmbeddingConfig};
 use ragloom::error::{RagloomError, RagloomErrorKind};
+use ragloom::observability::health::{HealthServer, HealthState};
 use ragloom::pipeline::runtime::{
     AckingExecutor, AsyncRuntime, IngestionSummary, PipelineExecutor, RetryPolicy, Runtime,
-    run_worker_with_retry,
+    RuntimeExitReason, run_worker_with_retry,
 };
 use ragloom::sink::qdrant::{QdrantConfig, QdrantSink};
 use ragloom::source::dir_scanner::DirectoryScannerSource;
@@ -30,6 +31,7 @@ pub struct RunConfig {
     pub qdrant_url: String,
     pub collection: String,
     pub state_path: String,
+    pub health_addr: Option<String>,
     pub create_collection_if_missing: bool,
     pub collection_vector_size: Option<usize>,
     pub chunker_strategy: String,
@@ -49,7 +51,7 @@ pub struct RunConfig {
     pub retry_max_backoff_ms: u64,
 }
 
-const USAGE: &str = "usage: ragloom [--config <path>] --dir <path> --qdrant-url <url> --collection <name> [--state-path <path>] [--retry-max-attempts <n>] [--embed-backend <openai|http>]";
+const USAGE: &str = "usage: ragloom [--config <path>] --dir <path> --qdrant-url <url> --collection <name> [--state-path <path>] [--health-addr <host:port>] [--retry-max-attempts <n>] [--embed-backend <openai|http>]";
 
 /// Top-level CLI command selected by argument parsing.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -99,6 +101,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
     let mut qdrant_url: Option<String> = None;
     let mut collection: Option<String> = None;
     let mut state_path: Option<String> = None;
+    let mut health_addr: Option<String> = None;
     let mut create_collection_if_missing = false;
     let mut collection_vector_size: Option<String> = None;
 
@@ -147,6 +150,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
             "--qdrant-url" => qdrant_url = next_value(),
             "--collection" => collection = next_value(),
             "--state-path" => state_path = next_value(),
+            "--health-addr" => health_addr = next_value(),
             "--create-collection-if-missing" => {
                 if inline_value.is_some() {
                     return Err(cli_invalid_input(
@@ -210,6 +214,14 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         .unwrap_or_else(|| DEFAULT_STATE_PATH.to_string());
     if state_path.trim().is_empty() {
         return Err(cli_config_error("--state-path or state.path is empty"));
+    }
+    let health_addr =
+        health_addr.or_else(|| file_config.as_ref().and_then(|c| c.health.addr.clone()));
+    if health_addr
+        .as_deref()
+        .is_some_and(|addr| addr.trim().is_empty())
+    {
+        return Err(cli_config_error("--health-addr or health.addr is empty"));
     }
     let collection_vector_size = collection_vector_size
         .map(|s| {
@@ -450,6 +462,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         qdrant_url,
         collection,
         state_path,
+        health_addr,
         create_collection_if_missing,
         collection_vector_size,
         chunker_strategy,
@@ -788,23 +801,54 @@ async fn try_main() -> Result<(), RagloomError> {
         ParsedCommand::Run(cfg) => *cfg,
     };
 
+    let health_state = HealthState::starting();
+    let health_server = match cfg.health_addr.as_deref() {
+        Some(addr) => match HealthServer::bind(addr, health_state.clone()).await {
+            Ok(server) => {
+                tracing::info!(
+                    event.name = "ragloom.health.started",
+                    addr = %addr,
+                    "ragloom.health.started"
+                );
+                Some(server)
+            }
+            Err(err) => {
+                health_state.mark_startup_failed();
+                return Err(err);
+            }
+        },
+        None => None,
+    };
+
     let PreparedStartup {
         embedding,
         sink,
         source,
         chunker,
-    } = prepare_startup(&cfg).await?;
+    } = match prepare_startup(&cfg).await {
+        Ok(startup) => startup,
+        Err(err) => {
+            health_state.mark_startup_failed();
+            return Err(err);
+        }
+    };
 
-    let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
-        ragloom::state::wal::FileWal::open(&cfg.state_path)
-            .map_err(|e| e.with_context("failed to initialize persistent WAL"))?,
-    ));
+    let wal = match ragloom::state::wal::FileWal::open(&cfg.state_path)
+        .map_err(|e| e.with_context("failed to initialize persistent WAL"))
+    {
+        Ok(wal) => std::sync::Arc::new(tokio::sync::Mutex::new(wal)),
+        Err(err) => {
+            health_state.mark_startup_failed();
+            return Err(err);
+        }
+    };
 
     let runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
     let summary = IngestionSummary::default();
     let (queue, shutdown) = AsyncRuntime::new(runtime, 128)
         .with_summary(summary.clone())
         .start();
+    let shutdown_for_monitor = shutdown.clone();
 
     let pipeline = PipelineExecutor::with_chunker(
         embedding,
@@ -830,16 +874,43 @@ async fn try_main() -> Result<(), RagloomError> {
         run_worker_with_retry(queue, executor, retry_policy, Some(summary_for_worker)).await;
     });
 
+    health_state.mark_ready();
+    let health_for_monitor = health_state.clone();
+    let health_monitor = tokio::spawn(async move {
+        loop {
+            match shutdown_for_monitor.exit_reason() {
+                Some(reason) => {
+                    mark_health_from_runtime_exit(&health_for_monitor, reason);
+                    return;
+                }
+                None if health_for_monitor.is_shutting_down() => return,
+                None => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+    });
+
     tokio::signal::ctrl_c().await.map_err(|e| {
         RagloomError::new(RagloomErrorKind::Internal, e)
             .with_context("failed to install Ctrl-C handler")
     })?;
 
+    health_state.mark_shutting_down();
     shutdown.shutdown();
+    if let Some(server) = health_server {
+        server.shutdown().await;
+    }
     let _ = worker.await;
+    let _ = health_monitor.await;
     summary.emit_if_dirty("shutdown");
 
     Ok(())
+}
+
+fn mark_health_from_runtime_exit(health: &HealthState, reason: RuntimeExitReason) {
+    match reason {
+        RuntimeExitReason::StartupFailed => health.mark_startup_failed(),
+        RuntimeExitReason::RuntimeFailed => health.mark_runtime_failed(),
+    }
 }
 
 #[cfg(test)]
@@ -1044,6 +1115,7 @@ mod tests {
                 qdrant_url: "http://qdrant".to_string(),
                 collection: "docs".to_string(),
                 state_path: DEFAULT_STATE_PATH.to_string(),
+                health_addr: None,
                 create_collection_if_missing: false,
                 collection_vector_size: None,
                 chunker_strategy: "recursive".to_string(),
@@ -1114,6 +1186,62 @@ mod tests {
             panic!("expected run config");
         };
         assert_eq!(cfg.state_path, ".state/ragloom.ndjson");
+    }
+
+    #[test]
+    fn parse_args_disables_health_endpoint_by_default() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.health_addr, None);
+    }
+
+    #[test]
+    fn parse_args_accepts_health_addr_separate_and_inline_values() {
+        for health_flag in [
+            vec!["--health-addr".to_string(), "127.0.0.1:0".to_string()],
+            vec!["--health-addr=127.0.0.1:0".to_string()],
+        ] {
+            let mut args = vec![
+                "ragloom".to_string(),
+                "--dir".to_string(),
+                "/tmp/docs".to_string(),
+                "--embed-backend".to_string(),
+                "http".to_string(),
+                "--embed-url".to_string(),
+                "http://embed".to_string(),
+                "--embed-model".to_string(),
+                "default".to_string(),
+                "--qdrant-url".to_string(),
+                "http://qdrant".to_string(),
+                "--collection".to_string(),
+                "docs".to_string(),
+            ];
+            args.extend(health_flag);
+
+            let cfg = parse_args(&args).expect("config");
+            let ParsedCommand::Run(cfg) = cfg else {
+                panic!("expected run config");
+            };
+            assert_eq!(cfg.health_addr.as_deref(), Some("127.0.0.1:0"));
+        }
     }
 
     #[test]
@@ -1397,6 +1525,7 @@ mod tests {
             qdrant_url: "http://qdrant".to_string(),
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: Some(768),
             chunker_strategy: "recursive".to_string(),
@@ -1432,6 +1561,7 @@ mod tests {
             qdrant_url: "http://qdrant".to_string(),
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1466,6 +1596,7 @@ mod tests {
             qdrant_url: "http://qdrant".to_string(),
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1507,6 +1638,7 @@ mod tests {
             qdrant_url: base_url,
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1567,6 +1699,7 @@ mod tests {
             qdrant_url: base_url.clone(),
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1628,6 +1761,7 @@ mod tests {
             qdrant_url: base_url.clone(),
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: Some(768),
             chunker_strategy: "recursive".to_string(),
@@ -1677,6 +1811,7 @@ mod tests {
             qdrant_url: "http://127.0.0.1:1".to_string(),
             collection: "docs".to_string(),
             state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
             create_collection_if_missing: true,
             collection_vector_size: None,
             chunker_strategy: "recursive".to_string(),
@@ -1765,6 +1900,8 @@ retry:
   max_queued: 32
   initial_backoff_ms: 10
   max_backoff_ms: 80
+health:
+  addr: "127.0.0.1:9000"
 "#,
         )
         .expect("write config");
@@ -1789,12 +1926,103 @@ retry:
         assert_eq!(cfg.retry_max_queued, 32);
         assert_eq!(cfg.retry_initial_backoff_ms, 10);
         assert_eq!(cfg.retry_max_backoff_ms, 80);
+        assert_eq!(cfg.health_addr.as_deref(), Some("127.0.0.1:9000"));
         assert_eq!(
             cfg.embed_backend,
             EmbedBackend::Http {
                 url: "http://embed-from-config".to_string(),
                 model: "default".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn parse_args_health_addr_cli_overrides_yaml_config() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/from-config"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+health:
+  addr: "127.0.0.1:9000"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--health-addr".to_string(),
+            "127.0.0.1:9001".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.health_addr.as_deref(), Some("127.0.0.1:9001"));
+    }
+
+    #[test]
+    fn parse_args_rejects_empty_yaml_health_addr() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/from-config"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+health:
+  addr: ""
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail validation");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("invalid config file"));
+    }
+
+    #[test]
+    fn runtime_exit_reason_updates_health_readiness() {
+        let health = HealthState::starting();
+        health.mark_ready();
+
+        mark_health_from_runtime_exit(&health, RuntimeExitReason::RuntimeFailed);
+
+        assert_eq!(
+            health.status(),
+            ragloom::observability::health::HealthStatus::NotReady
+        );
+        assert_eq!(
+            health.reason(),
+            Some(ragloom::observability::health::HealthFailureReason::RuntimeFailed)
+        );
+
+        let startup_health = HealthState::starting();
+        mark_health_from_runtime_exit(&startup_health, RuntimeExitReason::StartupFailed);
+        assert_eq!(
+            startup_health.reason(),
+            Some(ragloom::observability::health::HealthFailureReason::StartupFailed)
         );
     }
 

--- a/src/observability/health.rs
+++ b/src/observability/health.rs
@@ -1,0 +1,377 @@
+//! Minimal daemon health endpoint.
+//!
+//! # Why
+//! Supervisors need a stable, local signal that the daemon is ready without
+//! scraping logs or exposing ingestion data.
+
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::{RagloomError, RagloomErrorKind};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HealthStatus {
+    Starting,
+    Ready,
+    NotReady,
+    ShuttingDown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthFailureReason {
+    StartupFailed,
+    RuntimeFailed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct HealthSnapshot {
+    status: HealthStatus,
+    reason: Option<HealthFailureReason>,
+}
+
+/// Shared daemon readiness state.
+#[derive(Debug, Clone)]
+pub struct HealthState {
+    inner: std::sync::Arc<std::sync::RwLock<HealthSnapshot>>,
+}
+
+impl Default for HealthState {
+    fn default() -> Self {
+        Self::starting()
+    }
+}
+
+impl HealthState {
+    pub fn starting() -> Self {
+        Self {
+            inner: std::sync::Arc::new(std::sync::RwLock::new(HealthSnapshot {
+                status: HealthStatus::Starting,
+                reason: None,
+            })),
+        }
+    }
+
+    pub fn mark_ready(&self) {
+        self.set(HealthStatus::Ready, None);
+    }
+
+    pub fn mark_startup_failed(&self) {
+        self.set(
+            HealthStatus::NotReady,
+            Some(HealthFailureReason::StartupFailed),
+        );
+    }
+
+    pub fn mark_runtime_failed(&self) {
+        self.set(
+            HealthStatus::NotReady,
+            Some(HealthFailureReason::RuntimeFailed),
+        );
+    }
+
+    pub fn mark_shutting_down(&self) {
+        self.set(HealthStatus::ShuttingDown, None);
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.snapshot().status == HealthStatus::ShuttingDown
+    }
+
+    pub fn status(&self) -> HealthStatus {
+        self.snapshot().status
+    }
+
+    pub fn reason(&self) -> Option<HealthFailureReason> {
+        self.snapshot().reason
+    }
+
+    fn set(&self, status: HealthStatus, reason: Option<HealthFailureReason>) {
+        match self.inner.write() {
+            Ok(mut snapshot) => {
+                *snapshot = HealthSnapshot { status, reason };
+            }
+            Err(poisoned) => {
+                let mut snapshot = poisoned.into_inner();
+                *snapshot = HealthSnapshot { status, reason };
+            }
+        }
+    }
+
+    fn snapshot(&self) -> HealthSnapshot {
+        match self.inner.read() {
+            Ok(snapshot) => *snapshot,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct HealthResponse<'a> {
+    status: &'a str,
+    ready: bool,
+    version: &'a str,
+    build: BuildInfo<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<HealthFailureReason>,
+}
+
+#[derive(Debug, Serialize)]
+struct BuildInfo<'a> {
+    package: &'a str,
+    version: &'a str,
+}
+
+impl HealthResponse<'_> {
+    fn from_state(state: &HealthState) -> Self {
+        let snapshot = state.snapshot();
+        let (status, ready) = match snapshot.status {
+            HealthStatus::Starting => ("starting", false),
+            HealthStatus::Ready => ("ready", true),
+            HealthStatus::NotReady => ("not_ready", false),
+            HealthStatus::ShuttingDown => ("shutting_down", false),
+        };
+
+        Self {
+            status,
+            ready,
+            version: env!("CARGO_PKG_VERSION"),
+            build: BuildInfo {
+                package: env!("CARGO_PKG_NAME"),
+                version: env!("CARGO_PKG_VERSION"),
+            },
+            reason: snapshot.reason,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HealthServer {
+    shutdown: tokio::sync::watch::Sender<bool>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+impl HealthServer {
+    pub async fn bind(addr: &str, state: HealthState) -> Result<Self, RagloomError> {
+        let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+            RagloomError::new(RagloomErrorKind::Io, e)
+                .with_context(format!("failed to bind health endpoint: {addr}"))
+        })?;
+        Ok(Self::from_listener(listener, state))
+    }
+
+    fn from_listener(listener: tokio::net::TcpListener, state: HealthState) -> Self {
+        let (shutdown, mut shutdown_rx) = tokio::sync::watch::channel(false);
+
+        let join = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                    accepted = listener.accept() => {
+                        match accepted {
+                            Ok((stream, _)) => {
+                                let state = state.clone();
+                                tokio::spawn(async move {
+                                    if let Err(err) = handle_connection(stream, state).await {
+                                        tracing::debug!(
+                                            event.name = "ragloom.health.connection_failed",
+                                            error = %err,
+                                            "ragloom.health.connection_failed"
+                                        );
+                                    }
+                                });
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    event.name = "ragloom.health.accept_failed",
+                                    error = %err,
+                                    "ragloom.health.accept_failed"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Self { shutdown, join }
+    }
+
+    pub async fn shutdown(self) {
+        let _ = self.shutdown.send(true);
+        let _ = self.join.await;
+    }
+}
+
+async fn handle_connection(
+    mut stream: tokio::net::TcpStream,
+    state: HealthState,
+) -> Result<(), std::io::Error> {
+    let mut buf = [0_u8; 1024];
+    let mut request = Vec::new();
+
+    loop {
+        let read = stream.read(&mut buf).await?;
+        if read == 0 {
+            return Ok(());
+        }
+        request.extend_from_slice(&buf[..read]);
+        if request.windows(4).any(|w| w == b"\r\n\r\n") || request.len() >= 8192 {
+            break;
+        }
+    }
+
+    let request = String::from_utf8_lossy(&request);
+    let request_line = request.lines().next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+
+    let (status_code, reason, body) = match (method, target) {
+        ("GET", "/health") => {
+            let response = HealthResponse::from_state(&state);
+            let status = if response.ready { 200 } else { 503 };
+            let reason = if response.ready {
+                "OK"
+            } else {
+                "Service Unavailable"
+            };
+            (
+                status,
+                reason,
+                serde_json::to_string(&response).expect("health response serializes"),
+            )
+        }
+        ("GET", _) => (404, "Not Found", r#"{"error":"not_found"}"#.to_string()),
+        _ => (
+            405,
+            "Method Not Allowed",
+            r#"{"error":"method_not_allowed"}"#.to_string(),
+        ),
+    };
+
+    let response = format!(
+        "HTTP/1.1 {status_code} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.shutdown().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn spawn_server(state: HealthState) -> (std::net::SocketAddr, HealthServer) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        (addr, HealthServer::from_listener(listener, state))
+    }
+
+    async fn request(addr: std::net::SocketAddr, raw: &str) -> String {
+        let mut stream = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        stream.write_all(raw.as_bytes()).await.expect("write");
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await.expect("read");
+        response
+    }
+
+    fn response_body(response: &str) -> serde_json::Value {
+        let (_, body) = response.split_once("\r\n\r\n").expect("body");
+        serde_json::from_str(body).expect("json")
+    }
+
+    fn content_length_matches_body(response: &str) -> bool {
+        let (headers, body) = response.split_once("\r\n\r\n").expect("body");
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.eq_ignore_ascii_case("content-length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .expect("content-length");
+        content_length == body.len()
+    }
+
+    #[tokio::test]
+    async fn health_response_reports_ready_status_and_build_info() {
+        let state = HealthState::starting();
+        state.mark_ready();
+        let (addr, server) = spawn_server(state).await;
+
+        let response = request(addr, "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("Content-Type: application/json"));
+        assert!(content_length_matches_body(&response));
+        let body = response_body(&response);
+        assert_eq!(body["ready"], true);
+        assert_eq!(body["status"], "ready");
+        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(body["build"]["package"], env!("CARGO_PKG_NAME"));
+        assert_eq!(body["build"]["version"], env!("CARGO_PKG_VERSION"));
+        assert!(body.get("reason").is_none());
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_response_returns_503_with_failure_reason_when_not_ready() {
+        let state = HealthState::starting();
+        state.mark_runtime_failed();
+        let (addr, server) = spawn_server(state).await;
+
+        let response = request(addr, "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
+
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        let body = response_body(&response);
+        assert_eq!(body["ready"], false);
+        assert_eq!(body["status"], "not_ready");
+        assert_eq!(body["reason"], "runtime_failed");
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_rejects_unknown_routes_and_methods() {
+        let state = HealthState::starting();
+        state.mark_ready();
+        let (addr, server) = spawn_server(state).await;
+
+        let missing = request(addr, "GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
+        assert!(missing.starts_with("HTTP/1.1 404 Not Found"));
+
+        let method = request(addr, "POST /health HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
+        assert!(method.starts_with("HTTP/1.1 405 Method Not Allowed"));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn health_server_stops_on_shutdown() {
+        let state = HealthState::starting();
+        let (addr, server) = spawn_server(state).await;
+
+        server.shutdown().await;
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            tokio::net::TcpStream::connect(addr),
+        )
+        .await;
+        assert!(
+            result.is_err() || result.expect("connect result").is_err(),
+            "server should stop accepting connections"
+        );
+    }
+}

--- a/src/observability/health.rs
+++ b/src/observability/health.rs
@@ -153,6 +153,7 @@ pub struct HealthServer {
 
 impl HealthServer {
     pub async fn bind(addr: &str, state: HealthState) -> Result<Self, RagloomError> {
+        let addr = parse_loopback_addr(addr)?;
         let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
             RagloomError::new(RagloomErrorKind::Io, e)
                 .with_context(format!("failed to bind health endpoint: {addr}"))
@@ -207,6 +208,19 @@ impl HealthServer {
     }
 }
 
+fn parse_loopback_addr(addr: &str) -> Result<std::net::SocketAddr, RagloomError> {
+    let addr = addr.parse::<std::net::SocketAddr>().map_err(|e| {
+        RagloomError::new(RagloomErrorKind::Config, e).with_context(
+            "health endpoint address must be an IP socket address, such as 127.0.0.1:8080",
+        )
+    })?;
+    if !addr.ip().is_loopback() {
+        return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+            .with_context("health endpoint address must use a loopback IP address"));
+    }
+    Ok(addr)
+}
+
 async fn handle_connection(
     mut stream: tokio::net::TcpStream,
     state: HealthState,
@@ -240,11 +254,21 @@ async fn handle_connection(
             } else {
                 "Service Unavailable"
             };
-            (
-                status,
-                reason,
-                serde_json::to_string(&response).expect("health response serializes"),
-            )
+            match serde_json::to_string(&response) {
+                Ok(body) => (status, reason, body),
+                Err(err) => {
+                    tracing::error!(
+                        event.name = "ragloom.health.serialize_failed",
+                        error = %err,
+                        "ragloom.health.serialize_failed"
+                    );
+                    (
+                        500,
+                        "Internal Server Error",
+                        r#"{"error":"health_response_serialize_failed"}"#.to_string(),
+                    )
+                }
+            }
         }
         ("GET", _) => (404, "Not Found", r#"{"error":"not_found"}"#.to_string()),
         _ => (
@@ -373,5 +397,25 @@ mod tests {
             result.is_err() || result.expect("connect result").is_err(),
             "server should stop accepting connections"
         );
+    }
+
+    #[tokio::test]
+    async fn health_server_rejects_non_loopback_addresses() {
+        let err = HealthServer::bind("0.0.0.0:0", HealthState::starting())
+            .await
+            .expect_err("non-loopback bind should fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("loopback"));
+    }
+
+    #[tokio::test]
+    async fn health_server_rejects_non_socket_addresses() {
+        let err = HealthServer::bind("localhost:0", HealthState::starting())
+            .await
+            .expect_err("hostname bind should fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("IP socket address"));
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,6 +1,8 @@
 use crate::error::{RagloomError, RagloomErrorKind};
 use tracing_subscriber::EnvFilter;
 
+pub mod health;
+
 /// Log output format.
 ///
 /// # Why

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -933,6 +933,18 @@ impl ShutdownHandle {
     pub fn exit_reason(&self) -> Option<RuntimeExitReason> {
         *self.exit_rx.borrow()
     }
+
+    pub async fn wait_for_exit(&mut self) -> Option<RuntimeExitReason> {
+        loop {
+            if let Some(reason) = *self.exit_rx.borrow() {
+                return Some(reason);
+            }
+
+            if self.exit_rx.changed().await.is_err() {
+                return *self.exit_rx.borrow();
+            }
+        }
+    }
 }
 
 /// A minimal async runtime runner.
@@ -1312,18 +1324,13 @@ mod tests {
     async fn async_runtime_surfaces_startup_wal_read_failure() {
         let wal = std::sync::Arc::new(tokio::sync::Mutex::new(FailingWal));
         let runtime = Runtime::with_shared_wal(FakeSource::default(), wal);
-        let (mut rx, shutdown) = AsyncRuntime::new(runtime, 1).start();
+        let (mut rx, mut shutdown) = AsyncRuntime::new(runtime, 1).start();
 
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
-            loop {
-                if shutdown.exit_reason() == Some(RuntimeExitReason::StartupFailed) {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("startup failure should be surfaced");
+        let reason =
+            tokio::time::timeout(std::time::Duration::from_secs(1), shutdown.wait_for_exit())
+                .await
+                .expect("startup failure should be surfaced");
+        assert_eq!(reason, Some(RuntimeExitReason::StartupFailed));
 
         assert!(
             rx.recv().await.is_none(),


### PR DESCRIPTION
## Summary
- Add opt-in local health endpoint for daemon status monitoring
- Health endpoint is disabled by default, enabled via `--health-addr` CLI flag or `health.addr` config
- Returns minimal JSON with readiness status, version, and build metadata
- HTTP 200 for ready status, HTTP 503 for startup/runtime failures
- Integrates with CLI, config, and runtime lifecycle

## Changes
- **Health module**: New `src/observability/health.rs` with `HealthServer` and `HealthState`
- **Configuration**: Add `HealthConfig` with addr option in `src/config/mod.rs`
- **CLI**: Add `--health-addr` flag in `src/main.rs`
- **Runtime**: Update health state on startup, runtime events, and shutdown
- **Dependencies**: Add tokio `net` and `io-util` features in `Cargo.toml`
- **Documentation**: Update `CHANGELOG.md` and `README.md`

## Testing
- Added config validation test for empty health.addr
- Health endpoint is disabled by default
- No breaking changes to existing functionality

## Related Issues
Fixes #45

## Checklist
- [x] Code follows project coding standards
- [x] Documentation updated
- [x] Commits are logically organized
- [x] Branch pushed to origin

## Summary by Sourcery

Add an opt-in local health endpoint and integrate it with configuration, CLI, and runtime lifecycle to report daemon readiness and failures.

New Features:
- Introduce a TCP-based /health HTTP endpoint returning minimal readiness and build metadata, disabled by default and configurable via health.addr or --health-addr.

Enhancements:
- Track daemon startup, runtime failures, and shutdown in a shared HealthState and wire it into the runtime exit path to drive health responses.

Build:
- Enable Tokio net and io-util features to support the lightweight HTTP health server.

Documentation:
- Document the health endpoint configuration and behavior in README and CHANGELOG, including example YAML and HTTP responses.

Tests:
- Add unit tests for health endpoint responses and validation, CLI/config precedence for health.addr, and health readiness updates from runtime exit reasons.

## Summary by Sourcery

Add an opt-in local health endpoint and wire daemon readiness state into the runtime lifecycle and configuration.

New Features:
- Introduce a TCP-based /health HTTP endpoint that reports daemon readiness, failure status, and build metadata, disabled by default and configurable via health.addr or --health-addr.

Enhancements:
- Track startup, runtime failures, and shutdown in a shared HealthState and integrate it with runtime exit reasons and shutdown handling.

Build:
- Enable Tokio net and io-util features to support the lightweight HTTP health server.

Documentation:
- Document configuration, usage, and example responses for the health endpoint in the README and CHANGELOG.

Tests:
- Add tests covering health endpoint behavior, CLI/config precedence and validation for health.addr, and health readiness updates from runtime exit reasons.