### PR TITLE
fix(source): define s3 identity semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ The config model now reserves a first-class `s3` source shape, but actual S3
 polling support is still tracked separately and is not yet runnable in the
 current release line.
 
+When S3 runtime ingestion lands, Ragloom will treat object keys as opaque. The
+canonical S3 document identity will be `s3://{bucket}/{exact-key}` without
+normalizing duplicate slashes, dot segments, or the configured prefix.
+
 - traversal is deterministic because directory entries are processed in sorted path order
 - hidden files and hidden directories are treated like any other path
 - symbolic links are not followed
@@ -381,9 +385,20 @@ Ragloom generates deterministic point IDs from:
 - chunk index
 - chunker strategy fingerprint
 
+For the current filesystem source, the canonical document identity starts from
+the local canonical path and is then rendered into a stable `file://` URI for
+sink payloads and `doc_id` derivation. For the reserved S3 source shape, the
+canonical document identity is defined directly as `s3://{bucket}/{exact-key}`.
+
 This makes reruns safe.
 
 The same file and same chunking config produce the same point IDs. Changing chunking parameters creates a new ID space, so old chunks are not silently overwritten by new content.
+
+File-version identity is source-specific metadata hashed together with that
+canonical document identity. Today the filesystem source uses path, size, and
+mtime. The S3 design uses canonical S3 identity, object size, last-modified
+time, and normalized ETag so the planner and WAL can preserve deterministic
+replay semantics without requiring a per-object `HEAD` request.
 
 ## Chunking
 
@@ -445,6 +460,16 @@ This is the part of Ragloom that makes inspection easier: you can look at a poin
 Ragloom tracks files it has previously observed under the configured source root. When a completed scan no longer sees one of those paths, the runtime plans a durable delete work item and the Qdrant sink removes all points with that document's stable `doc_id`.
 
 Delete synchronization is idempotent and replay-safe: rerunning the same delete work is expected to leave Qdrant in the same state. Ragloom does not delete points for files it has never observed, and this is document-level cleanup only; it does not create, drop, or otherwise manage whole collections.
+
+The same delete-sync model is reserved for S3: deletes are inferred only after
+a completed successful listing of the configured bucket and prefix. Missing
+objects from a partial or failed scan must not be treated as deletes.
+
+For S3 object lifecycle semantics, Ragloom treats object identity as path-like:
+
+- overwriting the same key is a new version of the same document when version metadata changes
+- renaming a key is modeled as deleting the old key and ingesting a new document at the new key
+- copying to a new key is modeled as a distinct document even if the content and ETag match
 
 ## Observability
 

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -20,6 +20,8 @@ pub struct FileFingerprint {
     pub canonical_path: String,
     pub size_bytes: u64,
     pub mtime_unix_secs: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
 }
 
 /// Computes a stable 32-byte identifier for a file version.
@@ -33,7 +35,18 @@ pub fn file_version_id(fingerprint: &FileFingerprint) -> [u8; 32] {
     hasher.update(fingerprint.canonical_path.as_bytes());
     hasher.update(&fingerprint.size_bytes.to_le_bytes());
     hasher.update(&fingerprint.mtime_unix_secs.to_le_bytes());
+    if let Some(etag) = normalized_etag(fingerprint.etag.as_deref()) {
+        hasher.update(&[0x1F]);
+        hasher.update(etag.as_bytes());
+    }
     *hasher.finalize().as_bytes()
+}
+
+fn normalized_etag(etag: Option<&str>) -> Option<&str> {
+    etag.map(str::trim)
+        .filter(|etag| !etag.is_empty())
+        .map(|etag| etag.trim_matches('"'))
+        .filter(|etag| !etag.is_empty())
 }
 
 #[cfg(test)]
@@ -46,6 +59,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         assert_eq!(file_version_id(&fingerprint), file_version_id(&fingerprint));
     }
@@ -56,11 +70,13 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         let b = FileFingerprint {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 11,
             mtime_unix_secs: 100,
+            etag: None,
         };
         assert_ne!(file_version_id(&a), file_version_id(&b));
     }
