### PR TITLE
Include bounded embedding error response bodies

### DIFF
--- a/src/embed/http_client.rs
+++ b/src/embed/http_client.rs
@@ -170,7 +170,7 @@ mod tests {
 
         assert_eq!(err.kind, RagloomErrorKind::Embed);
         assert!(err.to_string().contains("non-success"));
-        assert!(err.to_string().contains(r#""error":"boom""#));
+        assert!(err.to_string().contains("error: boom"));
     }
 
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]

--- a/src/embed/http_client.rs
+++ b/src/embed/http_client.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::embed::EmbeddingProvider;
+use crate::embed::{EmbeddingProvider, read_error_body};
 use crate::error::{RagloomError, RagloomErrorKind};
 
 /// HTTP embedding client configuration.
@@ -90,11 +90,14 @@ impl EmbeddingProvider for HttpEmbeddingClient {
             })?;
 
         if !response.status().is_success() {
+            let status = response.status();
+            let body = read_error_body(response).await;
             return Err(
                 RagloomError::from_kind(RagloomErrorKind::Embed).with_context(format!(
-                    "embedding request returned non-success status (endpoint={}, status={})",
+                    "embedding request returned non-success status (endpoint={}, status={}, body={})",
                     self.config.endpoint,
-                    response.status()
+                    status,
+                    body
                 )),
             );
         }
