### PR TITLE
Update AGENTS scope for issue 58

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ The project is intentionally small and explicit. **Preserve the minimalist desig
 - `src/pipeline` contains planning, runtime, worker execution, and acknowledgements.
 - `src/sink` contains vector sink abstractions and Qdrant integration.
 - `src/source` contains file discovery sources.
-- `src/state` contains in-memory WAL record types.
+- `src/state` contains WAL record types and file-backed persistence.
 - `src/transform` contains chunking, chunk metadata, router, markdown/code/semantic chunkers.
 - `xtask` contains local developer automation, currently `cargo qa`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,12 +271,16 @@ Ragloom currently focuses on:
 
 - local filesystem input
 - polling directory scans
-- top-level files in the configured directory
-- UTF-8 document loading
+- recursive scanning of regular files under one configured directory
+- UTF-8 text, Markdown, and source code file loading
+- recursive, Markdown-aware, code-aware, and opt-in semantic chunking
 - Qdrant as the built-in sink
 - OpenAI and generic HTTP embedding backends
-- in-memory WAL
+- deterministic point IDs
+- persistent local WAL state
+- bounded in-process retry for transient ingest failures
+- delete synchronization for previously observed documents
+- opt-in local health and metrics endpoint
+- optional first-run collection bootstrap for the configured target collection
 
-Avoid expanding scope accidentally. New operational features such as persistent WAL, recursive scanning, collection management, retry queues, health endpoints, and dead-letter handling should be explicit design changes with tests and docs.
-
-```
+Avoid expanding scope accidentally. New operational features such as additional document parsers, new sink types, broader collection lifecycle management, persistent dead-letter handling, or non-local operator surfaces should be explicit design changes with tests and docs.


### PR DESCRIPTION
## Summary
- update `AGENTS.md` current project scope to match shipped recursive scanning, chunking, WAL, retry, delete sync, health/metrics, and collection bootstrap behavior
- replace outdated scope exclusions with narrower guidance about features that still remain intentionally out of scope

## Why
- issue #58 tracks bringing the agent guidance back in line with the current repository behavior so future coding agents do not make decisions from stale scope docs

## Validation
- `cargo qa`

Closes #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project scope to detail supported features: recursive scanning, Markdown/code/semantic chunking (opt-in semantic), embedding options (OpenAI and generic HTTP), Qdrant sink, deterministic point IDs, persistent local WAL, bounded retries for transient failures, delete synchronization, and optional health/metrics and first-run collection bootstrap.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/75)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->