### PR TITLE
docs: avoid echoing OPENAI_API_KEY in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,10 +618,10 @@ If startup looks healthy but nothing appears in Qdrant, check the latest `ragloo
 
 ### OpenAI API errors
 
-Verify your API key is set correctly:
+Verify your API key is set without printing the value:
 
 ```bash
-echo $OPENAI_API_KEY
+if [ -n "$OPENAI_API_KEY" ]; then echo "OPENAI_API_KEY is set"; else echo "OPENAI_API_KEY is not set"; fi
 ```
 
 Test the embedding endpoint directly:
@@ -632,6 +632,8 @@ curl https://api.openai.com/v1/embeddings \
   -H "Content-Type: application/json" \
   -d '{"input":"test","model":"text-embedding-3-small"}'
 ```
+
+Do not share command output if it includes credentials or other sensitive response details.
 
 ## Current limitations
 


### PR DESCRIPTION
## Summary

Update the README troubleshooting guidance for OpenAI API errors so it no longer suggests printing `OPENAI_API_KEY` while debugging.

## Related issue

Closes #59

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- replace `echo $OPENAI_API_KEY` with a non-secret environment-variable check
- keep the direct `curl` troubleshooting example intact for endpoint validation
- add guidance not to share sensitive command output from troubleshooting steps

## How to test

1. Open `README.md` and review the `OpenAI API errors` troubleshooting section.
2. Confirm the API-key check verifies whether the variable is set without printing the secret value.
3. Confirm the section now warns against sharing sensitive troubleshooting output.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [ ] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This is a README-only documentation fix, so I did not run `cargo qa`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting instructions for OpenAI API errors with improved credential handling
  * Added warning against sharing command output containing sensitive information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/74)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->