@@ -167,6 +170,7 @@ mod tests {
 
         assert_eq!(err.kind, RagloomErrorKind::Embed);
         assert!(err.to_string().contains("non-success"));
+        assert!(err.to_string().contains(r#""error":"boom""#));
     }
 
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -9,8 +9,13 @@ pub mod http_client;
 pub mod openai_client;
 
 use async_trait::async_trait;
+use reqwest::Response;
 
 use crate::error::RagloomError;
+
+const MAX_UPSTREAM_ERROR_BODY_CHARS: usize = 256;
+const MAX_UPSTREAM_ERROR_BODY_BYTES: usize = 1024;
+const TRUNCATION_SUFFIX: &str = "...(truncated)";
 
 /// Produces embedding vectors for input texts.
 ///
@@ -20,4 +25,92 @@ use crate::error::RagloomError;
 #[async_trait]
 pub trait EmbeddingProvider {
     async fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, RagloomError>;
+}
+
+async fn read_error_body(mut response: Response) -> String {
+    let mut body = Vec::new();
+    let mut truncated = false;
+
+    loop {
+        let chunk = match response.chunk().await {
+            Ok(Some(chunk)) => chunk,
+            Ok(None) => break,
+            Err(_) => {
+                if body.is_empty() {
+                    return "<failed to read body>".to_string();
+                }
+                truncated = true;
+                break;
+            }
+        };
+
+        let remaining = MAX_UPSTREAM_ERROR_BODY_BYTES.saturating_sub(body.len());
+        if remaining == 0 {
+            truncated = true;
+            break;
+        }
+
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+
+        body.extend_from_slice(&chunk);
+    }
+
+    let body = String::from_utf8_lossy(&body);
+    format_error_body(&body, truncated)
+}
+
+fn format_error_body(body: &str, truncated: bool) -> String {
+    let normalized = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        return "<empty body>".to_string();
+    }
+
+    let mut bounded = normalized.chars();
+    let preview: String = bounded
+        .by_ref()
+        .take(MAX_UPSTREAM_ERROR_BODY_CHARS)
+        .collect();
+    if truncated || bounded.next().is_some() {
+        format!("{preview}{TRUNCATION_SUFFIX}")
+    } else {
+        preview
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_error_body;
+
+    #[test]
+    fn upstream_error_body_is_normalized_and_bounded() {
+        let body = format!(
+            "  error:\n{}\n  ",
+            "x".repeat(super::MAX_UPSTREAM_ERROR_BODY_CHARS + 32)
+        );
+
+        let formatted = format_error_body(&body, false);
+
+        assert!(formatted.starts_with("error:"));
+        assert!(formatted.ends_with(super::TRUNCATION_SUFFIX));
+        assert!(!formatted.contains('\n'));
+    }
+
+    #[test]
+    fn empty_upstream_error_body_has_placeholder() {
+        assert_eq!(format_error_body(" \n\t ", false), "<empty body>");
+    }
+
+    #[test]
+    fn byte_truncated_upstream_error_body_is_marked_truncated() {
+        let formatted = format_error_body("temporary upstream outage", true);
+
+        assert_eq!(
+            formatted,
+            format!("temporary upstream outage{}", super::TRUNCATION_SUFFIX)
+        );
+    }
 }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -10,12 +10,17 @@ pub mod openai_client;
 
 use async_trait::async_trait;
 use reqwest::Response;
+use serde_json::Value;
 
 use crate::error::RagloomError;
 
 const MAX_UPSTREAM_ERROR_BODY_CHARS: usize = 256;
 const MAX_UPSTREAM_ERROR_BODY_BYTES: usize = 1024;
 const TRUNCATION_SUFFIX: &str = "...(truncated)";
+const REDACTED_EMAIL: &str = "[redacted-email]";
+const REDACTED_TOKEN: &str = "[redacted-token]";
+const REDACTED_JSON_BODY: &str = "<redacted json body>";
+const SAFE_JSON_FIELDS: &[&str] = &["message", "error", "code", "type"];
 
 /// Produces embedding vectors for input texts.
 ///
@@ -64,7 +69,8 @@ async fn read_error_body(mut response: Response) -> String {
 }
 
 fn format_error_body(body: &str, truncated: bool) -> String {
-    let normalized = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    let sanitized = sanitize_error_body(body);
+    let normalized = sanitized.split_whitespace().collect::<Vec<_>>().join(" ");
     if normalized.is_empty() {
         return "<empty body>".to_string();
     }
@@ -81,9 +87,161 @@ fn format_error_body(body: &str, truncated: bool) -> String {
     }
 }
 
+fn sanitize_error_body(body: &str) -> String {
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => sanitize_json_error_body(&value),
+        Err(_) => redact_plain_text(body),
+    }
+}
+
+fn sanitize_json_error_body(value: &Value) -> String {
+    let mut snippets = Vec::new();
+    collect_safe_json_fields(value, None, &mut snippets);
+
+    if snippets.is_empty() {
+        REDACTED_JSON_BODY.to_string()
+    } else {
+        snippets.join("; ")
+    }
+}
+
+fn collect_safe_json_fields(value: &Value, prefix: Option<&str>, snippets: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if SAFE_JSON_FIELDS.contains(&key.as_str()) {
+                    let path = join_json_path(prefix, key);
+                    match child {
+                        Value::Object(_) | Value::Array(_) => {
+                            collect_safe_json_fields(child, Some(path.as_str()), snippets);
+                        }
+                        _ => {
+                            snippets.push(format!(
+                                "{}: {}",
+                                path,
+                                redact_plain_text(&json_scalar_to_text(child))
+                            ));
+                        }
+                    }
+                } else {
+                    collect_safe_json_fields(child, prefix, snippets);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                collect_safe_json_fields(child, prefix, snippets);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn join_json_path(prefix: Option<&str>, key: &str) -> String {
+    match prefix {
+        Some(prefix) => format!("{prefix}.{key}"),
+        None => key.to_string(),
+    }
+}
+
+fn json_scalar_to_text(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => value.clone(),
+        Value::Array(_) | Value::Object(_) => String::new(),
+    }
+}
+
+fn redact_plain_text(text: &str) -> String {
+    let mut redacted_words = Vec::new();
+    let mut redact_next = false;
+
+    for word in text.split_whitespace() {
+        if redact_next {
+            redacted_words.push(REDACTED_TOKEN.to_string());
+            redact_next = false;
+            continue;
+        }
+
+        let lower = word.to_ascii_lowercase();
+        if lower == "bearer" || lower == "token" {
+            redacted_words.push(word.to_string());
+            redact_next = true;
+            continue;
+        }
+
+        let punctuation_end = word
+            .find(|ch: char| ch.is_ascii_alphanumeric())
+            .unwrap_or(word.len());
+        let suffix_start = word
+            .rfind(|ch: char| ch.is_ascii_alphanumeric())
+            .map(|index| index + 1)
+            .unwrap_or(0);
+
+        if punctuation_end >= suffix_start {
+            redacted_words.push(word.to_string());
+            continue;
+        }
+
+        let prefix = &word[..punctuation_end];
+        let core = &word[punctuation_end..suffix_start];
+        let suffix = &word[suffix_start..];
+
+        let redacted_core = if is_email_like(core) {
+            REDACTED_EMAIL.to_string()
+        } else if is_secret_like(core) {
+            REDACTED_TOKEN.to_string()
+        } else {
+            core.to_string()
+        };
+
+        redacted_words.push(format!("{prefix}{redacted_core}{suffix}"));
+    }
+
+    redacted_words.join(" ")
+}
+
+fn is_email_like(token: &str) -> bool {
+    token
+        .split_once('@')
+        .is_some_and(|(local, domain)| !local.is_empty() && domain.contains('.'))
+}
+
+fn is_secret_like(token: &str) -> bool {
+    let token = token.trim_matches(|ch: char| !is_secret_char(ch));
+    if token.is_empty() {
+        return false;
+    }
+
+    let lower = token.to_ascii_lowercase();
+    if lower.starts_with("sk-") && token.len() >= 10 {
+        return true;
+    }
+
+    if lower.starts_with("authorization:") || lower.starts_with("api-key:") {
+        return true;
+    }
+
+    if token.len() < 24 {
+        return false;
+    }
+
+    let has_alpha = token.chars().any(|ch| ch.is_ascii_alphabetic());
+    let has_digit = token.chars().any(|ch| ch.is_ascii_digit());
+    let all_secret_chars = token.chars().all(is_secret_char);
+
+    all_secret_chars && has_alpha && has_digit
+}
+
+fn is_secret_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '=')
+}
+
 #[cfg(test)]
 mod tests {
-    use super::format_error_body;
+    use super::{format_error_body, redact_plain_text, sanitize_error_body};
 
     #[test]
     fn upstream_error_body_is_normalized_and_bounded() {
@@ -112,5 +270,29 @@ mod tests {
             formatted,
             format!("temporary upstream outage{}", super::TRUNCATION_SUFFIX)
         );
+    }
+
+    #[test]
+    fn json_error_body_only_keeps_safe_fields() {
+        let formatted = sanitize_error_body(
+            r#"{"error":{"message":"quota exceeded","type":"insufficient_quota","details":"secret doc text"},"request_id":"abc"}"#,
+        );
+
+        assert!(formatted.contains("error.message: quota exceeded"));
+        assert!(formatted.contains("error.type: insufficient_quota"));
+        assert!(!formatted.contains("details"));
+        assert!(!formatted.contains("request_id"));
+    }
+
+    #[test]
+    fn plain_text_redaction_masks_emails_and_tokens() {
+        let formatted = redact_plain_text(
+            "contact ops@example.com Authorization: Bearer sk-1234567890abcdefghijklmnop",
+        );
+
+        assert!(formatted.contains(super::REDACTED_EMAIL));
+        assert!(formatted.contains("Bearer [redacted-token]"));
+        assert!(!formatted.contains("ops@example.com"));
+        assert!(!formatted.contains("sk-1234567890abcdefghijklmnop"));
     }
 }