@@ -71,11 +87,13 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         let b = FileFingerprint {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 101,
+            etag: None,
         };
         assert_ne!(file_version_id(&a), file_version_id(&b));
     }
@@ -86,12 +104,48 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         let b = FileFingerprint {
             canonical_path: "/x/b.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         assert_ne!(file_version_id(&a), file_version_id(&b));
+    }
+
+    #[test]
+    fn file_version_id_changes_when_etag_changes() {
+        let a = FileFingerprint {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-a\"".to_string()),
+        };
+        let b = FileFingerprint {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-b\"".to_string()),
+        };
+        assert_ne!(file_version_id(&a), file_version_id(&b));
+    }
+
+    #[test]
+    fn file_version_id_is_stable_across_quoted_etag_forms() {
+        let quoted = FileFingerprint {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-a\"".to_string()),
+        };
+        let unquoted = FileFingerprint {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("etag-a".to_string()),
+        };
+        assert_eq!(file_version_id(&quoted), file_version_id(&unquoted));
     }
 }

--- a/src/pipeline/planner.rs
+++ b/src/pipeline/planner.rs
@@ -116,6 +116,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
             file_version_id: version_id,
         }
@@ -142,6 +143,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -171,6 +173,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -232,6 +235,57 @@ mod tests {
                 },
                 WalRecord::DeleteDocument {
                     canonical_path: "/x/a.txt".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_clears_pending_delete_when_s3_locator_is_rediscovered() {
+        let mut planner = Planner::new();
+        let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+
+        let canonical_path = "s3://docs-bucket/kb/a.md";
+        planner
+            .plan_file_delete(canonical_path, &wal)
+            .expect("first delete");
+
+        let discovered = FileVersionDiscovered {
+            fingerprint: FileFingerprint {
+                canonical_path: canonical_path.to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: Some("\"etag-a\"".to_string()),
+            },
+            file_version_id: crate::ids::file_version_id(&FileFingerprint {
+                canonical_path: canonical_path.to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: Some("\"etag-a\"".to_string()),
+            }),
+        };
+        planner
+            .plan_file_version(&discovered, &wal)
+            .expect("recreated file");
+
+        planner
+            .plan_file_delete(canonical_path, &wal)
+            .expect("second delete");
+
+        let records = wal.try_lock().expect("wal").read_all().expect("read all");
+        assert_eq!(
+            records,
+            vec![
+                WalRecord::DeleteDocument {
+                    canonical_path: canonical_path.to_string()
+                },
+                WalRecord::WorkItemV2 {
+                    fingerprint: discovered.fingerprint
+                },
+                WalRecord::DeleteDocument {
+                    canonical_path: canonical_path.to_string()
                 },
             ]
         );

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -210,6 +210,10 @@ fn uuid_from_path_chunk_strategy(
 }
 
 fn canonical_path_to_file_uri(canonical_path: &str) -> String {
+    if has_uri_scheme(canonical_path) {
+        return canonical_path.to_string();
+    }
+
     // Convert a canonical path into a normalized file:// URI.
     //
     // # Why
@@ -229,6 +233,22 @@ fn canonical_path_to_file_uri(canonical_path: &str) -> String {
 
     // Fallback: treat as already-absolute-ish path.
     format!("file:///{normalized}")
+}
+
+fn has_uri_scheme(value: &str) -> bool {
+    let Some((scheme, _rest)) = value.split_once("://") else {
+        return false;
+    };
+
+    let mut chars = scheme.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+
+    chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
 }
 
 fn doc_id_from_canonical_path(canonical_path_uri: &str) -> String {
@@ -1191,6 +1211,36 @@ mod tests {
     use crate::ids::FileFingerprint;
     use crate::source::{FileVersionDiscovered, SourceEvent};
 
+    #[test]
+    fn canonical_path_to_file_uri_preserves_s3_uri() {
+        assert_eq!(
+            canonical_path_to_file_uri("s3://docs-bucket/kb/a.md"),
+            "s3://docs-bucket/kb/a.md"
+        );
+    }
+
+    #[test]
+    fn canonical_path_to_file_uri_normalizes_local_path_with_scheme_like_segment() {
+        let uri = canonical_path_to_file_uri("/tmp/notes://draft.txt");
+
+        assert!(uri.starts_with("file://"));
+        assert!(uri.ends_with("/tmp/notes://draft.txt"));
+    }
+
+    #[test]
+    fn doc_id_from_canonical_path_uses_preserved_s3_uri() {
+        let canonical_path_uri = canonical_path_to_file_uri("s3://docs-bucket/kb/a.md");
+        let doc_id = doc_id_from_canonical_path(&canonical_path_uri);
+
+        assert_eq!(canonical_path_uri, "s3://docs-bucket/kb/a.md");
+        assert_eq!(
+            doc_id,
+            blake3::hash(b"s3://docs-bucket/kb/a.md")
+                .to_hex()
+                .to_string()
+        );
+    }
+
     #[derive(Debug, Default)]
     struct FakeSource {
         pending: Vec<SourceEvent>,
@@ -1204,6 +1254,7 @@ mod tests {
                         canonical_path: "/x/a.txt".to_string(),
                         size_bytes: 10,
                         mtime_unix_secs: 100,
+                        etag: None,
                     },
                     file_version_id,
                 }));
@@ -1252,6 +1303,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -1274,6 +1326,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -1286,6 +1339,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -1307,6 +1361,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -1339,6 +1394,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -1409,6 +1465,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         {
             let mut guard = wal.lock().await;
@@ -1466,6 +1523,7 @@ mod tests {
                         canonical_path: "/x/a.txt".to_string(),
                         size_bytes: 10,
                         mtime_unix_secs: 100,
+                        etag: None,
                     }]
                 {
                     break;
@@ -1897,6 +1955,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             })
             .await
@@ -1929,6 +1988,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             })
             .await
