### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,19 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Run benchmarks
         run: cargo bench
 
       - name: Upload criterion output
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: criterion-output
           path: target/criterion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Check formatting
         run: cargo fmt --check
@@ -51,13 +51,13 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build workspace
         run: cargo build --workspace --all-targets
@@ -71,7 +71,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Apply labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
@@ -22,36 +21,44 @@ jobs:
   analyze-rust:
     name: analyze-rust
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           languages: rust
           build-mode: none
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           category: /language:rust
 
   analyze-actions:
     name: analyze-actions
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           languages: actions
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           category: /language:actions

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,9 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  attestations: write
 
 concurrency:
   group: container-${{ github.ref }}
@@ -20,18 +17,23 @@ jobs:
   image:
     name: image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +41,7 @@ jobs:
 
       - name: Compute image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -50,7 +52,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           push: true
@@ -59,20 +61,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
 
       - name: Sign image
         run: cosign sign --yes ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
       - name: Generate image SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           artifact-name: image-sbom
           output-file: image.spdx.json
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           format: table
@@ -82,7 +84,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload image SBOM
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: image-sbom
           path: image.spdx.json

--- a/.github/workflows/deps-maintenance.yml
+++ b/.github/workflows/deps-maintenance.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Run tests
         run: cargo test --workspace --all-targets --all-features

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: governance-${{ github.workflow }}-${{ github.ref }}
@@ -19,29 +18,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2.1.2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
         with:
           version: "1.7.12"
 
   scorecard:
     name: scorecard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: false
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
         with:
           sarif_file: scorecard-results.sarif
 
@@ -50,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Verify required governance files
         shell: bash

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -36,21 +36,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Verify release version
         env:

--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -20,22 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@b4e65a10a3c802628cd08fe1b6e34c6cf2a6330a # cargo-llvm-cov
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Generate coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lcov
           path: lcov.info
@@ -45,13 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Run loom tests
         run: cargo test --workspace --features loom
@@ -61,19 +61,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@cargo-deny
+        uses: taiki-e/install-action@be3adac037f90da0d749916fe96168cb6e3bb135 # cargo-deny
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+        uses: taiki-e/install-action@d475d259f9cdd2e19204434fef69818bef232e40 # cargo-audit
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build documentation
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  security-events: write
+  contents: read
 
 concurrency:
   group: release-${{ inputs.version || github.ref_name }}
@@ -32,12 +29,12 @@ jobs:
       create_tag: ${{ steps.plan.outputs.create_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -95,18 +92,18 @@ jobs:
             archive_extension: zip
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_ref }}
           fetch-depth: 0
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
@@ -140,7 +137,7 @@ jobs:
             -DestinationPath "dist/$archiveBasename.zip"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: dist/${{ matrix.target }}
           output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
@@ -160,7 +157,7 @@ jobs:
           fi
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -189,18 +186,18 @@ jobs:
             archive_extension: tar.gz
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_ref }}
           fetch-depth: 0
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
@@ -222,7 +219,7 @@ jobs:
           tar -C "dist/${{ matrix.target }}" -czf "dist/${archive_basename}.tar.gz" "${{ matrix.binary_name }}"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: dist/${{ matrix.target }}
           output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
@@ -242,7 +239,7 @@ jobs:
           fi
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -256,9 +253,11 @@ jobs:
       - prepare-release
       - release-binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_ref }}
           fetch-depth: 0
@@ -287,12 +286,12 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: release-artifacts
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
           name: ${{ needs.prepare-release.outputs.tag }}
