### PR TITLE
fix(source): preserve deleted-file synchronization across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,12 @@ YAML config to choose another file.
 
 The WAL is newline-delimited JSON and records planned `WorkItemV2` entries plus
 `SinkAckV2` acknowledgements. On startup, Ragloom replays work items that do not
-have a matching acknowledgement and seeds planner de-duplication from the WAL so
-already acknowledged file versions are not planned again. Corrupt or unreadable
-state files fail startup with a `state` error instead of being ignored.
+have a matching acknowledgement, seeds planner de-duplication from the WAL so
+already acknowledged file versions are not planned again, and restores the set
+of previously observed document paths used by delete detection. This means
+delete synchronization survives restarts as long as you reuse the same
+`--state-path` or `state.path`. Corrupt or unreadable state files fail startup
+with a `state` error instead of being ignored.
 Ragloom keeps the WAL append handle open for the lifetime of the process to
 avoid repeated open/close overhead, while still calling `sync_data()` after each
 record so the durability boundary remains one acknowledged append at a time.

--- a/src/main.rs
+++ b/src/main.rs
@@ -618,7 +618,6 @@ async fn bootstrap_collection_if_needed(
 struct PreparedStartup {
     embedding: std::sync::Arc<dyn ragloom::embed::EmbeddingProvider + Send + Sync>,
     sink: QdrantSink,
-    source: DirectoryScannerSource,
     chunker: std::sync::Arc<dyn ragloom::transform::chunker::Chunker>,
 }
 
@@ -787,17 +786,11 @@ async fn prepare_startup(cfg: &RunConfig) -> Result<PreparedStartup, RagloomErro
         }
     };
 
-    let source = DirectoryScannerSource::new(&cfg.dir).map_err(|e| {
-        RagloomError::new(RagloomErrorKind::Io, e)
-            .with_context("failed to create directory scanner source")
-    })?;
-
     bootstrap_collection_if_needed(cfg, &sink).await?;
 
     Ok(PreparedStartup {
         embedding,
         sink,
-        source,
         chunker,
     })
 }
@@ -866,19 +859,6 @@ async fn try_main() -> Result<(), RagloomError> {
         None => None,
     };
 
-    let PreparedStartup {
-        embedding,
-        sink,
-        source,
-        chunker,
-    } = match prepare_startup(&cfg).await {
-        Ok(startup) => startup,
-        Err(err) => {
-            health_state.mark_startup_failed();
-            return Err(err);
-        }
-    };
-
     let wal = match ragloom::state::wal::FileWal::open(&cfg.state_path)
         .map_err(|e| e.with_context("failed to initialize persistent WAL"))
     {
@@ -888,6 +868,33 @@ async fn try_main() -> Result<(), RagloomError> {
             return Err(err);
         }
     };
+
+    let previously_observed_paths = {
+        let guard = wal.lock().await;
+        let records = guard
+            .read_all()
+            .map_err(|e| e.with_context("failed to read persistent WAL for source recovery"))?;
+        ragloom::state::wal::known_live_document_paths(&records)
+    };
+
+    let PreparedStartup {
+        embedding,
+        sink,
+        chunker,
+    } = match prepare_startup(&cfg).await {
+        Ok(startup) => startup,
+        Err(err) => {
+            health_state.mark_startup_failed();
+            return Err(err);
+        }
+    };
+
+    let source =
+        DirectoryScannerSource::with_previously_observed_paths(&cfg.dir, previously_observed_paths)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Io, e)
+                    .with_context("failed to create directory scanner source")
+            })?;
 
     let runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
     let summary = IngestionSummary::default();