@@ -1941,6 +2001,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 }
             }),
             "expected SinkAckV2"
@@ -2017,6 +2078,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await
@@ -2031,6 +2093,7 @@ mod tests {
                         canonical_path: "/x/a.txt".to_string(),
                         size_bytes: 10,
                         mtime_unix_secs: 100,
+                        etag: None,
                     },
                 }) {
                     break;
@@ -2069,6 +2132,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await
@@ -2118,6 +2182,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await
@@ -2164,6 +2229,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await
@@ -2205,6 +2271,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await
@@ -2248,6 +2315,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await
@@ -2287,6 +2355,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .await

--- a/src/source/dir_scanner.rs
+++ b/src/source/dir_scanner.rs
@@ -79,6 +79,7 @@ impl DirectoryScannerSource {
                 canonical_path,
                 size_bytes,
                 mtime_unix_secs,
+                etag: None,
             });
         });
         self.tailer.complete_scan(&observed_paths);

--- a/src/source/file_tailer.rs
+++ b/src/source/file_tailer.rs
@@ -16,6 +16,7 @@ pub struct ObservedFileMeta {
     pub canonical_path: String,
     pub size_bytes: u64,
     pub mtime_unix_secs: i64,
+    pub etag: Option<String>,
 }
 
 impl ObservedFileMeta {
@@ -24,6 +25,7 @@ impl ObservedFileMeta {
             canonical_path: self.canonical_path.clone(),
             size_bytes: self.size_bytes,
             mtime_unix_secs: self.mtime_unix_secs,
+            etag: self.etag.clone(),
         }
     }
 }
@@ -123,6 +125,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         });
         assert_eq!(tailer.drain().len(), 1);
 
@@ -130,6 +133,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         });
         assert_eq!(tailer.drain().len(), 0);
     }
@@ -142,6 +146,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         });
         let first = tailer.drain();
         assert_eq!(first.len(), 1);
@@ -150,6 +155,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 101,
+            etag: None,
         });
         let second = tailer.drain();
         assert_eq!(second.len(), 1);
