### PR TITLE
xtask: add maintainer verification gate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 qa = "run -p xtask -- qa"
+maintainer-qa = "run -p xtask -- maintainer-qa"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ The project is intentionally small and explicit. **Preserve the minimalist desig
 - `src/source` contains file discovery sources.
 - `src/state` contains WAL record types and file-backed persistence.
 - `src/transform` contains chunking, chunk metadata, router, markdown/code/semantic chunkers.
-- `xtask` contains local developer automation, currently `cargo qa`.
+- `xtask` contains local developer automation, including `cargo qa` and `cargo maintainer-qa`.
 
 ## Build and verification commands
 
@@ -45,6 +45,21 @@ cargo qa
 ```
 
 `cargo qa` runs formatting, Clippy with warnings denied, and the full workspace test suite.
+
+### Authoritative maintainer gate
+
+```bash
+cargo maintainer-qa
+```
+
+`cargo maintainer-qa` runs `cargo qa` plus the deeper local maintainer checks:
+
+- `cargo test --workspace --features loom`
+- `cargo build --features fastembed`
+- `cargo test --workspace --all-targets --features fastembed`
+- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`
+- `cargo deny check`
+- `cargo audit`
 
 ### Additional deeper checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,22 +4,30 @@ Issues and pull requests are welcome. Keep changes small, test-backed, and align
 
 ## Local Verification
 
-Run these checks before opening a pull request:
+The local verification commands are:
+
+- `cargo qa`: the fast default contributor gate
+- `cargo maintainer-qa`: the authoritative deeper maintainer gate for
+  release-sensitive and v0.3 stability work
+
+`cargo qa` runs:
 
 - `cargo fmt --check`
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - `cargo test --workspace --all-targets --all-features`
 
-GitHub Actions also runs the authoritative pre-merge stability checks on pull requests:
+`cargo maintainer-qa` runs `cargo qa` plus:
 
 - `cargo build --features fastembed`
 - `cargo test --workspace --all-targets --features fastembed`
 - `cargo test --workspace --features loom`
+- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`
 - `cargo deny check`
 - `cargo audit`
-- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`
 
-Additional deeper checks still used on `main` and release paths:
+GitHub Actions also runs the same deeper stability checks on pull requests.
+
+Additional manual deep checks still used on `main` and release paths:
 
 - `cargo llvm-cov --workspace --all-features`
 - `cargo bench`

--- a/README.md
+++ b/README.md
@@ -667,9 +667,24 @@ Before opening a pull request, run:
 cargo qa
 ```
 
-Pull requests also run the repository's pre-merge stability gate in GitHub
-Actions, including `fastembed`, `loom`, dependency audit, and rustdoc warning
-checks.
+Maintainers preparing release-sensitive or v0.3 stability work should also run
+the authoritative deeper local gate:
+
+```bash
+cargo maintainer-qa
+```
+
+`cargo qa` stays the fast contributor gate. `cargo maintainer-qa` extends it
+with the checks that currently matter for local maintainer confidence:
+
+- `cargo test --workspace --features loom`
+- `cargo build --features fastembed`
+- `cargo test --workspace --all-targets --features fastembed`
+- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`
+- `cargo deny check`
+- `cargo audit`
+
+GitHub Actions runs the same deeper stability checks on pull requests.
 
 See `CONTRIBUTING.md` for development expectations, `SUPPORT.md` for support policy, and `SECURITY.md` for vulnerability reporting.
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -4,35 +4,96 @@ use std::process::{Command, ExitStatus};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Task {
     Qa,
+    MaintainerQa,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Step {
     pub name: &'static str,
     pub args: &'static [&'static str],
+    pub env: &'static [(&'static str, &'static str)],
 }
 
