### PR TITLE
Promote deep quality checks into PR-visible gating

### DIFF
--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -1,6 +1,7 @@
 name: quality-deep
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ concurrency:
 jobs:
   coverage:
     name: coverage
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,6 +41,25 @@ jobs:
         with:
           name: lcov
           path: lcov.info
+
+  fastembed:
+    name: fastembed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Build with fastembed
+        run: cargo build --features fastembed
+
+      - name: Run fastembed tests
+        run: cargo test --workspace --all-targets --features fastembed
 
   loom:
     name: loom

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,18 @@ Run these checks before opening a pull request:
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - `cargo test --workspace --all-targets --all-features`
 
-Deeper checks used by CI on `main` and release paths:
+GitHub Actions also runs the authoritative pre-merge stability checks on pull requests:
+
+- `cargo build --features fastembed`
+- `cargo test --workspace --all-targets --features fastembed`
+- `cargo test --workspace --features loom`
+- `cargo deny check`
+- `cargo audit`
+- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`
+
+Additional deeper checks still used on `main` and release paths:
 
 - `cargo llvm-cov --workspace --all-features`
-- `cargo test --workspace --features loom`
 - `cargo bench`
 
 GitHub-hosted security scanning runs through CodeQL and repository governance workflows rather than Miri.

--- a/README.md
+++ b/README.md
@@ -667,6 +667,10 @@ Before opening a pull request, run:
 cargo qa
 ```
 
+Pull requests also run the repository's pre-merge stability gate in GitHub
+Actions, including `fastembed`, `loom`, dependency audit, and rustdoc warning
+checks.
+
 See `CONTRIBUTING.md` for development expectations, `SUPPORT.md` for support policy, and `SECURITY.md` for vulnerability reporting.
 
 ## License

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -176,6 +176,69 @@ fn release_workflows_verify_tag_and_crate_version_consistency_and_pin_python() {
 }
 
 #[test]
+fn quality_deep_workflow_exposes_pre_merge_stability_gate() {
+    let workflow_yaml = read_repo_file(".github/workflows/quality-deep.yml");
+    let workflow: serde_yaml::Value =
+        serde_yaml::from_str(&workflow_yaml).expect("quality workflow is valid YAML");
+
+    let on = workflow
+        .get("on")
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected quality workflow to define an `on` mapping");
+    let jobs = workflow
+        .get("jobs")
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected quality workflow to define jobs");
+
+    assert!(
+        on.contains_key(serde_yaml::Value::String("pull_request".to_string())),
+        "expected deep quality workflow to run on pull requests before merge"
+    );
+    assert!(
+        on.contains_key(serde_yaml::Value::String("workflow_call".to_string())),
+        "expected deep quality workflow to remain reusable from release paths"
+    );
+    assert!(
+        workflow_yaml.contains("if: github.event_name != 'pull_request'"),
+        "expected coverage to stay outside the PR-visible stability gate"
+    );
+
+    let fastembed = jobs
+        .get(serde_yaml::Value::String("fastembed".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected quality workflow to define a fastembed job");
+    let loom = jobs
+        .get(serde_yaml::Value::String("loom".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected quality workflow to define a loom job");
+    let docs_and_security = jobs
+        .get(serde_yaml::Value::String("docs-and-security".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected quality workflow to define a docs-and-security job");
+
+    let fastembed_yaml = serde_yaml::to_string(fastembed).expect("serialize fastembed job");
+    let loom_yaml = serde_yaml::to_string(loom).expect("serialize loom job");
+    let docs_and_security_yaml =
+        serde_yaml::to_string(docs_and_security).expect("serialize docs-and-security job");
+
+    assert!(
+        fastembed_yaml.contains("cargo build --features fastembed")
+            && fastembed_yaml.contains("cargo test --workspace --all-targets --features fastembed"),
+        "expected PR-visible stability checks to cover fastembed build and tests"
+    );
+    assert!(
+        loom_yaml.contains("cargo test --workspace --features loom"),
+        "expected PR-visible stability checks to cover loom tests"
+    );
+    assert!(
+        docs_and_security_yaml.contains("cargo deny check")
+            && docs_and_security_yaml.contains("cargo audit")
+            && docs_and_security_yaml.contains("cargo doc --workspace --no-deps"),
+        "expected PR-visible stability checks to cover docs, cargo-deny, and cargo-audit"
+    );
+}
+
+#[test]
 fn release_version_verifier_accepts_v_prefixed_manual_version_input() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let output_file = tempfile::NamedTempFile::new().expect("create temporary GITHUB_OUTPUT");


### PR DESCRIPTION
## Summary

Promote the deep quality workflow into a PR-visible stability gate while keeping coverage on main and release paths.

## Related issue

Closes #96

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [x] Build / CI change
- [ ] Other

## Changes made

- Add `pull_request` coverage to `.github/workflows/quality-deep.yml` and keep `coverage` release-only via job gating
- Add a dedicated `fastembed` job so PRs see `fastembed`, `loom`, `cargo deny`, `cargo audit`, and rustdoc checks before merge
- Update contributor docs and add a workflow contract regression test for the new PR-visible gate

## How to test

1. Run `cargo qa`.
2. Run `cargo test --workspace --features loom`.
3. Run `cargo build --features fastembed` and `cargo test --workspace --all-targets --features fastembed`.

## Screenshots or recordings

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

`cargo audit` is not installed in the local environment, so that check was validated by wiring the existing CI install step and documented as a CI-only local limitation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now run enhanced pre-merge stability checks, including fastembed build and testing, loom verification, dependency audits, and rustdoc warning detection.

* **Documentation**
  * Updated contributing guide and README to document new pull request stability gate checks and required quality validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->