### PR TITLE
Minimize workflow token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +21,10 @@ jobs:
   analyze-rust:
     name: analyze-rust
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,6 +44,10 @@ jobs:
   analyze-actions:
     name: analyze-actions
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,9 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  attestations: write
 
 concurrency:
   group: container-${{ github.ref }}
@@ -20,6 +17,10 @@ jobs:
   image:
     name: image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: governance-${{ github.workflow }}-${{ github.ref }}
@@ -29,6 +28,9 @@ jobs:
   scorecard:
     name: scorecard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  security-events: write
+  contents: read
 
 concurrency:
   group: release-${{ inputs.version || github.ref_name }}
@@ -256,6 +253,8 @@ jobs:
       - prepare-release
       - release-binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -308,6 +307,8 @@ jobs:
       - release-binaries-best-effort
     if: always() && needs.publish-release.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download macOS release artifacts
         uses: actions/download-artifact@v8

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -115,8 +115,8 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
         "expected publish workflow to skip cargo publish cleanly when the crates.io token is unavailable"
     );
     assert!(
-        release_workflow.contains("security-events: write"),
-        "expected release workflow permissions to include security-events: write for reusable workflow calls"
+        !release_workflow.contains("security-events: write"),
+        "expected release workflow to avoid unused security-events write permissions"
     );
     assert!(
         release_workflow.contains("already exists at ${RELEASE_REF}; reusing it"),


### PR DESCRIPTION
## Summary
- reduce top-level `GITHUB_TOKEN` permissions in the security-sensitive workflows from issue #79
- scope write access down to the jobs that actually publish releases, push packages, or upload SARIF results
- keep CodeQL jobs functional by preserving the read scopes required for checkout and analysis

## Validation
- parsed `.github/workflows/codeql.yml`, `container.yml`, `governance.yml`, and `release.yml` with `python` + `yaml.safe_load`
- reviewed the resulting job-level permission boundaries against each workflow's steps
- ran `git diff --check -- .github/workflows/codeql.yml .github/workflows/container.yml .github/workflows/governance.yml .github/workflows/release.yml`

Closes #79.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI permissions by scoping GitHub Actions permissions to individual jobs, enforcing least-privilege access across workflows.
* **Tests**
  * Updated a release workflow test to reflect the revised permissions expectations and failure messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/82)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->