### PR TITLE
Fix #35: extract shared scripted HTTP test helper for Qdrant and runtime tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,7 @@ pub mod transform;
 
 pub mod observability;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub use crate::error::{RagloomError, RagloomErrorKind};

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,9 @@ use ragloom::pipeline::runtime::{
 use ragloom::sink::qdrant::{QdrantConfig, QdrantSink};
 use ragloom::source::dir_scanner::DirectoryScannerSource;
 
+#[cfg(test)]
+mod test_support;
+
 /// Runtime configuration constructed from CLI arguments.
 ///
 /// # Why
@@ -926,102 +929,17 @@ fn mark_health_from_runtime_exit(health: &HealthState, reason: RuntimeExitReason
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::VecDeque;
     use std::io::Write;
     use std::net::TcpListener;
     use std::sync::mpsc;
     use std::sync::mpsc::Sender;
-    use std::sync::{Arc, Mutex};
     use tempfile::NamedTempFile;
 
-    #[derive(Debug, Clone)]
-    struct TestResponse {
-        status: u16,
-        reason: &'static str,
-        body: &'static str,
-    }
+    use crate::test_support::{TestHttpResponse, spawn_scripted_http_server};
 
     struct RequestCounterServer {
         stop: Sender<()>,
         handle: std::thread::JoinHandle<usize>,
-    }
-
-    fn spawn_qdrant_bootstrap_server(
-        responses: Vec<TestResponse>,
-    ) -> (String, std::thread::JoinHandle<Vec<String>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        let responses = Arc::new(Mutex::new(VecDeque::from(responses)));
-
-        let handle = std::thread::spawn(move || {
-            let mut requests = Vec::new();
-
-            loop {
-                let response = {
-                    let mut guard = responses.lock().expect("lock");
-                    guard.pop_front()
-                };
-
-                let Some(response) = response else {
-                    break;
-                };
-
-                let (mut stream, _) = listener.accept().expect("accept");
-                let mut buf = [0_u8; 8192];
-                let mut request = Vec::new();
-
-                loop {
-                    let read = std::io::Read::read(&mut stream, &mut buf).expect("read");
-                    if read == 0 {
-                        break;
-                    }
-                    request.extend_from_slice(&buf[..read]);
-                    if request.windows(4).any(|w| w == b"\r\n\r\n") {
-                        let header_end = request
-                            .windows(4)
-                            .position(|w| w == b"\r\n\r\n")
-                            .expect("header end")
-                            + 4;
-                        let headers = String::from_utf8_lossy(&request[..header_end]);
-                        let content_length = headers
-                            .lines()
-                            .find_map(|line| {
-                                let (name, value) = line.split_once(':')?;
-                                if name.eq_ignore_ascii_case("content-length") {
-                                    value.trim().parse::<usize>().ok()
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap_or(0);
-                        while request.len() < header_end + content_length {
-                            let read =
-                                std::io::Read::read(&mut stream, &mut buf).expect("read body");
-                            if read == 0 {
-                                break;
-                            }
-                            request.extend_from_slice(&buf[..read]);
-                        }
-                        break;
-                    }
-                }
-
-                requests.push(String::from_utf8_lossy(&request).into_owned());
-                write!(
-                    stream,
-                    "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
-                    response.status,
-                    response.reason,
-                    response.body.len(),
-                    response.body
-                )
-                .expect("write response");
-            }
-
-            requests
-        });
-
-        (format!("http://{}", addr), handle)
     }
 
     fn spawn_qdrant_request_counter_server() -> (String, RequestCounterServer) {
@@ -1686,18 +1604,11 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn bootstrap_collection_if_needed_infers_known_openai_model_size_in_startup_path() {
-        let (base_url, server) = spawn_qdrant_bootstrap_server(vec![
-            TestResponse {
-                status: 404,
-                reason: "Not Found",
-                body: r#"{"status":"not_found"}"#,
-            },
-            TestResponse {
-                status: 200,
-                reason: "OK",
-                body: r#"{"status":"ok"}"#,
-            },
+        let server = spawn_scripted_http_server(vec![
+            TestHttpResponse::json(404, r#"{"status":"not_found"}"#),
+            TestHttpResponse::json(200, r#"{"status":"ok"}"#),
         ]);
+        let base_url = server.base_url();
 
         let cfg = RunConfig {
             dir: "/tmp/docs".to_string(),
@@ -1740,7 +1651,7 @@ mod tests {
             .await
             .expect("bootstrap");
 
-        let requests = server.join().expect("join");
+        let requests = server.join();
         assert_eq!(requests.len(), 2);
         assert!(requests[1].starts_with("PUT /collections/docs HTTP/1.1"));
         assert!(requests[1].contains(r#""size":1536"#));
@@ -1749,18 +1660,11 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn bootstrap_collection_if_needed_uses_explicit_http_vector_size_in_startup_path() {
-        let (base_url, server) = spawn_qdrant_bootstrap_server(vec![
-            TestResponse {
-                status: 404,
-                reason: "Not Found",
-                body: r#"{"status":"not_found"}"#,
-            },
-            TestResponse {
-                status: 200,
-                reason: "OK",
-                body: r#"{"status":"ok"}"#,
-            },
+        let server = spawn_scripted_http_server(vec![
+            TestHttpResponse::json(404, r#"{"status":"not_found"}"#),
+            TestHttpResponse::json(200, r#"{"status":"ok"}"#),
         ]);
+        let base_url = server.base_url();
 
         let cfg = RunConfig {
             dir: "/tmp/docs".to_string(),
@@ -1802,7 +1706,7 @@ mod tests {
             .await
             .expect("bootstrap");
 
-        let requests = server.join().expect("join");
+        let requests = server.join();
         assert_eq!(requests.len(), 2);
         assert!(requests[1].starts_with("PUT /collections/docs HTTP/1.1"));
         assert!(requests[1].contains(r#""size":768"#));

--- a/src/sink/qdrant.rs
+++ b/src/sink/qdrant.rs
@@ -337,85 +337,11 @@ struct QdrantResponse {
 mod tests {
     use super::*;
 
-    use std::collections::VecDeque;
-    use std::io::{Read, Write};
-    use std::net::{Shutdown, TcpListener};
-    use std::sync::{Arc, Mutex};
-
     use crate::sink::{PointId, VectorPoint};
-
-    #[derive(Debug, Clone)]
-    struct TestResponse {
-        status: u16,
-        reason: &'static str,
-        body: &'static str,
-    }
-
-    impl TestResponse {
-        fn json(status: u16, body: &'static str) -> Self {
-            let reason = match status {
-                200 => "OK",
-                404 => "Not Found",
-                409 => "Conflict",
-                500 => "Internal Server Error",
-                _ => "Test Response",
-            };
-
-            Self {
-                status,
-                reason,
-                body,
-            }
-        }
-    }
+    use crate::test_support::{TestHttpResponse, spawn_scripted_http_server};
 
     fn spawn_test_server(status: u16, body: &'static str) -> String {
-        let (base_url, _) = spawn_sequence_test_server(vec![TestResponse::json(status, body)]);
-        base_url
-    }
-
-    fn spawn_sequence_test_server(
-        responses: Vec<TestResponse>,
-    ) -> (String, Arc<Mutex<Vec<String>>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        let responses = Arc::new(Mutex::new(VecDeque::from(responses)));
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let thread_responses = Arc::clone(&responses);
-        let thread_requests = Arc::clone(&requests);
-
-        std::thread::spawn(move || {
-            while let Ok((mut stream, _)) = listener.accept() {
-                let mut buf = [0u8; 8192];
-                let bytes_read = stream.read(&mut buf).expect("read request");
-                thread_requests
-                    .lock()
-                    .expect("requests lock")
-                    .push(String::from_utf8_lossy(&buf[..bytes_read]).into_owned());
-
-                let response = thread_responses
-                    .lock()
-                    .expect("responses lock")
-                    .pop_front()
-                    .expect("response");
-                let response = format!(
-                    "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    response.status,
-                    response.reason,
-                    response.body.len(),
-                    response.body
-                );
-                let _ = stream.write_all(response.as_bytes());
-                let _ = stream.flush();
-                let _ = stream.shutdown(Shutdown::Both);
-
-                if thread_responses.lock().expect("responses lock").is_empty() {
-                    break;
-                }
-            }
-        });
-
-        (format!("http://{addr}"), requests)
+        spawn_scripted_http_server(vec![TestHttpResponse::json(status, body)]).base_url()
     }
 
     fn test_point() -> VectorPoint {
@@ -472,8 +398,9 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn delete_document_points_sends_doc_id_filter() {
-        let (base_url, requests) =
-            spawn_sequence_test_server(vec![TestResponse::json(200, r#"{"status":"ok"}"#)]);
+        let server =
+            spawn_scripted_http_server(vec![TestHttpResponse::json(200, r#"{"status":"ok"}"#)]);
+        let base_url = server.base_url();
 
         let sink = QdrantSink::new(QdrantConfig {
             base_url,
@@ -489,7 +416,7 @@ mod tests {
         .await
         .expect("delete");
 
-        let requests = requests.lock().expect("requests lock");
+        let requests = server.join();
         assert_eq!(requests.len(), 1);
         assert!(requests[0].starts_with("POST /collections/docs/points/delete?wait=true HTTP/1.1"));
         assert!(requests[0].contains(r#""key":"doc_id""#));
@@ -520,8 +447,9 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn ensure_collection_exists_noops_when_collection_already_exists() {
-        let (base_url, requests) =
-            spawn_sequence_test_server(vec![TestResponse::json(200, r#"{"status":"ok"}"#)]);
+        let server =
+            spawn_scripted_http_server(vec![TestHttpResponse::json(200, r#"{"status":"ok"}"#)]);
+        let base_url = server.base_url();
 
         let sink = QdrantSink::new(QdrantConfig {
             base_url,
@@ -532,7 +460,7 @@ mod tests {
 
         sink.ensure_collection_exists(384).await.expect("ok");
 
-        let requests = requests.lock().expect("requests lock");
+        let requests = server.join();
         assert_eq!(requests.len(), 1);
         assert!(requests[0].starts_with("GET /collections/docs HTTP/1.1"));
     }
@@ -540,10 +468,11 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn ensure_collection_exists_creates_missing_collection() {
-        let (base_url, requests) = spawn_sequence_test_server(vec![
-            TestResponse::json(404, r#"{"status":"error"}"#),
-            TestResponse::json(200, r#"{"status":"ok"}"#),
+        let server = spawn_scripted_http_server(vec![
+            TestHttpResponse::json(404, r#"{"status":"error"}"#),
+            TestHttpResponse::json(200, r#"{"status":"ok"}"#),
         ]);
+        let base_url = server.base_url();
 
         let sink = QdrantSink::new(QdrantConfig {
             base_url,
@@ -554,7 +483,7 @@ mod tests {
 
         sink.ensure_collection_exists(384).await.expect("created");
 
-        let requests = requests.lock().expect("requests lock");
+        let requests = server.join();
         assert_eq!(requests.len(), 2);
         assert!(requests[0].starts_with("GET /collections/docs HTTP/1.1"));
         assert!(requests[1].starts_with("PUT /collections/docs HTTP/1.1"));
@@ -565,11 +494,12 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn ensure_collection_exists_tolerates_create_race_when_collection_now_exists() {
-        let (base_url, requests) = spawn_sequence_test_server(vec![
-            TestResponse::json(404, r#"{"status":"error"}"#),
-            TestResponse::json(409, r#"{"status":"error","result":{"code":"conflict"}}"#),
-            TestResponse::json(200, r#"{"status":"ok"}"#),
+        let server = spawn_scripted_http_server(vec![
+            TestHttpResponse::json(404, r#"{"status":"error"}"#),
+            TestHttpResponse::json(409, r#"{"status":"error","result":{"code":"conflict"}}"#),
+            TestHttpResponse::json(200, r#"{"status":"ok"}"#),
         ]);
+        let base_url = server.base_url();
 
         let sink = QdrantSink::new(QdrantConfig {
             base_url,
@@ -580,7 +510,7 @@ mod tests {
 
         sink.ensure_collection_exists(384).await.expect("ok");
 
-        let requests = requests.lock().expect("requests lock");
+        let requests = server.join();
         assert_eq!(requests.len(), 3);
         assert!(requests[0].starts_with("GET /collections/docs HTTP/1.1"));
         assert!(requests[1].starts_with("PUT /collections/docs HTTP/1.1"));
@@ -590,10 +520,11 @@ mod tests {
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
     #[tokio::test]
     async fn ensure_collection_exists_surfaces_create_failures_with_bootstrap_context() {
-        let (base_url, _) = spawn_sequence_test_server(vec![
-            TestResponse::json(404, r#"{"status":"error"}"#),
-            TestResponse::json(500, r#"{"status":"error"}"#),
+        let server = spawn_scripted_http_server(vec![
+            TestHttpResponse::json(404, r#"{"status":"error"}"#),
+            TestHttpResponse::json(500, r#"{"status":"error"}"#),
         ]);
+        let base_url = server.base_url();
 
         let sink = QdrantSink::new(QdrantConfig {
             base_url,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,137 @@
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub(crate) struct TestHttpResponse {
+    status: u16,
+    reason: &'static str,
+    body: &'static str,
+}
+
+impl TestHttpResponse {
+    pub(crate) fn json(status: u16, body: &'static str) -> Self {
+        let reason = match status {
+            200 => "OK",
+            404 => "Not Found",
+            409 => "Conflict",
+            500 => "Internal Server Error",
+            _ => "Test Response",
+        };
+
+        Self {
+            status,
+            reason,
+            body,
+        }
+    }
+}
+
+pub(crate) struct ScriptedHttpServer {
+    base_url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl ScriptedHttpServer {
+    pub(crate) fn base_url(&self) -> String {
+        self.base_url.clone()
+    }
+
+    pub(crate) fn join(self) -> Vec<String> {
+        self.handle.join().expect("join scripted server");
+        self.requests.lock().expect("requests lock").clone()
+    }
+}
+
+pub(crate) fn spawn_scripted_http_server(responses: Vec<TestHttpResponse>) -> ScriptedHttpServer {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let responses = Arc::new(Mutex::new(VecDeque::from(responses)));
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let thread_responses = Arc::clone(&responses);
+    let thread_requests = Arc::clone(&requests);
+
+    let handle = std::thread::spawn(move || {
+        loop {
+            let response = {
+                let mut guard = thread_responses.lock().expect("responses lock");
+                guard.pop_front()
+            };
+
+            let Some(response) = response else {
+                break;
+            };
+
+            let (mut stream, _) = listener.accept().expect("accept");
+            let request = read_http_request(&mut stream);
+            thread_requests
+                .lock()
+                .expect("requests lock")
+                .push(String::from_utf8_lossy(&request).into_owned());
+
+            write!(
+                stream,
+                "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response.status,
+                response.reason,
+                response.body.len(),
+                response.body
+            )
+            .expect("write response");
+            let _ = stream.flush();
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    });
+
+    ScriptedHttpServer {
+        base_url: format!("http://{addr}"),
+        requests,
+        handle,
+    }
+}
+
+fn read_http_request(stream: &mut impl Read) -> Vec<u8> {
+    let mut buf = [0_u8; 8192];
+    let mut request = Vec::new();
+
+    loop {
+        let read = stream.read(&mut buf).expect("read request");
+        if read == 0 {
+            return request;
+        }
+
+        request.extend_from_slice(&buf[..read]);
+
+        let Some(header_end) = request.windows(4).position(|w| w == b"\r\n\r\n") else {
+            continue;
+        };
+        let header_end = header_end + 4;
+        let content_length = content_length(&request[..header_end]);
+
+        while request.len() < header_end + content_length {
+            let read = stream.read(&mut buf).expect("read body");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buf[..read]);
+        }
+
+        return request;
+    }
+}
+
+fn content_length(headers: &[u8]) -> usize {
+    String::from_utf8_lossy(headers)
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## Summary

Extract shared scripted HTTP test helper into src/test_support.rs and remove duplicate HTTP test server scaffolding from src/sink/qdrant.rs and src/main.rs.

## Related issue

Closes #35

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- Added src/test_support.rs with TestHttpResponse and ScriptedHttpServer utilities.
- Refactored src/sink/qdrant.rs tests to use shared scripted HTTP server helpers.
- Refactored src/main.rs tests to use shared scripted HTTP server helpers.
- Exposed 	est_support module in src/lib.rs for crate-local test sharing.

## How to test

1. Run cargo test --lib.
2. Verify the new shared test helper compiles and existing Qdrant tests pass.
3. Confirm no runtime behavior changes outside test scaffolding.

## Screenshots or recordings

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [ ] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This PR keeps the runtime and sink tests DRY by centralizing scripted HTTP server behavior in a shared helper module.