@@ -308,16 +307,18 @@ jobs:
       - release-binaries-best-effort
     if: always() && needs.publish-release.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download macOS release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: release-*-apple-darwin
           path: release-artifacts-macos
           merge-multiple: true
 
       - name: Publish best-effort macOS assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
           files: release-artifacts-macos/**/*

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark stale issues
-        uses: actions/stale@v10
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           days-before-issue-stale: 45
           days-before-issue-close: 14

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -2,6 +2,15 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+const SETUP_PYTHON_V5_PIN: &str =
+    "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5";
+const CODEQL_V4_INIT_PIN: &str =
+    "github/codeql-action/init@5e316336eb4f107009e477d4bfbfff13d7250fae # v4";
+const ACTION_GH_RELEASE_V2_REF: &str =
+    "softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65";
+const ACTION_GH_RELEASE_V2_PIN: &str =
+    "softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2";
+
 fn read_repo_file(path: &str) -> String {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     fs::read_to_string(repo_root.join(path)).expect("read repository file")
@@ -16,6 +25,13 @@ fn crate_version() -> String {
         .and_then(|version| version.strip_suffix('"'))
         .expect("Cargo.toml package.version is present")
         .to_string()
+}
+
+fn workflow_mapping<'a>(value: &'a serde_yaml::Value, field: &str) -> &'a serde_yaml::Mapping {
+    value
+        .get(serde_yaml::Value::String(field.to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .unwrap_or_else(|| panic!("expected `{field}` to be a mapping"))
 }
 
 #[test]
@@ -76,6 +92,16 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
     let publish_workflow = read_repo_file(".github/workflows/publish-crate.yml");
     let quality_workflow = read_repo_file(".github/workflows/quality-deep.yml");
     let codeql_workflow = read_repo_file(".github/workflows/codeql.yml");
+    let release_workflow_yaml: serde_yaml::Value =
+        serde_yaml::from_str(&release_workflow).expect("release workflow is valid YAML");
+    let release_permissions = workflow_mapping(&release_workflow_yaml, "permissions");
+    let release_jobs = workflow_mapping(&release_workflow_yaml, "jobs");
+    let publish_release = release_jobs
+        .get(serde_yaml::Value::String("publish-release".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected release workflow to define publish-release");
+    let publish_release_value = serde_yaml::Value::Mapping(publish_release.clone());
+    let publish_release_permissions = workflow_mapping(&publish_release_value, "permissions");
 
     assert!(
         release_workflow.contains("verify-release-version"),
@@ -86,16 +112,16 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
         "expected publish workflow to verify crate and tag versions before cargo publish"
     );
     assert!(
-        release_workflow.contains("actions/setup-python@v5"),
-        "expected release workflow to pin Python for the verification script"
+        release_workflow.contains(SETUP_PYTHON_V5_PIN),
+        "expected release workflow to pin Python to an immutable v5 commit for the verification script"
     );
     assert!(
         release_workflow.contains("python-version: \"3.11\""),
         "expected release workflow to require Python 3.11 for tomllib"
     );
     assert!(
-        publish_workflow.contains("actions/setup-python@v5"),
-        "expected publish workflow to pin Python for the verification script"
+        publish_workflow.contains(SETUP_PYTHON_V5_PIN),
+        "expected publish workflow to pin Python to an immutable v5 commit for the verification script"
     );
     assert!(
         publish_workflow.contains("python-version: \"3.11\""),
@@ -115,8 +141,17 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
         "expected publish workflow to skip cargo publish cleanly when the crates.io token is unavailable"
     );
     assert!(
-        release_workflow.contains("security-events: write"),
-        "expected release workflow permissions to include security-events: write for reusable workflow calls"
+        matches!(
+            release_permissions.get(serde_yaml::Value::String("contents".to_string())),
+            Some(serde_yaml::Value::String(level)) if level == "read"
+        ) && release_permissions.len() == 1
+            && matches!(
+                publish_release_permissions
+                    .get(serde_yaml::Value::String("contents".to_string())),
+                Some(serde_yaml::Value::String(level)) if level == "write"
+            )
+            && publish_release_permissions.len() == 1,
+        "expected release workflow to keep top-level permissions read-only and scope release mutation to publish jobs"
     );
     assert!(
         release_workflow.contains("already exists at ${RELEASE_REF}; reusing it"),
@@ -127,8 +162,12 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
         "expected deep quality workflow to keep Miri out of the release-critical CI path"
     );
     assert!(
-        codeql_workflow.contains("github/codeql-action/init@v4"),
-        "expected repository code scanning to run through CodeQL"
+        codeql_workflow.contains(CODEQL_V4_INIT_PIN),
+        "expected repository code scanning to pin CodeQL to an immutable v4 commit"
+    );
+    assert!(
+        codeql_workflow.contains("security-events: write"),
+        "expected CodeQL analyze jobs to keep the permission needed for SARIF uploads"
     );
     assert!(
         codeql_workflow.contains("languages: rust"),
@@ -249,8 +288,9 @@ fn release_workflow_packages_named_assets_and_keeps_macos_best_effort() {
     );
     assert!(
         publish_best_effort_yaml.contains("pattern: release-*-apple-darwin")
-            && publish_best_effort_yaml.contains("softprops/action-gh-release@v2"),
-        "expected successful macOS artifacts to be appended to the GitHub Release after the blocking targets publish"
+            && publish_best_effort_yaml.contains(ACTION_GH_RELEASE_V2_REF)
+            && workflow_yaml.contains(ACTION_GH_RELEASE_V2_PIN),
+        "expected successful macOS artifacts to be appended to the GitHub Release with the immutable v2 release action pin"
     );
 }
 


### PR DESCRIPTION
## Summary
- pin every remote GitHub Action in the issue #80 workflow set to immutable commit SHAs with version comments
- minimize `GITHUB_TOKEN` permissions in security-sensitive workflows, including scoping release write access to publish jobs and removing unused top-level release permissions
- update the release workflow contract test to assert the hardened permissions and immutable action pins more robustly

## Testing
- cargo test -p ragloom --test release_workflow_contract
- cargo qa
- python workflow pin audit (`ALL_REMOTE_USES_PINNED`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by pinning GitHub Actions to specific commit hashes for improved supply chain integrity and reproducibility.
  * Refined workflow permissions across all pipeline stages to follow the principle of least privilege.
  * Extended test coverage to verify pinned action configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->