--- a/src/source/dir_scanner.rs
+++ b/src/source/dir_scanner.rs
@@ -31,9 +31,21 @@ impl DirectoryScannerSource {
     /// The scanner is stateful (it must remember previously observed versions)
     /// so construction is explicit and fallible only for invalid inputs.
     pub fn new(root: impl AsRef<Path>) -> Result<Self, std::io::Error> {
+        Self::with_previously_observed_paths(root, HashSet::new())
+    }
+
+    /// Creates a scanner seeded with previously observed canonical paths.
+    ///
+    /// # Why
+    /// Seeding source state from the WAL lets delete detection survive process
+    /// restarts without introducing another persistent state file.
+    pub fn with_previously_observed_paths(
+        root: impl AsRef<Path>,
+        canonical_paths: HashSet<String>,
+    ) -> Result<Self, std::io::Error> {
         Ok(Self {
             root: root.as_ref().to_path_buf(),
-            tailer: FileTailer::new(),
+            tailer: FileTailer::with_previously_observed_paths(canonical_paths),
         })
     }
 
@@ -186,6 +198,24 @@ mod tests {
         assert!(
             logs_contain("ragloom.source.dir_scanner.skip_dir"),
             "expected ragloom.source.dir_scanner.skip_dir trace event"
+        );
+    }
+
+    #[test]
+    fn seeded_scanner_emits_delete_for_missing_file_on_first_poll() {
+        let tmp = tempdir().expect("create tempdir");
+        let missing = tmp.path().join("gone.txt").to_string_lossy().to_string();
+        let mut scanner = DirectoryScannerSource::with_previously_observed_paths(
+            tmp.path(),
+            HashSet::from([missing.clone()]),
+        )
+        .expect("create scanner");
+
+        assert_eq!(
+            scanner.poll(),
+            vec![SourceEvent::FileDeleted {
+                canonical_path: missing
+            }]
         );
     }
 

--- a/src/source/file_tailer.rs
+++ b/src/source/file_tailer.rs
@@ -45,6 +45,25 @@ impl FileTailer {
         Self::default()
     }
 
+    /// Constructs a tailer seeded with previously observed canonical paths.
+    ///
+    /// # Why
+    /// Restart-time delete detection only needs path membership. We seed
+    /// placeholder versions so a first completed scan can emit delete events
+    /// for files removed while the process was offline.
+    pub fn with_previously_observed_paths(
+        canonical_paths: impl IntoIterator<Item = String>,
+    ) -> Self {
+        let last_seen_version = canonical_paths
+            .into_iter()
+            .map(|canonical_path| (canonical_path, [0u8; 32]))
+            .collect();
+        Self {
+            last_seen_version,
+            pending: Vec::new(),
+        }
+    }
+
     /// Feeds an observation into the tailer.
     ///
     /// # Why
@@ -164,6 +183,30 @@ mod tests {
         );
 
         tailer.complete_scan(&HashSet::new());
+        assert!(tailer.drain().is_empty());
+    }
+
+    #[test]
+    fn seeded_missing_path_emits_delete_on_first_completed_scan() {
+        let mut tailer = FileTailer::with_previously_observed_paths(["/x/a.txt".to_string()]);
+
+        tailer.complete_scan(&HashSet::new());
+
+        assert_eq!(
+            tailer.drain(),
+            vec![SourceEvent::FileDeleted {
+                canonical_path: "/x/a.txt".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn seeded_existing_path_does_not_emit_spurious_delete() {
+        let mut tailer = FileTailer::with_previously_observed_paths(["/x/a.txt".to_string()]);
+        let observed = HashSet::from(["/x/a.txt".to_string()]);
+
+        tailer.complete_scan(&observed);
+
         assert!(tailer.drain().is_empty());
     }
 }

--- a/src/source/file_tailer.rs
+++ b/src/source/file_tailer.rs
@@ -35,7 +35,7 @@ impl ObservedFileMeta {
 /// from any real filesystem scanning/watching implementation.
 #[derive(Debug, Default)]
 pub struct FileTailer {
-    last_seen_version: HashMap<String, [u8; 32]>,
+    last_seen_version: HashMap<String, Option<[u8; 32]>>,
     pending: Vec<SourceEvent>,
 }
 
@@ -56,7 +56,7 @@ impl FileTailer {
     ) -> Self {
         let last_seen_version = canonical_paths
             .into_iter()
-            .map(|canonical_path| (canonical_path, [0u8; 32]))
+            .map(|canonical_path| (canonical_path, None))
             .collect();
         Self {
             last_seen_version,
@@ -75,12 +75,12 @@ impl FileTailer {
         let should_emit = self
             .last_seen_version
             .get(&fingerprint.canonical_path)
-            .map(|existing| existing != &version_id)
+            .map(|existing| existing.as_ref() != Some(&version_id))
             .unwrap_or(true);
 
         if should_emit {
             self.last_seen_version
-                .insert(fingerprint.canonical_path.clone(), version_id);
+                .insert(fingerprint.canonical_path.clone(), Some(version_id));
             self.pending
                 .push(SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
                     fingerprint,
@@ -207,6 +207,25 @@ mod tests {
 
         tailer.complete_scan(&observed);
 
+        assert!(tailer.drain().is_empty());
+    }
+
+    #[test]
+    fn seeded_existing_path_emits_discovery_once_on_first_observe() {
+        let mut tailer = FileTailer::with_previously_observed_paths(["/x/a.txt".to_string()]);
+
+        tailer.observe(ObservedFileMeta {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+        });
+        assert_eq!(tailer.drain().len(), 1);
+
+        tailer.observe(ObservedFileMeta {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+        });
         assert!(tailer.drain().is_empty());
     }
 }

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -270,6 +270,31 @@ pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
     unacked.into_iter().map(|(_, record)| record).collect()
 }
 
+/// Projects the set of canonical paths that were last known to exist.
+///
+/// # Why
+/// The polling source keeps delete detection state in memory. On restart we
+/// rebuild the minimum source-side state from the WAL so the next completed
+/// scan can emit delete work for files removed while Ragloom was offline.
+pub fn known_live_document_paths(records: &[WalRecord]) -> std::collections::HashSet<String> {
+    let mut live_paths = std::collections::HashSet::new();
+
+    for record in records {
+        match record {
+            WalRecord::WorkItemV2 { fingerprint } | WalRecord::SinkAckV2 { fingerprint } => {
+                live_paths.insert(fingerprint.canonical_path.clone());
+            }
+            WalRecord::DeleteDocument { canonical_path }
+            | WalRecord::DeleteAck { canonical_path } => {
+                live_paths.remove(canonical_path);
+            }
+            WalRecord::WorkItem { .. } | WalRecord::SinkAck { .. } => {}
+        }
+    }
+
+    live_paths
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -456,6 +481,98 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string()
             }]
         );
+    }
+
+    #[test]
+    fn known_live_document_paths_restores_acknowledged_file_as_live() {
+        let records = vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                },
+            },
+            WalRecord::SinkAckV2 {
+                fingerprint: FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                },
+            },
+        ];
+
+        assert_eq!(
+            known_live_document_paths(&records),
+            std::collections::HashSet::from(["/x/a.txt".to_string()])
+        );
+    }
+
+    #[test]
+    fn known_live_document_paths_removes_path_after_delete() {
+        let records = vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                },
+            },
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+            WalRecord::DeleteAck {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+        ];
+
+        assert!(known_live_document_paths(&records).is_empty());
+    }
+
+    #[test]
+    fn known_live_document_paths_restores_path_after_reingest() {
+        let records = vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                },
+            },
+            WalRecord::DeleteAck {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+            WalRecord::WorkItemV2 {
+                fingerprint: FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 11,
+                    mtime_unix_secs: 101,
+                },
+            },
+        ];
+
+        assert_eq!(
+            known_live_document_paths(&records),
+            std::collections::HashSet::from(["/x/a.txt".to_string()])
+        );
+    }
+
+    #[test]
+    fn known_live_document_paths_keeps_pending_delete_absent() {
+        let records = vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                },
+            },
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+        ];
+
+        assert!(known_live_document_paths(&records).is_empty());
     }
 
     #[test]

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -276,6 +276,10 @@ pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
 /// The polling source keeps delete detection state in memory. On restart we
 /// rebuild the minimum source-side state from the WAL so the next completed
 /// scan can emit delete work for files removed while Ragloom was offline.
