### PR TITLE
[codex] Reuse the WAL append handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 - Prometheus-compatible `/metrics` endpoint on the same local health listener,
   exposing ingest progress, retry reliability counters, and queue depth gauges.
 
+### Changed
+- `FileWal` now keeps its append handle open across records to avoid repeated
+  open/close overhead on the WAL hot path, while still calling
+  `sync_data()` per append so crash recovery semantics stay unchanged.
+
 ### Notes
 - The WAL format is append-only newline-delimited JSON. Corrupt or unreadable
   state files fail startup with a `state` error so operators can inspect or

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ The WAL is newline-delimited JSON and records planned `WorkItemV2` entries plus
 have a matching acknowledgement and seeds planner de-duplication from the WAL so
 already acknowledged file versions are not planned again. Corrupt or unreadable
 state files fail startup with a `state` error instead of being ignored.
+Ragloom keeps the WAL append handle open for the lifetime of the process to
+avoid repeated open/close overhead, while still calling `sync_data()` after each
+record so the durability boundary remains one acknowledged append at a time.
 
 Retries are not persisted as separate WAL records. If the process stops while
 retries are queued, unacknowledged work is replayed from the WAL on the next

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -5,6 +5,7 @@
 //! us replay un-acked work after crashes without requiring complex distributed
 //! coordination.
 
+use std::fs::File;
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
@@ -114,6 +115,7 @@ impl WalStore for InMemoryWal {
 #[derive(Debug)]
 pub struct FileWal {
     path: PathBuf,
+    file: File,
 }
 
 impl FileWal {
@@ -130,16 +132,10 @@ impl FileWal {
             })?;
         }
 
-        std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|e| {
-                RagloomError::new(RagloomErrorKind::State, e)
-                    .with_context(format!("failed to open WAL file: {}", path.display()))
-            })?;
-
-        let wal = Self { path };
+        let wal = Self {
+            file: open_wal_append_file(&path)?,
+            path,
+        };
         wal.read_all().map_err(|e| {
             RagloomError::new(e.kind, e).with_context("failed to validate WAL file")
         })?;
@@ -166,23 +162,15 @@ impl WalStore for FileWal {
                 .with_context("failed to encode WAL record")
         })?;
 
-        // Keep append durability simple and explicit: one record, one sync.
-        // This favors crash recovery over throughput for the current local WAL.
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
-            .map_err(|e| {
-                RagloomError::new(RagloomErrorKind::State, e)
-                    .with_context(format!("failed to open WAL file: {}", self.path.display()))
-            })?;
-        writeln!(file, "{encoded}").map_err(|e| {
+        // Keep one append handle open to avoid per-record open/close overhead,
+        // but still sync every appended record so crash recovery stays explicit.
+        writeln!(self.file, "{encoded}").map_err(|e| {
             RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
                 "failed to append WAL file: {}",
                 self.path.display()
             ))
         })?;
-        file.sync_data().map_err(|e| {
+        self.file.sync_data().map_err(|e| {
             RagloomError::new(RagloomErrorKind::State, e)
                 .with_context(format!("failed to sync WAL file: {}", self.path.display()))
         })?;
@@ -227,6 +215,17 @@ impl WalStore for FileWal {
             }
         }
     }
+}
+
+fn open_wal_append_file(path: &Path) -> Result<File, RagloomError> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e)
+                .with_context(format!("failed to open WAL file: {}", path.display()))
+        })
 }
 
 /// Returns unacked work in original append order.
@@ -475,6 +474,7 @@ mod tests {
     fn file_wal_is_empty_uses_file_metadata_without_parsing() {
         let mut file = NamedTempFile::new().expect("temp wal");
         let wal = FileWal {
+            file: open_wal_append_file(file.path()).expect("open"),
             path: file.path().to_path_buf(),
         };
         assert!(wal.is_empty());
@@ -488,9 +488,38 @@ mod tests {
     fn file_wal_reports_missing_file_as_empty() {
         let dir = tempfile::tempdir().expect("temp dir");
         let wal = FileWal {
+            file: open_wal_append_file(&dir.path().join("missing.ndjson")).expect("open"),
             path: dir.path().join("missing.ndjson"),
         };
 
         assert!(wal.is_empty());
+    }
+
+    #[test]
+    fn file_wal_reuses_open_handle_across_multiple_appends() {
+        let file = NamedTempFile::new().expect("temp wal");
+        let path = file.path().to_path_buf();
+
+        let mut wal = FileWal::open(&path).expect("open");
+        wal.append(WalRecord::WorkItem {
+            chunk_id: [1u8; 32],
+        })
+        .expect("append first");
+        wal.append(WalRecord::SinkAck {
+            chunk_id: [1u8; 32],
+        })
+        .expect("append second");
+
+        assert_eq!(
+            wal.read_all().expect("read"),
+            vec![
+                WalRecord::WorkItem {
+                    chunk_id: [1u8; 32]
+                },
+                WalRecord::SinkAck {
+                    chunk_id: [1u8; 32]
+                },
+            ]
+        );
     }
 }

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -472,25 +472,23 @@ mod tests {
 
     #[test]
     fn file_wal_is_empty_uses_file_metadata_without_parsing() {
-        let mut file = NamedTempFile::new().expect("temp wal");
-        let wal = FileWal {
-            file: open_wal_append_file(file.path()).expect("open"),
-            path: file.path().to_path_buf(),
-        };
+        let file = NamedTempFile::new().expect("temp wal");
+        let wal = FileWal::open(file.path()).expect("open");
         assert!(wal.is_empty());
 
-        file.write_all(b"{not json}\n")
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(file.path())
+            .expect("reopen")
+            .write_all(b"{not json}\n")
             .expect("write invalid content");
         assert!(!wal.is_empty());
     }
 
     #[test]
-    fn file_wal_reports_missing_file_as_empty() {
+    fn file_wal_reports_newly_opened_file_as_empty() {
         let dir = tempfile::tempdir().expect("temp dir");
-        let wal = FileWal {
-            file: open_wal_append_file(&dir.path().join("missing.ndjson")).expect("open"),
-            path: dir.path().join("missing.ndjson"),
-        };
+        let wal = FileWal::open(dir.path().join("fresh.ndjson")).expect("open");
 
         assert!(wal.is_empty());
     }


### PR DESCRIPTION
## Summary
- keep the WAL append file handle open for the lifetime of FileWal
- retain per-record sync_data() so the durability boundary does not change
- document the throughput vs durability tradeoff and cover the reused-handle path with tests

## Why
Issue #48 called out the repeated open + write + sync path in FileWal::append as unnecessary hot-path overhead. This change removes the repeated open/close cost without introducing batched fsync semantics or a wider crash window.

## Testing
- cargo test file_wal --lib
- cargo qa

Fixes #48.

## Summary by Sourcery

Keep the file-backed WAL’s append handle open for the lifetime of FileWal to reduce hot-path overhead while preserving per-record durability semantics.

Enhancements:
- Refactor FileWal to hold a persistent append File handle instead of opening and closing it on each append.
- Extract a helper to open the WAL append file for reuse across production code and tests.

Documentation:
- Document the WAL append-handle reuse and its throughput vs durability tradeoff in the changelog and README.

Tests:
- Add a test verifying that FileWal reuses its open handle across multiple appends and still correctly replays records.