### PR TITLE
Fix CI labeler concurrency for pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Tighten the CI workflow concurrency key so `pull_request_target` labeler runs are isolated by event type and PR number instead of sharing the broad ref-based group.

## Related issue

Closes #83

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [x] Build / CI change
- [ ] Other

## Changes made

- include `github.event_name` in the workflow concurrency group
- use `github.event.pull_request.number || github.ref` so PR-targeted runs group by PR number while push runs keep using the ref
- keep the fix scoped to `.github/workflows/ci.yml` without changing job behavior

## How to test

1. Run `cargo qa`.
2. Run `cargo test --workspace --features loom`.
3. Inspect `.github/workflows/ci.yml` and confirm the concurrency group now differentiates `pull_request`, `pull_request_target`, and the specific PR number for labeler runs.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This issue was caused by a concurrency key that was too broad for `pull_request_target`: labeler runs from different PR-related events could cancel each other because they shared the same `github.ref`. The new key keeps cancellation semantics for superseded runs while preventing unrelated labeler checks from colliding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow concurrency handling for pull requests to improve build efficiency by using PR-specific identifiers for better management of concurrent runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->