@@ -171,6 +177,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         });
         tailer.drain();
 
@@ -218,6 +225,7 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         });
         assert_eq!(tailer.drain().len(), 1);
 
@@ -225,7 +233,78 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         });
         assert!(tailer.drain().is_empty());
+    }
+
+    #[test]
+    fn s3_etag_change_emits_new_version_event() {
+        let mut tailer = FileTailer::new();
+
+        tailer.observe(ObservedFileMeta {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-a\"".to_string()),
+        });
+        assert_eq!(tailer.drain().len(), 1);
+
+        tailer.observe(ObservedFileMeta {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-b\"".to_string()),
+        });
+        assert_eq!(tailer.drain().len(), 1);
+    }
+
+    #[test]
+    fn s3_rename_behaves_as_delete_plus_new_document() {
+        let mut tailer = FileTailer::new();
+
+        let old_path = "s3://docs-bucket/kb/old.md".to_string();
+        let new_path = "s3://docs-bucket/kb/new.md".to_string();
+
+        tailer.observe(ObservedFileMeta {
+            canonical_path: old_path.clone(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-a\"".to_string()),
+        });
+        tailer.drain();
+
+        let mut observed = HashSet::new();
+        observed.insert(new_path.clone());
+        tailer.observe(ObservedFileMeta {
+            canonical_path: new_path.clone(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-a\"".to_string()),
+        });
+        tailer.complete_scan(&observed);
+
+        assert_eq!(
+            tailer.drain(),
+            vec![
+                SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                    fingerprint: FileFingerprint {
+                        canonical_path: new_path,
+                        size_bytes: 10,
+                        mtime_unix_secs: 100,
+                        etag: Some("\"etag-a\"".to_string()),
+                    },
+                    file_version_id: crate::ids::file_version_id(&FileFingerprint {
+                        canonical_path: "s3://docs-bucket/kb/new.md".to_string(),
+                        size_bytes: 10,
+                        mtime_unix_secs: 100,
+                        etag: Some("\"etag-a\"".to_string()),
+                    }),
+                }),
+                SourceEvent::FileDeleted {
+                    canonical_path: old_path
+                }
+            ]
+        );
     }
 }

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -231,7 +231,7 @@ fn open_wal_append_file(path: &Path) -> Result<File, RagloomError> {
 /// Returns unacked work in original append order.
 pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
     let mut acked_chunks = std::collections::HashSet::<[u8; 32]>::new();
-    let mut acked_files = std::collections::HashSet::<crate::ids::FileFingerprint>::new();
+    let mut acked_files = std::collections::HashSet::<[u8; 32]>::new();
     let mut pending_deletes = std::collections::HashMap::<String, (usize, WalRecord)>::new();
 
     for (idx, record) in records.iter().enumerate() {
@@ -240,7 +240,7 @@ pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
                 acked_chunks.insert(*chunk_id);
             }
             WalRecord::SinkAckV2 { fingerprint } => {
-                acked_files.insert(fingerprint.clone());
+                acked_files.insert(crate::ids::file_version_id(fingerprint));
             }
             WalRecord::DeleteDocument { canonical_path } => {
                 pending_deletes.insert(canonical_path.clone(), (idx, record.clone()));
@@ -259,7 +259,9 @@ pub fn unacked_work_items(records: &[WalRecord]) -> Vec<WalRecord> {
             WalRecord::WorkItem { chunk_id } if !acked_chunks.contains(chunk_id) => {
                 Some((idx, record.clone()))
             }
-            WalRecord::WorkItemV2 { fingerprint } if !acked_files.contains(fingerprint) => {
+            WalRecord::WorkItemV2 { fingerprint }
+                if !acked_files.contains(&crate::ids::file_version_id(fingerprint)) =>
+            {
                 Some((idx, record.clone()))
             }
             _ => None,
@@ -349,6 +351,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .expect("append work item v2");
@@ -362,6 +365,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             }
         );
@@ -378,6 +382,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .expect("append work");
@@ -386,6 +391,7 @@ mod tests {
                 canonical_path: "/x/a.txt".to_string(),
                 size_bytes: 10,
                 mtime_unix_secs: 100,
+                etag: None,
             },
         })
         .expect("append ack");
