### PR TITLE
Generalize source config and runtime wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Ragloom supports a small typed YAML config for source, embed, and sink wiring.
 
 ```yaml
 source:
+  kind: "filesystem"
   root: "./docs"
 
 embed:
@@ -233,10 +234,15 @@ ragloom --config ./ragloom.yaml --embed-backend http --embed-model default
 
 ### Configuration notes
 
-- `--config` can provide `source.root`, `embed.endpoint`, `sink.qdrant_url`, and `sink.collection`
+- `source.kind: filesystem` plus `source.root` is the canonical filesystem config shape
+- legacy filesystem config that only sets `source.root` remains supported for compatibility
+- the config model reserves `source.kind: s3` plus `source.bucket` and optional `source.prefix`, but that source kind is not runnable in the current release line
+- `--config` can provide `source.kind`, `source.root`, `source.bucket`, `source.prefix`, `embed.endpoint`, `sink.qdrant_url`, and `sink.collection`
 - `--config` can also provide `state.path`; the CLI flag is `--state-path`
 - `--config` can provide `retry.max_attempts`, `retry.max_queued`, `retry.initial_backoff_ms`, and `retry.max_backoff_ms`
 - `--config` can provide `health.addr`; the CLI flag is `--health-addr`
+- `--dir` remains the filesystem CLI shorthand; `--source-kind filesystem --dir ./docs` is equivalent to filesystem config
+- `--s3-bucket` and `--s3-prefix` participate in source-shape validation and require `--source-kind s3`, but S3 runtime ingestion is still not available
 - backend-specific auth still comes from CLI flags, such as `--openai-api-key`
 - chunker settings are currently configured by CLI flags, not by YAML
 - flags support both `--flag value` and `--flag=value`
@@ -267,8 +273,12 @@ jitter-free so tests and local runs remain reproducible.
 
 ### Source scanning behavior
 
-The built-in filesystem source walks the configured root recursively and ingests
-regular files it can stat.
+The current built-in runtime source is the filesystem source. It walks the
+configured root recursively and ingests regular files it can stat.
+
+The config model now reserves a first-class `s3` source shape, but actual S3
+polling support is still tracked separately and is not yet runnable in the
+current release line.
 
 - traversal is deterministic because directory entries are processed in sorted path order
 - hidden files and hidden directories are treated like any other path

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,7 +31,21 @@ pub struct PipelineConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct SourceConfig {
-    pub root: String,
+    #[serde(default = "default_source_kind")]
+    pub kind: SourceKind,
+    #[serde(default)]
+    pub root: Option<String>,
+    #[serde(default)]
+    pub bucket: Option<String>,
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceKind {
+    Filesystem,
+    S3,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -92,6 +106,10 @@ fn default_state_path() -> String {
     DEFAULT_STATE_PATH.to_string()
 }
 
+fn default_source_kind() -> SourceKind {
+    SourceKind::Filesystem
+}
+
 fn default_retry_max_attempts() -> u32 {
     3
 }
@@ -127,10 +145,7 @@ impl PipelineConfig {
     /// Reload applies configs at runtime. Validation prevents partial/unsafe
     /// configs from being activated.
     pub fn validate(&self) -> Result<(), RagloomError> {
-        if self.source.root.trim().is_empty() {
-            return Err(RagloomError::from_kind(RagloomErrorKind::Config)
-                .with_context("source.root is empty"));
-        }
+        self.source.validate()?;
         if self.embed.endpoint.trim().is_empty() {
             return Err(RagloomError::from_kind(RagloomErrorKind::Config)
                 .with_context("embed.endpoint is empty"));
@@ -172,6 +187,55 @@ impl PipelineConfig {
     }
 }
 
+impl SourceConfig {
+    fn validate(&self) -> Result<(), RagloomError> {
+        match self.kind {
+            SourceKind::Filesystem => {
+                let root = self.root.as_deref().ok_or_else(|| {
+                    RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.root is required when source.kind=filesystem")
+                })?;
+                if root.trim().is_empty() {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.root is empty"));
+                }
+                if self.bucket.is_some() {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.bucket is only valid when source.kind=s3"));
+                }
+                if self.prefix.is_some() {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.prefix is only valid when source.kind=s3"));
+                }
+            }
+            SourceKind::S3 => {
+                let bucket = self.bucket.as_deref().ok_or_else(|| {
+                    RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.bucket is required when source.kind=s3")
+                })?;
+                if bucket.trim().is_empty() {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.bucket is empty"));
+                }
+                if self
+                    .prefix
+                    .as_deref()
+                    .is_some_and(|prefix| prefix.trim().is_empty())
+                {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.prefix is empty"));
+                }
+                if self.root.is_some() {
+                    return Err(RagloomError::from_kind(RagloomErrorKind::Config)
+                        .with_context("source.root is only valid when source.kind=filesystem"));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,6 +265,8 @@ health:
         assert_eq!(cfg.state.path, ".ragloom/wal.ndjson");
         assert_eq!(cfg.retry.max_attempts, 3);
         assert_eq!(cfg.health.addr.as_deref(), Some("127.0.0.1:0"));
+        assert_eq!(cfg.source.kind, SourceKind::Filesystem);
+        assert_eq!(cfg.source.root.as_deref(), Some("/data"));
     }
 
     #[test]
@@ -239,5 +305,79 @@ health:
         let err = cfg.validate().expect_err("validate");
         assert_eq!(err.kind, RagloomErrorKind::Config);
         assert!(err.to_string().contains("health.addr"));
+    }
+
+    #[test]
+    fn validates_explicit_filesystem_source_kind() {
+        let yaml = r#"
+source:
+  kind: filesystem
+  root: "/data"
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+"#;
+        let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+        assert_eq!(cfg.source.kind, SourceKind::Filesystem);
+        assert_eq!(cfg.source.root.as_deref(), Some("/data"));
+    }
+
+    #[test]
+    fn rejects_filesystem_source_with_s3_fields() {
+        let yaml = r#"
+source:
+  kind: filesystem
+  root: "/data"
+  bucket: "docs"
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+"#;
+        let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
+        let err = cfg.validate().expect_err("validate");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("source.bucket"));
+    }
+
+    #[test]
+    fn rejects_s3_source_without_bucket() {
+        let yaml = r#"
+source:
+  kind: s3
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+"#;
+        let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
+        let err = cfg.validate().expect_err("validate");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("source.bucket"));
+    }
+
+    #[test]
+    fn validates_s3_source_shape() {
+        let yaml = r#"
+source:
+  kind: s3
+  bucket: "docs"
+  prefix: "kb/"
+embed:
+  endpoint: "http://localhost:8080/embed"
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+"#;
+        let cfg = PipelineConfig::from_yaml_str(yaml).expect("parse");
+        cfg.validate().expect("validate");
+        assert_eq!(cfg.source.kind, SourceKind::S3);
+        assert_eq!(cfg.source.bucket.as_deref(), Some("docs"));
+        assert_eq!(cfg.source.prefix.as_deref(), Some("kb/"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,11 +258,17 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         .ok_or_else(|| {
             cli_config_error("missing required value: --qdrant-url or sink.qdrant_url in --config")
         })?;
+    if qdrant_url.trim().is_empty() {
+        return Err(cli_config_error("--qdrant-url or sink.qdrant_url is empty"));
+    }
     let collection = collection
         .or_else(|| file_config.as_ref().map(|c| c.sink.collection.clone()))
         .ok_or_else(|| {
             cli_config_error("missing required value: --collection or sink.collection in --config")
         })?;
+    if collection.trim().is_empty() {
+        return Err(cli_config_error("--collection or sink.collection is empty"));
+    }
     let state_path = state_path
         .or_else(|| file_config.as_ref().map(|c| c.state.path.clone()))
         .unwrap_or_else(|| DEFAULT_STATE_PATH.to_string());
@@ -307,6 +313,11 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
             let endpoint = openai_endpoint
                 .or_else(|| file_config.as_ref().map(|c| c.embed.endpoint.clone()))
                 .unwrap_or_else(|| "https://api.openai.com/v1/embeddings".to_string());
+            if endpoint.trim().is_empty() {
+                return Err(cli_config_error(
+                    "--openai-endpoint or embed.endpoint is empty",
+                ));
+            }
             let api_key = openai_api_key.ok_or_else(|| {
                 cli_config_error("missing required flag for openai backend: --openai-api-key")
             })?;
@@ -325,6 +336,9 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
                         "missing required value for http backend: --embed-url or embed.endpoint in --config",
                     )
                 })?;
+            if url.trim().is_empty() {
+                return Err(cli_config_error("--embed-url or embed.endpoint is empty"));
+            }
             let model = embed_model.unwrap_or_else(|| "default".to_string());
             EmbedBackend::Http { url, model }
         }
@@ -600,8 +614,14 @@ fn resolve_run_source(
     file_source: Option<&ragloom::config::SourceConfig>,
 ) -> Result<RunSource, RagloomError> {
     let source_kind_overridden = cli_source_kind.is_some();
+    let cli_dir_overrides_s3 = dir.is_some()
+        && !source_kind_overridden
+        && file_source
+            .map(|source| source.kind == ConfigSourceKind::S3)
+            .unwrap_or(false);
     let source_kind = match cli_source_kind {
         Some(kind) => parse_source_kind(kind)?,
+        None if dir.is_some() => ConfigSourceKind::Filesystem,
         None => file_source
             .map(|source| source.kind)
             .unwrap_or(ConfigSourceKind::Filesystem),
@@ -614,7 +634,8 @@ fn resolve_run_source(
                     "--s3-bucket and --s3-prefix require --source-kind s3",
                 ));
             }
-            if !source_kind_overridden
+            if !cli_dir_overrides_s3
+                && !source_kind_overridden
                 && file_source
                     .and_then(|source| source.bucket.as_deref())
                     .is_some()
@@ -623,7 +644,8 @@ fn resolve_run_source(
                     "source.bucket is only valid when source.kind=s3",
                 ));
             }
-            if !source_kind_overridden
+            if !cli_dir_overrides_s3
+                && !source_kind_overridden
                 && file_source
                     .and_then(|source| source.prefix.as_deref())
                     .is_some()
@@ -1560,6 +1582,41 @@ sink:
     }
 
     #[test]
+    fn parse_args_dir_overrides_configured_s3_source_kind() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  kind: s3
+  bucket: "docs-bucket"
+  prefix: "knowledge/"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--dir".to_string(),
+            "/tmp/from-cli".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.source, filesystem_source("/tmp/from-cli"));
+    }
+
+    #[test]
     fn parse_args_rejects_dir_with_s3_source_kind() {
         let args = vec![
             "ragloom".to_string(),
@@ -2425,6 +2482,102 @@ health:
         assert!(
             err.to_string()
                 .contains("--health-addr or health.addr is empty")
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_empty_yaml_embed_endpoint() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/from-config"
+embed:
+  endpoint: ""
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail validation");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(
+            err.to_string()
+                .contains("--embed-url or embed.endpoint is empty")
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_empty_yaml_qdrant_url() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/from-config"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: ""
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail validation");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(
+            err.to_string()
+                .contains("--qdrant-url or sink.qdrant_url is empty")
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_empty_yaml_collection() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  root: "/tmp/from-config"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: ""
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail validation");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(
+            err.to_string()
+                .contains("--collection or sink.collection is empty")
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use ragloom::config::{DEFAULT_STATE_PATH, PipelineConfig};
+use ragloom::config::{DEFAULT_STATE_PATH, PipelineConfig, SourceKind as ConfigSourceKind};
 use ragloom::doc::FsUtf8Loader;
 use ragloom::embed::http_client::{HttpEmbeddingClient, HttpEmbeddingConfig};
 use ragloom::error::{RagloomError, RagloomErrorKind};
@@ -30,7 +30,7 @@ mod test_support;
 /// `main()` focused on wiring.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RunConfig {
-    pub dir: String,
+    pub source: RunSource,
     pub embed_backend: EmbedBackend,
     pub qdrant_url: String,
     pub collection: String,
@@ -55,7 +55,43 @@ pub struct RunConfig {
     pub retry_max_backoff_ms: u64,
 }
 
-const USAGE: &str = "usage: ragloom [--config <path>] --dir <path> --qdrant-url <url> --collection <name> [--state-path <path>] [--health-addr <host:port>] [--retry-max-attempts <n>] [--embed-backend <openai|http>]";
+/// Source selection constructed from CLI arguments and config.
+///
+/// # Why
+/// Keeping source selection explicit lets `main.rs` stay as a small composition
+/// layer while leaving room for future source kinds without pushing that logic
+/// into the runtime.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RunSource {
+    Filesystem {
+        root: String,
+    },
+    S3 {
+        bucket: String,
+        prefix: Option<String>,
+    },
+}
+
+impl RunSource {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Filesystem { .. } => "filesystem",
+            Self::S3 { .. } => "s3",
+        }
+    }
+
+    fn log_target(&self) -> String {
+        match self {
+            Self::Filesystem { root } => root.clone(),
+            Self::S3 { bucket, prefix } => match prefix {
+                Some(prefix) => format!("s3://{bucket}/{prefix}"),
+                None => format!("s3://{bucket}"),
+            },
+        }
+    }
+}
+
+const USAGE: &str = "usage: ragloom [--config <path>] [--source-kind <filesystem|s3>] [--dir <path>] [--s3-bucket <name>] [--s3-prefix <prefix>] --qdrant-url <url> --collection <name> [--state-path <path>] [--health-addr <host:port>] [--retry-max-attempts <n>] [--embed-backend <openai|http>]";
 
 /// Top-level CLI command selected by argument parsing.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -92,7 +128,10 @@ pub enum EmbedBackend {
 /// deterministic unit tests for argument handling.
 pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
     let mut config_path: Option<String> = None;
+    let mut source_kind: Option<String> = None;
     let mut dir: Option<String> = None;
+    let mut s3_bucket: Option<String> = None;
+    let mut s3_prefix: Option<String> = None;
     let mut embed_backend: Option<String> = None;
 
     let mut embed_url: Option<String> = None;
@@ -134,7 +173,10 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
 
         match flag {
             "--config" => config_path = next_arg_value(inline_value, &mut iter),
+            "--source-kind" => source_kind = next_arg_value(inline_value, &mut iter),
             "--dir" => dir = next_arg_value(inline_value, &mut iter),
+            "--s3-bucket" => s3_bucket = next_arg_value(inline_value, &mut iter),
+            "--s3-prefix" => s3_prefix = next_arg_value(inline_value, &mut iter),
 
             "--embed-backend" => embed_backend = next_arg_value(inline_value, &mut iter),
 
@@ -203,11 +245,13 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         .map(load_pipeline_config)
         .transpose()?;
 
-    let dir = dir
-        .or_else(|| file_config.as_ref().map(|c| c.source.root.clone()))
-        .ok_or_else(|| {
-            cli_config_error("missing required value: --dir or source.root in --config")
-        })?;
+    let source = resolve_run_source(
+        source_kind.as_deref(),
+        dir,
+        s3_bucket,
+        s3_prefix,
+        file_config.as_ref().map(|cfg| &cfg.source),
+    )?;
 
     let qdrant_url = qdrant_url
         .or_else(|| file_config.as_ref().map(|c| c.sink.qdrant_url.clone()))
@@ -251,7 +295,8 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
 
     tracing::info!(
         event.name = "ragloom.start",
-        dir = %dir,
+        source_kind = %source.kind(),
+        source_target = %source.log_target(),
         embed_backend = %backend,
         qdrant_collection = %collection,
         "ragloom.start"
@@ -467,7 +512,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
     retry_policy.validate()?;
 
     Ok(ParsedCommand::Run(Box::new(RunConfig {
-        dir,
+        source,
         embed_backend,
         qdrant_url,
         collection,
@@ -499,13 +544,10 @@ fn load_pipeline_config(path: &str) -> Result<PipelineConfig, RagloomError> {
             .with_context(format!("failed to read config file: {path}"))
     })?;
 
-    let cfg = PipelineConfig::from_yaml_str(&yaml)
-        .map_err(|e| e.with_context(format!("failed to parse config file: {path}")))?;
-
-    cfg.validate()
-        .map_err(|e| e.with_context(format!("invalid config file: {path}")))?;
-
-    Ok(cfg)
+    // CLI flags are merged after file load, so parse the raw shape here and let
+    // the merged runtime configuration enforce the effective invariants.
+    PipelineConfig::from_yaml_str(&yaml)
+        .map_err(|e| e.with_context(format!("failed to parse config file: {path}")))
 }
 
 fn cli_invalid_input(message: impl Into<String>) -> RagloomError {
@@ -538,6 +580,108 @@ where
 fn cli_config_error(message: impl Into<String>) -> RagloomError {
     let message = message.into();
     RagloomError::from_kind(RagloomErrorKind::Config).with_context(format!("{message}\n{USAGE}"))
+}
+
+fn parse_source_kind(kind: &str) -> Result<ConfigSourceKind, RagloomError> {
+    match kind {
+        "filesystem" => Ok(ConfigSourceKind::Filesystem),
+        "s3" => Ok(ConfigSourceKind::S3),
+        other => Err(cli_invalid_input(format!(
+            "invalid value for --source-kind: {other} (expected: filesystem|s3)"
+        ))),
+    }
+}
+
+fn resolve_run_source(
+    cli_source_kind: Option<&str>,
+    dir: Option<String>,
+    s3_bucket: Option<String>,
+    s3_prefix: Option<String>,
+    file_source: Option<&ragloom::config::SourceConfig>,
+) -> Result<RunSource, RagloomError> {
+    let source_kind_overridden = cli_source_kind.is_some();
+    let source_kind = match cli_source_kind {
+        Some(kind) => parse_source_kind(kind)?,
+        None => file_source
+            .map(|source| source.kind)
+            .unwrap_or(ConfigSourceKind::Filesystem),
+    };
+
+    match source_kind {
+        ConfigSourceKind::Filesystem => {
+            if s3_bucket.is_some() || s3_prefix.is_some() {
+                return Err(cli_config_error(
+                    "--s3-bucket and --s3-prefix require --source-kind s3",
+                ));
+            }
+            if !source_kind_overridden
+                && file_source
+                    .and_then(|source| source.bucket.as_deref())
+                    .is_some()
+            {
+                return Err(cli_config_error(
+                    "source.bucket is only valid when source.kind=s3",
+                ));
+            }
+            if !source_kind_overridden
+                && file_source
+                    .and_then(|source| source.prefix.as_deref())
+                    .is_some()
+            {
+                return Err(cli_config_error(
+                    "source.prefix is only valid when source.kind=s3",
+                ));
+            }
+
+            let root = dir
+                .or_else(|| file_source.and_then(|source| source.root.clone()))
+                .ok_or_else(|| {
+                    cli_config_error("missing required value: --dir or source.root in --config")
+                })?;
+            if root.trim().is_empty() {
+                return Err(cli_config_error("--dir or source.root is empty"));
+            }
+
+            Ok(RunSource::Filesystem { root })
+        }
+        ConfigSourceKind::S3 => {
+            if dir.is_some() {
+                return Err(cli_config_error(
+                    "--dir is only valid when source.kind=filesystem",
+                ));
+            }
+            if !source_kind_overridden
+                && file_source
+                    .and_then(|source| source.root.as_deref())
+                    .is_some()
+            {
+                return Err(cli_config_error(
+                    "source.root is only valid when source.kind=filesystem",
+                ));
+            }
+
+            let bucket = s3_bucket
+                .or_else(|| file_source.and_then(|source| source.bucket.clone()))
+                .ok_or_else(|| {
+                    cli_config_error(
+                        "missing required value for s3 source: --s3-bucket or source.bucket in --config",
+                    )
+                })?;
+            if bucket.trim().is_empty() {
+                return Err(cli_config_error("--s3-bucket or source.bucket is empty"));
+            }
+
+            let prefix = s3_prefix.or_else(|| file_source.and_then(|source| source.prefix.clone()));
+            if prefix
+                .as_deref()
+                .is_some_and(|prefix| prefix.trim().is_empty())
+            {
+                return Err(cli_config_error("--s3-prefix or source.prefix is empty"));
+            }
+
+            Ok(RunSource::S3 { bucket, prefix })
+        }
+    }
 }
 
 fn parse_code_lang(s: &str) -> Result<ragloom::transform::chunker::code::Language, RagloomError> {
@@ -619,6 +763,38 @@ struct PreparedStartup {
     embedding: std::sync::Arc<dyn ragloom::embed::EmbeddingProvider + Send + Sync>,
     sink: QdrantSink,
     chunker: std::sync::Arc<dyn ragloom::transform::chunker::Chunker>,
+}
+
+struct PreparedSourceRuntime {
+    source: Box<dyn ragloom::source::Source + Send>,
+    loader: std::sync::Arc<dyn ragloom::doc::DocumentLoader + Send + Sync>,
+}
+
+fn prepare_source_and_loader(
+    cfg: &RunConfig,
+    previously_observed_paths: std::collections::HashSet<String>,
+) -> Result<PreparedSourceRuntime, RagloomError> {
+    match &cfg.source {
+        RunSource::Filesystem { root } => {
+            let source = DirectoryScannerSource::with_previously_observed_paths(
+                root,
+                previously_observed_paths,
+            )
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Io, e)
+                    .with_context("failed to create directory scanner source")
+            })?;
+
+            Ok(PreparedSourceRuntime {
+                source: Box::new(source),
+                loader: std::sync::Arc::new(FsUtf8Loader),
+            })
+        }
+        RunSource::S3 { .. } => Err(RagloomError::from_kind(RagloomErrorKind::Config)
+            .with_context(
+                "s3 source wiring is not available yet; implementation is tracked by issue #108",
+            )),
+    }
 }
 
 async fn prepare_startup(cfg: &RunConfig) -> Result<PreparedStartup, RagloomError> {
@@ -889,12 +1065,14 @@ async fn try_main() -> Result<(), RagloomError> {
         }
     };
 
-    let source =
-        DirectoryScannerSource::with_previously_observed_paths(&cfg.dir, previously_observed_paths)
-            .map_err(|e| {
-                RagloomError::new(RagloomErrorKind::Io, e)
-                    .with_context("failed to create directory scanner source")
-            })?;
+    let PreparedSourceRuntime { source, loader } =
+        match prepare_source_and_loader(&cfg, previously_observed_paths) {
+            Ok(prepared) => prepared,
+            Err(err) => {
+                health_state.mark_startup_failed();
+                return Err(err);
+            }
+        };
 
     let runtime = Runtime::with_shared_wal(source, std::sync::Arc::clone(&wal));
     let summary = IngestionSummary::default();
@@ -904,14 +1082,10 @@ async fn try_main() -> Result<(), RagloomError> {
         .start();
     let mut shutdown_for_monitor = shutdown.clone();
 
-    let pipeline = PipelineExecutor::with_chunker(
-        embedding,
-        std::sync::Arc::new(sink),
-        std::sync::Arc::new(FsUtf8Loader),
-        chunker,
-    )
-    .with_summary(summary.clone())
-    .with_metrics(metrics.clone());
+    let pipeline =
+        PipelineExecutor::with_chunker(embedding, std::sync::Arc::new(sink), loader, chunker)
+            .with_summary(summary.clone())
+            .with_metrics(metrics.clone());
 
     let executor = AckingExecutor {
         inner: pipeline,
@@ -980,6 +1154,12 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use crate::test_support::{TestHttpResponse, spawn_scripted_http_server};
+
+    fn filesystem_source(root: &str) -> RunSource {
+        RunSource::Filesystem {
+            root: root.to_string(),
+        }
+    }
 
     struct RequestCounterServer {
         stop: Sender<()>,
@@ -1079,7 +1259,7 @@ mod tests {
         assert_eq!(
             cfg,
             ParsedCommand::Run(Box::new(RunConfig {
-                dir: "/tmp/docs".to_string(),
+                source: filesystem_source("/tmp/docs"),
                 embed_backend: EmbedBackend::Http {
                     url: "http://embed".to_string(),
                     model: "default".to_string(),
@@ -1214,6 +1394,228 @@ mod tests {
             };
             assert_eq!(cfg.health_addr.as_deref(), Some("127.0.0.1:0"));
         }
+    }
+
+    #[test]
+    fn parse_args_accepts_explicit_filesystem_source_kind() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--source-kind".to_string(),
+            "filesystem".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.source, filesystem_source("/tmp/docs"));
+    }
+
+    #[test]
+    fn parse_args_rejects_s3_flags_without_s3_source_kind() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--s3-bucket".to_string(),
+            "docs-bucket".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("expected config error");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("--s3-bucket"));
+    }
+
+    #[test]
+    fn parse_args_loads_s3_source_from_yaml_config() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  kind: s3
+  bucket: "docs-bucket"
+  prefix: "knowledge/"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(
+            cfg.source,
+            RunSource::S3 {
+                bucket: "docs-bucket".to_string(),
+                prefix: Some("knowledge/".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_allows_cli_dir_to_complete_filesystem_source_config() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  kind: filesystem
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--dir".to_string(),
+            "/tmp/from-cli".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(cfg.source, filesystem_source("/tmp/from-cli"));
+    }
+
+    #[test]
+    fn parse_args_allows_cli_bucket_to_complete_s3_source_config() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  kind: s3
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--s3-bucket".to_string(),
+            "docs-bucket".to_string(),
+        ];
+
+        let cfg = parse_args(&args).expect("config");
+        let ParsedCommand::Run(cfg) = cfg else {
+            panic!("expected run config");
+        };
+        assert_eq!(
+            cfg.source,
+            RunSource::S3 {
+                bucket: "docs-bucket".to_string(),
+                prefix: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_dir_with_s3_source_kind() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--source-kind".to_string(),
+            "s3".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--s3-bucket".to_string(),
+            "docs-bucket".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("expected config error");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("--dir"));
+    }
+
+    #[test]
+    fn parse_args_rejects_invalid_filesystem_source_shape_without_override() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+source:
+  kind: filesystem
+  bucket: "docs-bucket"
+embed:
+  endpoint: "http://embed-from-config"
+sink:
+  qdrant_url: "http://qdrant-from-config"
+  collection: "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--dir".to_string(),
+            "/tmp/from-cli".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("should fail source validation");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("source.bucket"));
     }
 
     #[test]
@@ -1543,7 +1945,7 @@ mod tests {
     #[test]
     fn resolve_collection_vector_size_prefers_explicit_override() {
         let cfg = RunConfig {
-            dir: "/tmp/docs".to_string(),
+            source: filesystem_source("/tmp/docs"),
             embed_backend: EmbedBackend::OpenAi {
                 endpoint: "https://api.openai.com/v1/embeddings".to_string(),
                 api_key: "test-key".to_string(),
@@ -1579,7 +1981,7 @@ mod tests {
     #[test]
     fn resolve_collection_vector_size_infers_known_openai_model_size() {
         let mut cfg = RunConfig {
-            dir: "/tmp/docs".to_string(),
+            source: filesystem_source("/tmp/docs"),
             embed_backend: EmbedBackend::OpenAi {
                 endpoint: "https://api.openai.com/v1/embeddings".to_string(),
                 api_key: "test-key".to_string(),
@@ -1623,7 +2025,7 @@ mod tests {
     #[test]
     fn resolve_collection_vector_size_rejects_http_backend_without_override() {
         let cfg = RunConfig {
-            dir: "/tmp/docs".to_string(),
+            source: filesystem_source("/tmp/docs"),
             embed_backend: EmbedBackend::Http {
                 url: "http://embed".to_string(),
                 model: "default".to_string(),
@@ -1664,7 +2066,7 @@ mod tests {
     async fn prepare_startup_skips_bootstrap_when_embedding_client_construction_fails() {
         let (base_url, server) = spawn_qdrant_request_counter_server();
         let cfg = RunConfig {
-            dir: ".".to_string(),
+            source: filesystem_source("."),
             embed_backend: EmbedBackend::OpenAi {
                 endpoint: "https://api.openai.com/v1/embeddings".to_string(),
                 api_key: "bad\nkey".to_string(),
@@ -1718,7 +2120,7 @@ mod tests {
         let base_url = server.base_url();
 
         let cfg = RunConfig {
-            dir: "/tmp/docs".to_string(),
+            source: filesystem_source("/tmp/docs"),
             embed_backend: EmbedBackend::OpenAi {
                 endpoint: "https://api.openai.com/v1/embeddings".to_string(),
                 api_key: "test-key".to_string(),
@@ -1774,7 +2176,7 @@ mod tests {
         let base_url = server.base_url();
 
         let cfg = RunConfig {
-            dir: "/tmp/docs".to_string(),
+            source: filesystem_source("/tmp/docs"),
             embed_backend: EmbedBackend::Http {
                 url: "http://embed".to_string(),
                 model: "default".to_string(),
@@ -1823,7 +2225,7 @@ mod tests {
     #[tokio::test]
     async fn bootstrap_collection_if_needed_surfaces_unknown_openai_model_with_config_context() {
         let cfg = RunConfig {
-            dir: "/tmp/docs".to_string(),
+            source: filesystem_source("/tmp/docs"),
             embed_backend: EmbedBackend::OpenAi {
                 endpoint: "https://api.openai.com/v1/embeddings".to_string(),
                 api_key: "test-key".to_string(),
@@ -1939,7 +2341,7 @@ health:
         let ParsedCommand::Run(cfg) = cfg else {
             panic!("expected run config");
         };
-        assert_eq!(cfg.dir, "/tmp/from-config");
+        assert_eq!(cfg.source, filesystem_source("/tmp/from-config"));
         assert_eq!(cfg.qdrant_url, "http://qdrant-from-config");
         assert_eq!(cfg.collection, "from-config");
         assert_eq!(cfg.state_path, ".state/from-config.ndjson");
@@ -2020,7 +2422,10 @@ health:
 
         let err = parse_args(&args).expect_err("should fail validation");
         assert_eq!(err.kind, RagloomErrorKind::Config);
-        assert!(err.to_string().contains("invalid config file"));
+        assert!(
+            err.to_string()
+                .contains("--health-addr or health.addr is empty")
+        );
     }
 
     #[test]
@@ -2073,7 +2478,7 @@ sink:
 
         let err = parse_args(&args).expect_err("should fail validation");
         assert_eq!(err.kind, RagloomErrorKind::Config);
-        assert!(err.to_string().contains("invalid config file"));
+        assert!(err.to_string().contains("--dir or source.root is empty"));
     }
 
     #[test]
@@ -2103,5 +2508,47 @@ sink:
         let err = parse_args(&args).expect_err("should fail parse");
         assert_eq!(err.kind, RagloomErrorKind::Config);
         assert!(err.to_string().contains("failed to parse config file"));
+    }
+
+    #[test]
+    fn prepare_source_and_loader_rejects_s3_until_issue_108() {
+        let cfg = RunConfig {
+            source: RunSource::S3 {
+                bucket: "docs-bucket".to_string(),
+                prefix: Some("knowledge/".to_string()),
+            },
+            embed_backend: EmbedBackend::Http {
+                url: "http://embed".to_string(),
+                model: "default".to_string(),
+            },
+            qdrant_url: "http://qdrant".to_string(),
+            collection: "docs".to_string(),
+            state_path: DEFAULT_STATE_PATH.to_string(),
+            health_addr: None,
+            create_collection_if_missing: false,
+            collection_vector_size: None,
+            chunker_strategy: "recursive".to_string(),
+            size_metric: "chars".to_string(),
+            size_max: 2000,
+            size_min: 0,
+            size_overlap: 0,
+            tokenizer: "tiktoken-cl100k".to_string(),
+            chunker_mode: "router".to_string(),
+            chunker_single: None,
+            enable_semantic: false,
+            semantic_provider: "adapter".to_string(),
+            semantic_percentile: 95,
+            retry_max_attempts: 3,
+            retry_max_queued: 128,
+            retry_initial_backoff_ms: 100,
+            retry_max_backoff_ms: 2_000,
+        };
+
+        let err = match prepare_source_and_loader(&cfg, std::collections::HashSet::new()) {
+            Ok(_) => panic!("expected s3 placeholder error"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(err.to_string().contains("issue #108"));
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -45,3 +45,9 @@ pub enum SourceEvent {
 pub trait Source {
     fn poll(&mut self) -> Vec<SourceEvent>;
 }
+
+impl<T: Source + ?Sized> Source for Box<T> {
+    fn poll(&mut self) -> Vec<SourceEvent> {
+        (**self).poll()
+    }
+}


### PR DESCRIPTION
## Summary

Generalize Ragloom's source configuration and runtime wiring so the binary can reason about filesystem and future S3 source shapes without pushing source-specific logic into lower layers.

## Related issue

Refs #106

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- Added kind-aware source config with validation for `filesystem` and reserved `s3` source shapes while preserving legacy `source.root` compatibility.
- Reworked CLI parsing and runtime wiring around `RunSource`, including compatibility for `--dir` and a dedicated source/loader composition point in `main.rs`.
- Updated README and added regression tests covering CLI/config merge behavior, source-kind validation, and the current S3 placeholder boundary.

## How to test

1. Run `cargo qa` from the repository root.
2. Verify filesystem config still works with either `--dir` or YAML `source.root`.
3. Verify S3-shaped config parses and validates, but runtime startup still fails fast with the tracked `#108` placeholder.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This PR intentionally stops short of implementing a runnable S3 polling source. It establishes the minimal config and wiring seams needed for `#108` and keeps current filesystem behavior compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--source-kind` CLI flag to select between filesystem and S3 sources.
  * Updated configuration schema to support polymorphic source selection.

* **Documentation**
  * Clarified filesystem source configuration as canonical format.
  * Documented S3 source configuration shape (not yet available in current release).
  * Expanded configuration notes detailing supported fields by source type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->