### PR TITLE
Pin release workflows to full action SHAs

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -36,21 +36,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Verify release version
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
       create_tag: ${{ steps.plan.outputs.create_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -95,18 +95,18 @@ jobs:
             archive_extension: zip
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_ref }}
           fetch-depth: 0
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
@@ -140,7 +140,7 @@ jobs:
             -DestinationPath "dist/$archiveBasename.zip"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: dist/${{ matrix.target }}
           output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
@@ -160,7 +160,7 @@ jobs:
           fi
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -189,18 +189,18 @@ jobs:
             archive_extension: tar.gz
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_ref }}
           fetch-depth: 0
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
@@ -222,7 +222,7 @@ jobs:
           tar -C "dist/${{ matrix.target }}" -czf "dist/${archive_basename}.tar.gz" "${{ matrix.binary_name }}"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: dist/${{ matrix.target }}
           output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
@@ -242,7 +242,7 @@ jobs:
           fi
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_ref }}
           fetch-depth: 0
@@ -287,12 +287,12 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: release-artifacts
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
           name: ${{ needs.prepare-release.outputs.tag }}
@@ -310,14 +310,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download macOS release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: release-*-apple-darwin
           path: release-artifacts-macos
           merge-multiple: true
 
       - name: Publish best-effort macOS assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
           files: release-artifacts-macos/**/*

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -19,7 +19,13 @@ fn crate_version() -> String {
 }
 
 fn workflow_pins_action_with_comment(workflow: &str, pinned: &str, version_comment: &str) -> bool {
-    workflow.contains(&format!("{pinned} # {version_comment}"))
+    let expected = format!("uses: {pinned} # {version_comment}");
+
+    workflow
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("uses:"))
+        .any(|line| line == expected)
 }
 
 #[test]

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -18,6 +18,10 @@ fn crate_version() -> String {
         .to_string()
 }
 
+fn workflow_pins_action_with_comment(workflow: &str, pinned: &str, version_comment: &str) -> bool {
+    workflow.contains(&format!("{pinned} # {version_comment}"))
+}
+
 #[test]
 fn release_workflow_supports_version_dispatch_and_release_notes() {
     let workflow_yaml = read_repo_file(".github/workflows/release.yml");
@@ -86,16 +90,24 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
         "expected publish workflow to verify crate and tag versions before cargo publish"
     );
     assert!(
-        release_workflow.contains("actions/setup-python@v5"),
-        "expected release workflow to pin Python for the verification script"
+        workflow_pins_action_with_comment(
+            &release_workflow,
+            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+            "v5",
+        ),
+        "expected release workflow to pin Python for the verification script to a full SHA and preserve the source version comment"
     );
     assert!(
         release_workflow.contains("python-version: \"3.11\""),
         "expected release workflow to require Python 3.11 for tomllib"
     );
     assert!(
-        publish_workflow.contains("actions/setup-python@v5"),
-        "expected publish workflow to pin Python for the verification script"
+        workflow_pins_action_with_comment(
+            &publish_workflow,
+            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+            "v5",
+        ),
+        "expected publish workflow to pin Python for the verification script to a full SHA and preserve the source version comment"
     );
     assert!(
         publish_workflow.contains("python-version: \"3.11\""),
@@ -249,8 +261,12 @@ fn release_workflow_packages_named_assets_and_keeps_macos_best_effort() {
     );
     assert!(
         publish_best_effort_yaml.contains("pattern: release-*-apple-darwin")
-            && publish_best_effort_yaml.contains("softprops/action-gh-release@v2"),
-        "expected successful macOS artifacts to be appended to the GitHub Release after the blocking targets publish"
+            && workflow_pins_action_with_comment(
+                &workflow_yaml,
+                "softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65",
+                "v2",
+            ),
+        "expected successful macOS artifacts to be appended to the GitHub Release after the blocking targets publish with a full SHA pin and preserved source version comment"
     );
 }
 


### PR DESCRIPTION
## Summary
- pin all external `uses:` references in `.github/workflows/release.yml` and `.github/workflows/publish-crate.yml` to full 40-character commit SHAs
- preserve the original action version comments alongside each pin for traceability
- update the release workflow contract test so it validates the new `SHA + version comment` convention

## Why
- closes #76 by removing mutable tag references from the release/publish workflows
- keeps the release pipeline aligned with stricter action pinning expectations without silently regressing the repository's workflow contract coverage

## Verification
- manually reviewed both workflow diffs to confirm every external `uses:` in scope is pinned and local reusable workflow calls remain unchanged
- `cargo fmt --check`
- `cargo test -p ragloom --test release_workflow_contract -- --nocapture`
- `cargo qa`

## Notes
- `actionlint` was not available in the local environment, so workflow validation relied on repository tests plus manual pin auditing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/release workflows to pin third‑party actions to fixed commit SHAs for stronger supply‑chain stability, preserving inline version comments.
* **Tests**
  * Updated workflow contract tests to require pinned action SHAs and to verify retained inline version annotations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/84)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/84)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->