@@ -399,6 +405,7 @@ mod tests {
                         canonical_path: "/x/a.txt".to_string(),
                         size_bytes: 10,
                         mtime_unix_secs: 100,
+                        etag: None,
                     },
                 },
                 WalRecord::SinkAckV2 {
@@ -406,6 +413,7 @@ mod tests {
                         canonical_path: "/x/a.txt".to_string(),
                         size_bytes: 10,
                         mtime_unix_secs: 100,
+                        etag: None,
                     },
                 },
             ]
@@ -418,11 +426,13 @@ mod tests {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
         let b = FileFingerprint {
             canonical_path: "/x/b.txt".to_string(),
             size_bytes: 20,
             mtime_unix_secs: 200,
+            etag: None,
         };
 
         let records = vec![
@@ -441,6 +451,31 @@ mod tests {
             unacked_work_items(&records),
             vec![WalRecord::WorkItemV2 { fingerprint: b }]
         );
+    }
+
+    #[test]
+    fn unacked_work_items_treats_quoted_and_unquoted_etag_as_same_version() {
+        let work = FileFingerprint {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("\"etag-a\"".to_string()),
+        };
+        let ack = FileFingerprint {
+            canonical_path: "s3://docs-bucket/kb/a.md".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: Some("etag-a".to_string()),
+        };
+
+        let records = vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: work.clone(),
+            },
+            WalRecord::SinkAckV2 { fingerprint: ack },
+        ];
+
+        assert!(unacked_work_items(&records).is_empty());
     }
 
     #[test]
@@ -495,6 +530,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             },
             WalRecord::SinkAckV2 {
@@ -502,6 +538,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             },
         ];
@@ -520,6 +557,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             },
             WalRecord::DeleteDocument {
@@ -541,6 +579,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             },
             WalRecord::DeleteAck {
@@ -551,6 +590,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 11,
                     mtime_unix_secs: 101,
+                    etag: None,
                 },
             },
         ];
@@ -569,6 +609,7 @@ mod tests {
                     canonical_path: "/x/a.txt".to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
             },
             WalRecord::DeleteDocument {
@@ -577,6 +618,23 @@ mod tests {
         ];
 
         assert!(known_live_document_paths(&records).is_empty());
+    }
+
+    #[test]
+    fn known_live_document_paths_tracks_s3_locator_without_normalizing_key() {
+        let records = vec![WalRecord::WorkItemV2 {
+            fingerprint: FileFingerprint {
+                canonical_path: "s3://docs-bucket/kb//a.md".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: Some("\"etag-a\"".to_string()),
+            },
+        }];
+
+        assert_eq!(
+            known_live_document_paths(&records),
+            std::collections::HashSet::from(["s3://docs-bucket/kb//a.md".to_string()])
+        );
     }
 
     #[test]

--- a/tests/canonical_path_file_uri.rs
+++ b/tests/canonical_path_file_uri.rs
@@ -53,6 +53,7 @@ async fn payload_canonical_path_is_file_uri() {
         canonical_path: "D:/code\\repo\\a.txt".to_string(),
         size_bytes: 10,
         mtime_unix_secs: 100,
+        etag: None,
     };
 
     let points = executor

--- a/tests/pipeline_chunk_payload.rs
+++ b/tests/pipeline_chunk_payload.rs
@@ -54,6 +54,7 @@ async fn points_payload_includes_chunk_metadata_and_optional_text() {
             canonical_path: "/x/a.txt".to_string(),
             size_bytes: 10,
             mtime_unix_secs: 100,
+            etag: None,
         };
 
         let points = executor

--- a/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
+++ b/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
@@ -20,6 +20,7 @@ impl FakeSource {
                     canonical_path: canonical_path.to_string(),
                     size_bytes: 10,
                     mtime_unix_secs: 100,
+                    etag: None,
                 },
                 file_version_id,
             }));