--- a/src/embed/openai_client.rs
+++ b/src/embed/openai_client.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 
-use crate::embed::EmbeddingProvider;
+use crate::embed::{EmbeddingProvider, read_error_body};
 use crate::error::{RagloomError, RagloomErrorKind};
 
 /// OpenAI embedding client configuration.
@@ -117,11 +117,14 @@ impl EmbeddingProvider for OpenAiEmbeddingClient {
             })?;
 
         if !response.status().is_success() {
+            let status = response.status();
+            let body = read_error_body(response).await;
             return Err(RagloomError::from_kind(RagloomErrorKind::Embed).with_context(format!(
-                "openai embedding request returned non-success status (model={}, endpoint={}, status={})",
+                "openai embedding request returned non-success status (model={}, endpoint={}, status={}, body={})",
                 self.config.model,
                 self.config.endpoint,
-                response.status()
+                status,
+                body
             )));
         }
 
@@ -189,5 +192,28 @@ mod tests {
         let out = client.embed(&["hello".to_string()]).await.expect("embed");
 
         assert_eq!(out, vec![vec![1.0, 2.0]]);
+    }
+
+    #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
+    #[tokio::test]
+    async fn non_success_status_includes_upstream_body_text() {
+        let url = spawn_test_server(429, r#"{ "error": { "message": "quota exceeded" } }"#);
+
+        let client = OpenAiEmbeddingClient::new(OpenAiEmbeddingConfig {
+            endpoint: url,
+            api_key: "test-key".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            timeout: Duration::from_secs(5),
+        })
+        .expect("client");
+
+        let err = client
+            .embed(&["hello".to_string()])
+            .await
+            .expect_err("should fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::Embed);
+        assert!(err.to_string().contains("non-success"));
+        assert!(err.to_string().contains("quota exceeded"));
     }
 }


### PR DESCRIPTION
## Summary

Include bounded upstream response bodies in embedding non-success diagnostics so operators can see actionable provider errors without reading unbounded payloads into memory.

## Related issue

Closes #57

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- add a shared embed helper that reads only a bounded preview of non-success upstream response bodies, normalizes whitespace, and marks truncated output
- include `body=...` context in both generic HTTP and OpenAI embedding non-success errors
- add regression tests covering helper truncation behavior and both embedding clients' surfaced error text

## How to test

1. `cargo test --lib embed:: -- --nocapture`
2. `cargo qa`
3. Trigger a non-2xx embedding response and confirm the error display includes a bounded upstream body preview

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [ ] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

No documentation updates were needed because this changes error diagnostics only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for failed embedding requests by including upstream response body text, status and endpoint details in error context
  * Normalized and truncated upstream response previews for readability, and added redaction/sanitization of sensitive fields (emails, tokens, non-whitelisted JSON paths)

* **Tests**
  * Added unit tests covering upstream error-body reading, normalization, empty responses, truncation behavior, JSON safe-field filtering, and plain-text redaction

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/73)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/73)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->