-const QA_STEPS: [Step; 3] = [
-    Step {
-        name: "fmt",
-        args: &["fmt", "--check"],
-    },
-    Step {
-        name: "clippy",
-        args: &[
-            "clippy",
-            "--workspace",
-            "--all-targets",
-            "--all-features",
-            "--",
-            "-D",
-            "warnings",
-        ],
-    },
-    Step {
-        name: "test",
-        args: &["test", "--workspace", "--all-targets", "--all-features"],
-    },
+const FMT_STEP: Step = Step {
+    name: "fmt",
+    args: &["fmt", "--check"],
+    env: &[],
+};
+
+const CLIPPY_STEP: Step = Step {
+    name: "clippy",
+    args: &[
+        "clippy",
+        "--workspace",
+        "--all-targets",
+        "--all-features",
+        "--",
+        "-D",
+        "warnings",
+    ],
+    env: &[],
+};
+
+const TEST_STEP: Step = Step {
+    name: "test",
+    args: &["test", "--workspace", "--all-targets", "--all-features"],
+    env: &[],
+};
+
+const LOOM_STEP: Step = Step {
+    name: "loom",
+    args: &["test", "--workspace", "--features", "loom"],
+    env: &[],
+};
+
+const FASTEMBED_BUILD_STEP: Step = Step {
+    name: "fastembed-build",
+    args: &["build", "--features", "fastembed"],
+    env: &[],
+};
+
+const FASTEMBED_TEST_STEP: Step = Step {
+    name: "fastembed-test",
+    args: &[
+        "test",
+        "--workspace",
+        "--all-targets",
+        "--features",
+        "fastembed",
+    ],
+    env: &[],
+};
+
+const DOC_STEP: Step = Step {
+    name: "doc",
+    args: &["doc", "--workspace", "--no-deps"],
+    env: &[("RUSTDOCFLAGS", "-D warnings")],
+};
+
+const DENY_STEP: Step = Step {
+    name: "deny",
+    args: &["deny", "check"],
+    env: &[],
+};
+
+const AUDIT_STEP: Step = Step {
+    name: "audit",
+    args: &["audit"],
+    env: &[],
+};
+
+const QA_STEPS: [Step; 3] = [FMT_STEP, CLIPPY_STEP, TEST_STEP];
+
+const MAINTAINER_QA_STEPS: [Step; 9] = [
+    FMT_STEP,
+    CLIPPY_STEP,
+    TEST_STEP,
+    LOOM_STEP,
+    FASTEMBED_BUILD_STEP,
+    FASTEMBED_TEST_STEP,
+    DOC_STEP,
+    DENY_STEP,
+    AUDIT_STEP,
 ];
 
 #[derive(Debug)]
@@ -54,7 +115,10 @@ impl fmt::Display for XtaskError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnknownCommand { command } => {
-                write!(f, "unknown xtask command: {command} (supported: qa)")
+                write!(
+                    f,
+                    "unknown xtask command: {command} (supported: qa, maintainer-qa)"
+                )
             }
             Self::SpawnFailed { step, source } => {
                 write!(f, "failed to spawn cargo step `{step}`: {source}")
@@ -78,6 +142,7 @@ impl std::error::Error for XtaskError {
 pub fn parse_task(args: &[String]) -> Result<Task, XtaskError> {
     match args.first().map(String::as_str) {
         None | Some("qa") => Ok(Task::Qa),
+        Some("maintainer-qa") => Ok(Task::MaintainerQa),
         Some(command) => Err(XtaskError::UnknownCommand {
             command: command.to_string(),
         }),
@@ -88,9 +153,14 @@ pub fn qa_steps() -> &'static [Step] {
     &QA_STEPS
 }
 
+pub fn maintainer_qa_steps() -> &'static [Step] {
+    &MAINTAINER_QA_STEPS
+}
+
 pub fn run_task(task: Task) -> Result<(), XtaskError> {
     let steps = match task {
         Task::Qa => qa_steps(),
+        Task::MaintainerQa => maintainer_qa_steps(),
     };
 
     for step in steps {
@@ -103,13 +173,14 @@ pub fn run_task(task: Task) -> Result<(), XtaskError> {
 fn run_step(step: &Step) -> Result<(), XtaskError> {
     println!("==> cargo {}", step.args.join(" "));
 
-    let status = Command::new("cargo")
-        .args(step.args)
-        .status()
-        .map_err(|source| XtaskError::SpawnFailed {
-            step: step.name,
-            source,
-        })?;
+    let mut command = Command::new("cargo");
+    command.args(step.args);
+    command.envs(step.env.iter().copied());
+
+    let status = command.status().map_err(|source| XtaskError::SpawnFailed {
+        step: step.name,
+        source,
+    })?;
 
     if status.success() {
         Ok(())
@@ -123,7 +194,7 @@ fn run_step(step: &Step) -> Result<(), XtaskError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Task, parse_task, qa_steps};
+    use super::{Task, maintainer_qa_steps, parse_task, qa_steps};
 
     #[test]
     fn qa_steps_match_local_developer_gate() {
@@ -163,8 +234,48 @@ mod tests {
     }
 
     #[test]
+    fn parse_task_accepts_explicit_maintainer_qa() {
+        assert_eq!(
+            parse_task(&["maintainer-qa".to_string()]).expect("task"),
+            Task::MaintainerQa
+        );
+    }
+
+    #[test]
     fn parse_task_rejects_unknown_subcommand() {
         let err = parse_task(&["unknown".to_string()]).expect_err("unknown command");
-        assert!(err.to_string().contains("unknown xtask command"));
+        assert!(err.to_string().contains("supported: qa, maintainer-qa"));
+    }
+
+    #[test]
+    fn maintainer_qa_steps_match_local_maintainer_gate() {
+        let steps = maintainer_qa_steps();
+
+        assert_eq!(steps.len(), 9);
+        assert_eq!(steps[0], qa_steps()[0]);
+        assert_eq!(steps[1], qa_steps()[1]);
+        assert_eq!(steps[2], qa_steps()[2]);
+        assert_eq!(steps[3].name, "loom");
+        assert_eq!(steps[3].args, ["test", "--workspace", "--features", "loom"]);
+        assert_eq!(steps[4].name, "fastembed-build");
+        assert_eq!(steps[4].args, ["build", "--features", "fastembed"]);
+        assert_eq!(steps[5].name, "fastembed-test");
+        assert_eq!(
+            steps[5].args,
+            [
+                "test",
+                "--workspace",
+                "--all-targets",
+                "--features",
+                "fastembed"
+            ]
+        );
+        assert_eq!(steps[6].name, "doc");
+        assert_eq!(steps[6].args, ["doc", "--workspace", "--no-deps"]);
+        assert_eq!(steps[6].env, [("RUSTDOCFLAGS", "-D warnings")]);
+        assert_eq!(steps[7].name, "deny");
+        assert_eq!(steps[7].args, ["deny", "check"]);
+        assert_eq!(steps[8].name, "audit");
+        assert_eq!(steps[8].args, ["audit"]);
     }
 }


### PR DESCRIPTION
## Summary

Add a dedicated `cargo maintainer-qa` xtask command so maintainers can run the deeper local stability gate without turning `cargo qa` into a slower default workflow.

## Related issue

Closes #97

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor
- [ ] Performance improvement
- [x] Test update
- [x] Build / CI change
- [ ] Other

## Changes made

- add the `cargo maintainer-qa` alias and xtask subcommand with the documented deep-check sequence
- keep `cargo qa` as the fast contributor gate while reusing shared xtask step definitions for the overlapping checks
- update `README.md`, `CONTRIBUTING.md`, and `AGENTS.md` to explain when to use the new maintainer gate and keep the xtask documentation in sync

## How to test

1. `cargo test -p xtask`
2. `cargo qa`
3. `cargo maintainer-qa` (runs through `cargo deny check` here and then stops because `cargo-audit` is not installed locally)

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

`cargo maintainer-qa` intentionally mirrors the existing `quality-deep` CI workflow checks, while leaving slower manual-only checks like coverage, benches, and Miri outside the default maintainer gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cargo maintainer-qa` command for deeper stability verification, running comprehensive checks including loom tests, feature builds, documentation validation, and security audits.

* **Documentation**
  * Updated contribution and agent guidance with clarified local verification workflow: fast `cargo qa` for contributors and comprehensive `cargo maintainer-qa` for maintainers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->