--- a/tests/pipeline_point_id_strategy.rs
+++ b/tests/pipeline_point_id_strategy.rs
@@ -66,6 +66,7 @@ async fn two_strategies_yield_distinct_point_ids() {
         canonical_path: "/tmp/x.txt".into(),
         size_bytes: 10,
         mtime_unix_secs: 1,
+        etag: None,
     };
     let text = "hello world. good morning. nice weather. lots of content here. \
                 and more prose. even more. still more. and yet more.";

--- a/tests/pipeline_router_dispatch.rs
+++ b/tests/pipeline_router_dispatch.rs
@@ -70,6 +70,7 @@ async fn txt_gets_recursive_fingerprint() {
         canonical_path: "/tmp/notes.txt".into(),
         size_bytes: 1,
         mtime_unix_secs: 1,
+        etag: None,
     };
     let points = exec()
         .build_points_from_text(&fp, "plain text content here\n")
@@ -85,6 +86,7 @@ async fn md_gets_markdown_fingerprint() {
         canonical_path: "/tmp/notes.md".into(),
         size_bytes: 1,
         mtime_unix_secs: 1,
+        etag: None,
     };
     let points = exec()
         .build_points_from_text(&fp, "# Title\n\nSome body.\n")
@@ -100,6 +102,7 @@ async fn rs_gets_code_rust_fingerprint() {
         canonical_path: "/tmp/x.rs".into(),
         size_bytes: 1,
         mtime_unix_secs: 1,
+        etag: None,
     };
     let points = exec()
         .build_points_from_text(&fp, "fn a(){}\nfn b(){}\n")

--- a/tests/pipeline_router_fingerprint_distinct.rs
+++ b/tests/pipeline_router_fingerprint_distinct.rs
@@ -64,11 +64,13 @@ async fn md_and_rs_produce_disjoint_point_ids_from_same_text() {
         canonical_path: "/tmp/n.md".into(),
         size_bytes: 1,
         mtime_unix_secs: 1,
+        etag: None,
     };
     let rs_fp = FileFingerprint {
         canonical_path: "/tmp/n.rs".into(),
         size_bytes: 1,
         mtime_unix_secs: 1,
+        etag: None,
     };
 
     let md_pts = exec(Arc::clone(&router))

--- a/tests/pipeline_semantic_flag.rs
+++ b/tests/pipeline_semantic_flag.rs
@@ -77,6 +77,7 @@ async fn default_and_semantic_routers_produce_disjoint_ids_for_md() {
         canonical_path: "/tmp/n.md".into(),
         size_bytes: 1,
         mtime_unix_secs: 1,
+        etag: None,
     };
 
     let default: Arc<dyn Chunker> = Arc::new(default_router(cfg()).unwrap());


### PR DESCRIPTION
## Summary

Define the deterministic identity semantics reserved for the future S3 source without implementing the S3 runtime path from #108.

## Related issue

Closes #107

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- add optional `etag` support to `FileFingerprint` and include normalized ETag in deterministic file-version identity
- preserve canonical URIs for source locators that already have a real scheme, while keeping filesystem paths normalized to `file://` payloads and `doc_id`s
- document reserved S3 identity, delete-sync, and rename/copy semantics, and add regression tests for tailer/planner/WAL/runtime behavior

## How to test

1. Run `cargo qa`.
2. Run `cargo test source::file_tailer:: --lib` to verify the S3 rename and ETag change semantics.
3. Run `cargo test state::wal:: --lib` to verify quoted/unquoted ETag replay equivalence.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This PR keeps the change scoped to shared identity and replay semantics for the reserved S3 source shape. It does not implement the runnable S3 ingestion path, which remains tracked by #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for S3 canonical document identity and object lifecycle mapping
  * Integrated ETag tracking for enhanced file version detection and change identification
  * Implemented S3 delete synchronization to infer object deletions after bucket listing

* **Documentation**
  * Updated documentation with S3 semantics, canonical identity derivation, and lifecycle mapping rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->