+///
+/// Legacy `WorkItem`/`SinkAck` records are intentionally ignored here because
+/// they only carry chunk ids, not canonical paths, so they cannot reconstruct
+/// source-side document membership for restart-time delete detection.
 pub fn known_live_document_paths(records: &[WalRecord]) -> std::collections::HashSet<String> {
     let mut live_paths = std::collections::HashSet::new();
 

--- a/tests/delete_sync_restart.rs
+++ b/tests/delete_sync_restart.rs
@@ -56,17 +56,29 @@ async fn delete_sync_survives_restart_when_reusing_same_wal() {
     let mut restarted_runtime = Runtime::with_shared_wal(restarted_source, Arc::clone(&wal));
 
     restarted_runtime.tick().expect("restart tick");
+    restarted_runtime.tick().expect("second restart tick");
 
     let delete_records = {
         let guard = wal.lock().await;
         guard.read_all().expect("read wal")
     };
+    let delete_count = delete_records
+        .iter()
+        .filter(|record| {
+            matches!(
+                record,
+                WalRecord::DeleteDocument { canonical_path }
+                if canonical_path == &path.to_string_lossy()
+            )
+        })
+        .count();
     assert!(
         delete_records.contains(&WalRecord::DeleteDocument {
             canonical_path: path.to_string_lossy().to_string()
         }),
         "expected durable delete work after restart"
     );
+    assert_eq!(delete_count, 1, "delete work should not be re-emitted");
 
     let (tx, rx) = tokio::sync::mpsc::channel(1);
     let executor = AckingExecutor {

--- a/tests/delete_sync_restart.rs
+++ b/tests/delete_sync_restart.rs
@@ -1,0 +1,118 @@
+use std::fs;
+use std::io::Write;
+use std::sync::Arc;
+
+use ragloom::pipeline::runtime::{AckingExecutor, Runtime, WorkExecutor, run_worker};
+use ragloom::source::DirectoryScannerSource;
+use ragloom::state::wal::{FileWal, WalRecord, known_live_document_paths};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn delete_sync_survives_restart_when_reusing_same_wal() {
+    let tmp = tempdir().expect("create tempdir");
+    let source_root = tmp.path().join("docs");
+    fs::create_dir(&source_root).expect("create source root");
+    let wal_path = tmp.path().join("ragloom.ndjson");
+    let path = source_root.join("a.txt");
+    write_text_file(&path, "hello");
+
+    let wal = Arc::new(tokio::sync::Mutex::new(
+        FileWal::open(&wal_path).expect("open wal"),
+    ));
+    let source = DirectoryScannerSource::new(&source_root).expect("create scanner");
+    let mut runtime = Runtime::with_shared_wal(source, Arc::clone(&wal));
+
+    runtime.tick().expect("first tick");
+
+    let initial_records = {
+        let guard = wal.lock().await;
+        guard.read_all().expect("read wal")
+    };
+    assert_eq!(initial_records.len(), 1);
+    let fingerprint = match &initial_records[0] {
+        WalRecord::WorkItemV2 { fingerprint } => fingerprint.clone(),
+        other => panic!("expected WorkItemV2, got {other:?}"),
+    };
+
+    {
+        let mut guard = wal.lock().await;
+        guard
+            .append(WalRecord::SinkAckV2 {
+                fingerprint: fingerprint.clone(),
+            })
+            .expect("append ack");
+    }
+
+    fs::remove_file(&path).expect("delete file while offline");
+
+    let seeded_paths = {
+        let guard = wal.lock().await;
+        let records = guard.read_all().expect("read wal");
+        known_live_document_paths(&records)
+    };
+    let restarted_source =
+        DirectoryScannerSource::with_previously_observed_paths(&source_root, seeded_paths)
+            .expect("create restarted scanner");
+    let mut restarted_runtime = Runtime::with_shared_wal(restarted_source, Arc::clone(&wal));
+
+    restarted_runtime.tick().expect("restart tick");
+
+    let delete_records = {
+        let guard = wal.lock().await;
+        guard.read_all().expect("read wal")
+    };
+    assert!(
+        delete_records.contains(&WalRecord::DeleteDocument {
+            canonical_path: path.to_string_lossy().to_string()
+        }),
+        "expected durable delete work after restart"
+    );
+
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let executor = AckingExecutor {
+        inner: DeleteOnlyExecutor::default(),
+        wal: Arc::clone(&wal),
+    };
+    let worker = tokio::spawn(async move {
+        run_worker(rx, executor).await;
+    });
+
+    tx.send(WalRecord::DeleteDocument {
+        canonical_path: path.to_string_lossy().to_string(),
+    })
+    .await
+    .expect("send delete");
+    drop(tx);
+    worker.await.expect("worker join");
+
+    let final_records = {
+        let guard = wal.lock().await;
+        guard.read_all().expect("read wal")
+    };
+    assert!(
+        final_records.contains(&WalRecord::DeleteAck {
+            canonical_path: path.to_string_lossy().to_string()
+        }),
+        "expected delete acknowledgement after worker execution"
+    );
+}
+
+#[derive(Debug, Default)]
+struct DeleteOnlyExecutor {
+    seen: Arc<tokio::sync::Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl WorkExecutor for DeleteOnlyExecutor {
+    async fn execute(&self, record: WalRecord) -> Result<(), ragloom::RagloomError> {
+        if let WalRecord::DeleteDocument { canonical_path } = record {
+            self.seen.lock().await.push(canonical_path);
+        }
+        Ok(())
+    }
+}
+
+fn write_text_file(path: &std::path::Path, contents: &str) {
+    let mut file = fs::File::create(path).expect("create file");
+    write!(file, "{contents}").expect("write file");
+}


### PR DESCRIPTION
## Summary

Fixes delete synchronization across restarts. Previously, files deleted while Ragloom was stopped were not detected on the next startup because the source-side state (FileTailer) was only kept in memory. This PR implements persistent delete detection by recovering previously observed document paths from the WAL on startup.

## Related issue

Closes #70

## Type of change

<!-- Mark the relevant option with an "x". -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

<!-- List the main changes introduced by this PR. -->

- Added `known_live_document_paths()` function in `src/state/wal.rs` to reconstruct the set of previously observed document paths from WAL records
- Extended `FileTailer` and `DirectoryScannerSource` to accept a seed set of previously observed canonical paths
- Modified `main.rs` to read the WAL before creating the source and extract previously observed paths to seed the source
- Added regression tests for delete detection after restart
- Updated README to document delete synchronization semantics across restarts

## How to test

<!-- Describe how reviewers can test or verify this change. -->

1. Run `cargo qa` to verify formatting, clippy, and all tests pass
2. Test delete-while-running scenario:
   - Start Ragloom against a test directory with some files
   - Delete a file while Ragloom is running
   - Verify Qdrant point count drops (delete is synchronized)
3. Test delete-across-restart scenario:
   - Start Ragloom against a test directory with some files
   - Stop Ragloom
   - Delete a file from the test directory
   - Restart Ragloom with the same `--state-path`
   - Verify Qdrant point count drops (delete is synchronized after restart)
4. Run the new integration test: `cargo test --test delete_sync_restart`

## Screenshots or recordings

<!-- Add screenshots, videos, or terminal output if relevant. -->

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.

## Summary by Sourcery

Persist and replay source-side delete detection state from the WAL so file deletions made while Ragloom is offline are synchronized after restart.

Bug Fixes:
- Ensure files deleted while Ragloom is stopped are detected and synchronized on the next startup when reusing the same state path.

Enhancements:
- Recover previously observed live document paths from WAL records and use them to seed directory scanning and file tailing on startup.

Documentation:
- Document that delete synchronization now survives restarts when the same WAL state path is reused.

Tests:
- Add unit tests for WAL-based live-path reconstruction and seeded file tailer/scanner behavior, plus an integration test covering delete synchronization across restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete detection now survives restarts and will immediately detect files removed while the service was offline when the same state storage is reused.

* **Bug Fixes**
  * Corrupt or unreadable state files now cause startup to fail explicitly instead of being ignored.

* **Documentation**
  * Clarified state recovery and delete synchronization behavior.

* **Tests**
  * Added integration tests validating durable delete behavior across restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->