### PR TITLE
feat: implement polling S3 source runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "log",
+ "native-tls",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +199,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "aws-creds"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3b85155d265df828f84e53886ed9e427aed979dd8a39f5b8b2162c77e142d7"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -251,7 +292,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -436,6 +486,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +565,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -581,6 +660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "daggrs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -681,6 +771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +811,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -982,6 +1092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1192,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1105,6 +1231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,10 +1258,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1628,6 +1778,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1797,12 @@ dependencies = [
  "cfg-if",
  "rayon",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -1938,6 +2105,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,12 +2469,14 @@ dependencies = [
  "proptest",
  "pulldown-cmark",
  "reqwest",
+ "rust-s3",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror",
  "tiktoken-rs",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2539,6 +2728,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeedb13abdaa7e48d391de05b0569b37fa0a7a64a668dff6ffb2141ad0c2527e"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "aws-creds",
+ "aws-region",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,6 +2983,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -3023,6 +3263,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3418,6 +3667,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,11 @@ serde = { version = "1", features = ["derive"] }
 blake3 = "1"
 async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+s3 = { package = "rust-s3", version = "0.37.2", default-features = false, features = ["sync-native-tls", "fail-on-err"] }
 serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
+time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync", "fs", "signal", "net", "io-util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/README.md
+++ b/README.md
@@ -236,13 +236,14 @@ ragloom --config ./ragloom.yaml --embed-backend http --embed-model default
 
 - `source.kind: filesystem` plus `source.root` is the canonical filesystem config shape
 - legacy filesystem config that only sets `source.root` remains supported for compatibility
-- the config model reserves `source.kind: s3` plus `source.bucket` and optional `source.prefix`, but that source kind is not runnable in the current release line
+- `source.kind: s3` plus `source.bucket` and optional `source.prefix` configures polling S3 ingestion
 - `--config` can provide `source.kind`, `source.root`, `source.bucket`, `source.prefix`, `embed.endpoint`, `sink.qdrant_url`, and `sink.collection`
 - `--config` can also provide `state.path`; the CLI flag is `--state-path`
 - `--config` can provide `retry.max_attempts`, `retry.max_queued`, `retry.initial_backoff_ms`, and `retry.max_backoff_ms`
 - `--config` can provide `health.addr`; the CLI flag is `--health-addr`
 - `--dir` remains the filesystem CLI shorthand; `--source-kind filesystem --dir ./docs` is equivalent to filesystem config
-- `--s3-bucket` and `--s3-prefix` participate in source-shape validation and require `--source-kind s3`, but S3 runtime ingestion is still not available
+- `--s3-bucket` and `--s3-prefix` require `--source-kind s3`
+- S3 runtime auth and region come from the process environment; set `AWS_REGION` or `AWS_DEFAULT_REGION` plus your normal AWS credential chain inputs
 - backend-specific auth still comes from CLI flags, such as `--openai-api-key`
 - chunker settings are currently configured by CLI flags, not by YAML
 - flags support both `--flag value` and `--flag=value`
@@ -273,14 +274,12 @@ jitter-free so tests and local runs remain reproducible.
 
 ### Source scanning behavior
 
-The current built-in runtime source is the filesystem source. It walks the
-configured root recursively and ingests regular files it can stat.
+Ragloom ships with two polling source shapes:
 
-The config model now reserves a first-class `s3` source shape, but actual S3
-polling support is still tracked separately and is not yet runnable in the
-current release line.
+- filesystem: walks the configured root recursively and ingests regular files it can stat
+- s3: lists objects under the configured bucket and optional prefix, then ingests them through the same planner/runtime flow
 
-When S3 runtime ingestion lands, Ragloom will treat object keys as opaque. The
+For S3 runtime ingestion, Ragloom treats object keys as opaque. The
 canonical S3 document identity will be `s3://{bucket}/{exact-key}` without
 normalizing duplicate slashes, dot segments, or the configured prefix.
 
@@ -685,7 +684,7 @@ Do not share command output if it includes credentials or other sensitive respon
 
 ## Current limitations
 
-- only local filesystem input
+- only local filesystem and polling S3 input
 - only Qdrant as a built-in sink
 - only UTF-8 file loading
 - no general collection lifecycle management beyond optional first-run bootstrap

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -79,7 +79,7 @@ Release after the supported Linux and Windows assets have already published.
 
 Core support boundary maintainers are hardening for `v0.3` release-readiness:
 
-- local filesystem ingestion under one configured directory
+- local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix
 - UTF-8 text, Markdown, and source code loading
 - recursive, Markdown-aware, and code-aware chunking
 - OpenAI and generic HTTP embedding backends

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,12 @@ allow = [
     "Unicode-3.0",
     "ISC",
 ]
+# rust-s3 currently pulls these transitively for sync HTTP transport and aws-creds.
+# Keep the exception scoped to the exact crates instead of globally allowing the licenses.
+exceptions = [
+    { crate = "attohttpc", allow = ["MPL-2.0"] },
+    { crate = "tiny-keccak", allow = ["CC0-1.0"] },
+]
 confidence-threshold = 0.8
 
 [bans]

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -4,6 +4,9 @@ use async_trait::async_trait;
 
 use crate::{RagloomError, RagloomErrorKind};
 
+pub mod s3;
+pub use s3::S3Utf8Loader;
+
 /// Loads document bytes/text from a backing store.
 ///
 /// # Why

--- a/src/doc/s3.rs
+++ b/src/doc/s3.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::doc::DocumentLoader;
+use crate::s3::{S3Client, parse_s3_uri};
+use crate::{RagloomError, RagloomErrorKind};
+
+#[derive(Debug, Clone)]
+pub struct S3Utf8Loader {
+    client: Arc<dyn S3Client>,
+}
+
+impl S3Utf8Loader {
+    pub fn new(client: Arc<dyn S3Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl DocumentLoader for S3Utf8Loader {
+    async fn load_utf8(&self, path: &str) -> Result<String, RagloomError> {
+        let location = parse_s3_uri(path)?;
+        if location.bucket != self.client.bucket_name() {
+            return Err(
+                RagloomError::from_kind(RagloomErrorKind::InvalidInput).with_context(format!(
+                    "S3 canonical path bucket {} does not match configured bucket {}",
+                    location.bucket,
+                    self.client.bucket_name()
+                )),
+            );
+        }
+        let client = Arc::clone(&self.client);
+        let key = location.key.to_string();
+        let bytes = tokio::task::spawn_blocking(move || client.get_object(&key))
+            .await
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Internal, e)
+                    .with_context("failed to join S3 object read task")
+            })?
+            .map_err(|e| RagloomError::new(e.kind, e).with_context("failed to read utf-8 file"))?;
+
+        String::from_utf8(bytes).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::InvalidInput, e)
+                .with_context("failed to read utf-8 file")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::s3::S3ObjectMeta;
+
+    #[derive(Debug)]
+    struct FakeS3Client {
+        bytes: Vec<u8>,
+    }
+
+    impl S3Client for FakeS3Client {
+        fn bucket_name(&self) -> &str {
+            "docs-bucket"
+        }
+
+        fn list_objects(&self, _prefix: Option<&str>) -> Result<Vec<S3ObjectMeta>, RagloomError> {
+            unreachable!("source only")
+        }
+
+        fn get_object(&self, _key: &str) -> Result<Vec<u8>, RagloomError> {
+            Ok(self.bytes.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_non_s3_canonical_path() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: b"hello".to_vec(),
+        }));
+
+        let err = loader
+            .load_utf8("/tmp/hello.txt")
+            .await
+            .expect_err("expected invalid input");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn reads_utf8_text_from_s3() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: b"hello from s3".to_vec(),
+        }));
+
+        let text = loader
+            .load_utf8("s3://docs-bucket/kb/hello.txt")
+            .await
+            .expect("load text");
+
+        assert_eq!(text, "hello from s3");
+    }
+
+    #[tokio::test]
+    async fn rejects_bucket_mismatch() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: b"hello from s3".to_vec(),
+        }));
+
+        let err = loader
+            .load_utf8("s3://other-bucket/kb/hello.txt")
+            .await
+            .expect_err("expected invalid input");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(err.to_string().contains("does not match configured bucket"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod state;
 pub mod transform;
 
 pub mod observability;
+pub mod s3;
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use ragloom::config::{DEFAULT_STATE_PATH, PipelineConfig, SourceKind as ConfigSourceKind};
-use ragloom::doc::FsUtf8Loader;
+use ragloom::doc::{FsUtf8Loader, S3Utf8Loader};
 use ragloom::embed::http_client::{HttpEmbeddingClient, HttpEmbeddingConfig};
 use ragloom::error::{RagloomError, RagloomErrorKind};
 use ragloom::observability::health::{HealthServer, HealthState};
@@ -17,8 +17,10 @@ use ragloom::pipeline::runtime::{
     AckingExecutor, AsyncRuntime, IngestionSummary, PipelineExecutor, RetryPolicy, Runtime,
     RuntimeExitReason, run_worker_with_retry_and_metrics,
 };
+use ragloom::s3::{RustS3Client, S3Client};
 use ragloom::sink::qdrant::{QdrantConfig, QdrantSink};
 use ragloom::source::dir_scanner::DirectoryScannerSource;
+use ragloom::source::s3_scanner::S3PollingSource;
 
 #[cfg(test)]
 mod test_support;
@@ -796,6 +798,14 @@ fn prepare_source_and_loader(
     cfg: &RunConfig,
     previously_observed_paths: std::collections::HashSet<String>,
 ) -> Result<PreparedSourceRuntime, RagloomError> {
+    prepare_source_and_loader_with_s3_client(cfg, previously_observed_paths, None)
+}
+
+fn prepare_source_and_loader_with_s3_client(
+    cfg: &RunConfig,
+    previously_observed_paths: std::collections::HashSet<String>,
+    s3_client: Option<std::sync::Arc<dyn S3Client>>,
+) -> Result<PreparedSourceRuntime, RagloomError> {
     match &cfg.source {
         RunSource::Filesystem { root } => {
             let source = DirectoryScannerSource::with_previously_observed_paths(
@@ -812,10 +822,26 @@ fn prepare_source_and_loader(
                 loader: std::sync::Arc::new(FsUtf8Loader),
             })
         }
-        RunSource::S3 { .. } => Err(RagloomError::from_kind(RagloomErrorKind::Config)
-            .with_context(
-                "s3 source wiring is not available yet; implementation is tracked by issue #108",
-            )),
+        RunSource::S3 { bucket, prefix } => {
+            let client = match s3_client {
+                Some(client) => client,
+                None => std::sync::Arc::new(RustS3Client::from_default_env(bucket)?),
+            };
+            let source = S3PollingSource::with_previously_observed_paths(
+                bucket.clone(),
+                prefix.clone(),
+                std::sync::Arc::clone(&client),
+                previously_observed_paths,
+            )
+            .map_err(|e| {
+                RagloomError::new(e.kind, e).with_context("failed to create S3 polling source")
+            })?;
+
+            Ok(PreparedSourceRuntime {
+                source: Box::new(source),
+                loader: std::sync::Arc::new(S3Utf8Loader::new(client)),
+            })
+        }
     }
 }
 
@@ -2664,7 +2690,27 @@ sink:
     }
 
     #[test]
-    fn prepare_source_and_loader_rejects_s3_until_issue_108() {
+    fn prepare_source_and_loader_builds_s3_source_and_loader() {
+        #[derive(Debug)]
+        struct FakeS3Client;
+
+        impl ragloom::s3::S3Client for FakeS3Client {
+            fn bucket_name(&self) -> &str {
+                "docs-bucket"
+            }
+
+            fn list_objects(
+                &self,
+                _prefix: Option<&str>,
+            ) -> Result<Vec<ragloom::s3::S3ObjectMeta>, RagloomError> {
+                Ok(Vec::new())
+            }
+
+            fn get_object(&self, key: &str) -> Result<Vec<u8>, RagloomError> {
+                Ok(format!("loaded {key}").into_bytes())
+            }
+        }
+
         let cfg = RunConfig {
             source: RunSource::S3 {
                 bucket: "docs-bucket".to_string(),
@@ -2697,11 +2743,22 @@ sink:
             retry_max_backoff_ms: 2_000,
         };
 
-        let err = match prepare_source_and_loader(&cfg, std::collections::HashSet::new()) {
-            Ok(_) => panic!("expected s3 placeholder error"),
-            Err(err) => err,
-        };
-        assert_eq!(err.kind, RagloomErrorKind::Config);
-        assert!(err.to_string().contains("issue #108"));
+        let mut prepared = prepare_source_and_loader_with_s3_client(
+            &cfg,
+            std::collections::HashSet::new(),
+            Some(std::sync::Arc::new(FakeS3Client)),
+        )
+        .expect("prepare S3 source");
+
+        assert!(prepared.source.poll().is_empty());
+        let text = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(
+                prepared
+                    .loader
+                    .load_utf8("s3://docs-bucket/knowledge/hello.txt"),
+            )
+            .expect("load text");
+        assert_eq!(text, "loaded knowledge/hello.txt");
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,0 +1,163 @@
+use crate::{RagloomError, RagloomErrorKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3ObjectMeta {
+    pub key: String,
+    pub size_bytes: u64,
+    pub mtime_unix_secs: i64,
+    pub etag: Option<String>,
+}
+
+pub trait S3Client: Send + Sync + std::fmt::Debug {
+    fn bucket_name(&self) -> &str;
+    fn list_objects(&self, prefix: Option<&str>) -> Result<Vec<S3ObjectMeta>, RagloomError>;
+    fn get_object(&self, key: &str) -> Result<Vec<u8>, RagloomError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct S3Location<'a> {
+    pub bucket: &'a str,
+    pub key: &'a str,
+}
+
+pub fn parse_s3_uri(uri: &str) -> Result<S3Location<'_>, RagloomError> {
+    let Some(rest) = uri.strip_prefix("s3://") else {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+            .with_context("expected s3://bucket/key canonical path"));
+    };
+    let Some((bucket, key)) = rest.split_once('/') else {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+            .with_context("expected s3://bucket/key canonical path"));
+    };
+    if bucket.trim().is_empty() || key.is_empty() {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+            .with_context("expected s3://bucket/key canonical path"));
+    }
+    Ok(S3Location { bucket, key })
+}
+
+pub fn canonical_s3_path(bucket: &str, key: &str) -> String {
+    format!("s3://{bucket}/{key}")
+}
+
+#[derive(Debug, Clone)]
+pub struct RustS3Client {
+    bucket_name: String,
+    bucket: Box<s3::Bucket>,
+}
+
+impl RustS3Client {
+    pub fn from_default_env(bucket_name: &str) -> Result<Self, RagloomError> {
+        let region = resolve_region_from_env()?;
+        let credentials = s3::creds::Credentials::default().map_err(|e| {
+            RagloomError::new(RagloomErrorKind::Config, e)
+                .with_context("failed to load S3 credentials from the default environment chain")
+        })?;
+        let bucket = s3::Bucket::new(bucket_name, region, credentials).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::Config, e).with_context(format!(
+                "failed to configure S3 bucket client for {bucket_name}"
+            ))
+        })?;
+        Ok(Self {
+            bucket_name: bucket_name.to_string(),
+            bucket,
+        })
+    }
+}
+
+impl S3Client for RustS3Client {
+    fn bucket_name(&self) -> &str {
+        &self.bucket_name
+    }
+
+    fn list_objects(&self, prefix: Option<&str>) -> Result<Vec<S3ObjectMeta>, RagloomError> {
+        let pages = self
+            .bucket
+            .list(prefix.unwrap_or_default().to_string(), None)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Io, e).with_context(format!(
+                    "failed to list S3 objects in bucket {}",
+                    self.bucket_name
+                ))
+            })?;
+        let mut objects = Vec::new();
+
+        for page in pages {
+            for object in page.contents {
+                objects.push(S3ObjectMeta {
+                    key: object.key,
+                    size_bytes: object.size,
+                    mtime_unix_secs: parse_last_modified(&object.last_modified)?,
+                    etag: object.e_tag,
+                });
+            }
+        }
+
+        Ok(objects)
+    }
+
+    fn get_object(&self, key: &str) -> Result<Vec<u8>, RagloomError> {
+        let response = self.bucket.get_object(key).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::Io, e).with_context(format!(
+                "failed to get S3 object s3://{}/{key}",
+                self.bucket_name
+            ))
+        })?;
+        let status = response.status_code();
+        if !(200..300).contains(&status) {
+            return Err(
+                RagloomError::from_kind(RagloomErrorKind::Io).with_context(format!(
+                    "failed to get S3 object s3://{}/{key}: status {status}",
+                    self.bucket_name
+                )),
+            );
+        }
+        Ok(response.into_bytes().to_vec())
+    }
+}
+
+fn resolve_region_from_env() -> Result<s3::Region, RagloomError> {
+    let region = std::env::var("AWS_REGION")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("AWS_DEFAULT_REGION")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .ok_or_else(|| {
+            RagloomError::from_kind(RagloomErrorKind::Config)
+                .with_context("missing AWS region; set AWS_REGION or AWS_DEFAULT_REGION")
+        })?;
+    region.parse().map_err(|e| {
+        RagloomError::new(RagloomErrorKind::Config, e)
+            .with_context(format!("invalid AWS region {region}"))
+    })
+}
+
+fn parse_last_modified(value: &str) -> Result<i64, RagloomError> {
+    time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        .map(|timestamp| timestamp.unix_timestamp())
+        .map_err(|e| {
+            RagloomError::new(RagloomErrorKind::InvalidInput, e)
+                .with_context(format!("invalid S3 last_modified timestamp {value}"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_s3_uri_preserves_exact_key() {
+        let location = parse_s3_uri("s3://docs-bucket/kb//a.md").expect("parse s3 uri");
+        assert_eq!(location.bucket, "docs-bucket");
+        assert_eq!(location.key, "kb//a.md");
+    }
+
+    #[test]
+    fn parse_last_modified_accepts_rfc3339() {
+        let timestamp = parse_last_modified("2026-05-23T12:34:56.000Z").expect("parse timestamp");
+        assert_eq!(timestamp, 1_779_539_696);
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -8,8 +8,10 @@
 
 pub mod dir_scanner;
 pub mod file_tailer;
+pub mod s3_scanner;
 
 pub use dir_scanner::DirectoryScannerSource;
+pub use s3_scanner::S3PollingSource;
 
 use crate::ids::FileFingerprint;
 

--- a/src/source/s3_scanner.rs
+++ b/src/source/s3_scanner.rs
@@ -1,0 +1,252 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::RagloomError;
+use crate::s3::{S3Client, canonical_s3_path};
+use crate::source::file_tailer::{FileTailer, ObservedFileMeta};
+use crate::source::{Source, SourceEvent};
+
+#[derive(Debug)]
+pub struct S3PollingSource {
+    bucket: String,
+    prefix: Option<String>,
+    client: Arc<dyn S3Client>,
+    tailer: FileTailer,
+}
+
+impl S3PollingSource {
+    pub fn with_previously_observed_paths(
+        bucket: impl Into<String>,
+        prefix: Option<String>,
+        client: Arc<dyn S3Client>,
+        canonical_paths: HashSet<String>,
+    ) -> Result<Self, RagloomError> {
+        let bucket = bucket.into();
+        if client.bucket_name() != bucket {
+            return Err(
+                crate::RagloomError::from_kind(crate::RagloomErrorKind::Config).with_context(
+                    format!(
+                        "configured S3 bucket {bucket} does not match S3 client bucket {}",
+                        client.bucket_name()
+                    ),
+                ),
+            );
+        }
+        Ok(Self {
+            bucket,
+            prefix,
+            client,
+            tailer: FileTailer::with_previously_observed_paths(canonical_paths),
+        })
+    }
+
+    fn observe_bucket_once(&mut self) -> Result<(), RagloomError> {
+        let mut objects = self
+            .client
+            .list_objects(self.prefix.as_deref())
+            .map_err(|e| {
+                crate::RagloomError::new(e.kind, e).with_context(format!(
+                    "failed to poll S3 source s3://{}/{}",
+                    self.bucket,
+                    self.prefix.as_deref().unwrap_or("")
+                ))
+            })?;
+        objects.sort_by(|left, right| left.key.cmp(&right.key));
+
+        let mut observed_paths = HashSet::new();
+        for object in objects {
+            let canonical_path = canonical_s3_path(&self.bucket, &object.key);
+            observed_paths.insert(canonical_path.clone());
+            self.tailer.observe(ObservedFileMeta {
+                canonical_path,
+                size_bytes: object.size_bytes,
+                mtime_unix_secs: object.mtime_unix_secs,
+                etag: object.etag,
+            });
+        }
+        self.tailer.complete_scan(&observed_paths);
+        Ok(())
+    }
+}
+
+impl Source for S3PollingSource {
+    fn poll(&mut self) -> Vec<SourceEvent> {
+        if let Err(err) = self.observe_bucket_once() {
+            tracing::warn!(
+                event.name = "ragloom.source.s3.poll_failed",
+                error.kind = %err.kind,
+                error.message = %err,
+                bucket = %self.bucket,
+                prefix = self.prefix.as_deref().unwrap_or(""),
+                "ragloom.source.s3.poll_failed"
+            );
+        }
+        self.tailer.drain()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use crate::s3::S3ObjectMeta;
+    use crate::source::FileVersionDiscovered;
+
+    #[derive(Debug)]
+    struct FakeS3Client {
+        listings: Mutex<VecDeque<Result<Vec<S3ObjectMeta>, RagloomError>>>,
+    }
+
+    impl FakeS3Client {
+        fn new(
+            listings: impl IntoIterator<Item = Result<Vec<S3ObjectMeta>, RagloomError>>,
+        ) -> Self {
+            Self {
+                listings: Mutex::new(listings.into_iter().collect()),
+            }
+        }
+    }
+
+    impl S3Client for FakeS3Client {
+        fn bucket_name(&self) -> &str {
+            "docs-bucket"
+        }
+
+        fn list_objects(&self, _prefix: Option<&str>) -> Result<Vec<S3ObjectMeta>, RagloomError> {
+            self.listings
+                .lock()
+                .expect("lock")
+                .pop_front()
+                .unwrap_or_else(|| Ok(Vec::new()))
+        }
+
+        fn get_object(&self, _key: &str) -> Result<Vec<u8>, RagloomError> {
+            unreachable!("loader only")
+        }
+    }
+
+    fn object(
+        key: &str,
+        size_bytes: u64,
+        mtime_unix_secs: i64,
+        etag: Option<&str>,
+    ) -> S3ObjectMeta {
+        S3ObjectMeta {
+            key: key.to_string(),
+            size_bytes,
+            mtime_unix_secs,
+            etag: etag.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn first_poll_emits_discoveries_in_sorted_key_order() {
+        let client = Arc::new(FakeS3Client::new([Ok(vec![
+            object("kb/z.md", 1, 20, Some("\"z\"")),
+            object("kb/a.md", 1, 10, Some("\"a\"")),
+        ])]));
+        let mut source = S3PollingSource::with_previously_observed_paths(
+            "docs-bucket",
+            Some("kb/".to_string()),
+            client,
+            HashSet::new(),
+        )
+        .expect("create source");
+
+        let events = source.poll();
+        let paths: Vec<String> = events
+            .into_iter()
+            .map(|event| match event {
+                SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                    fingerprint, ..
+                }) => fingerprint.canonical_path,
+                SourceEvent::FileDeleted { canonical_path } => canonical_path,
+            })
+            .collect();
+
+        assert_eq!(
+            paths,
+            vec![
+                "s3://docs-bucket/kb/a.md".to_string(),
+                "s3://docs-bucket/kb/z.md".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn later_poll_with_missing_key_emits_delete() {
+        let client = Arc::new(FakeS3Client::new([
+            Ok(vec![
+                object("kb/a.md", 1, 10, Some("\"a\"")),
+                object("kb/b.md", 1, 10, Some("\"b\"")),
+            ]),
+            Ok(vec![object("kb/a.md", 1, 10, Some("\"a\""))]),
+        ]));
+        let mut source = S3PollingSource::with_previously_observed_paths(
+            "docs-bucket",
+            Some("kb/".to_string()),
+            client,
+            HashSet::new(),
+        )
+        .expect("create source");
+
+        assert_eq!(source.poll().len(), 2);
+        assert_eq!(
+            source.poll(),
+            vec![SourceEvent::FileDeleted {
+                canonical_path: "s3://docs-bucket/kb/b.md".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn later_poll_with_changed_etag_emits_new_version() {
+        let client = Arc::new(FakeS3Client::new([
+            Ok(vec![object("kb/a.md", 1, 10, Some("\"etag-a\""))]),
+            Ok(vec![object("kb/a.md", 1, 10, Some("\"etag-b\""))]),
+        ]));
+        let mut source = S3PollingSource::with_previously_observed_paths(
+            "docs-bucket",
+            Some("kb/".to_string()),
+            client,
+            HashSet::new(),
+        )
+        .expect("create source");
+
+        let first = source.poll();
+        let second = source.poll();
+
+        let first_id = match &first[0] {
+            SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                file_version_id, ..
+            }) => *file_version_id,
+            SourceEvent::FileDeleted { .. } => panic!("expected discovery"),
+        };
+        let second_id = match &second[0] {
+            SourceEvent::FileVersionDiscovered(FileVersionDiscovered {
+                file_version_id, ..
+            }) => *file_version_id,
+            SourceEvent::FileDeleted { .. } => panic!("expected discovery"),
+        };
+
+        assert_ne!(first_id, second_id);
+    }
+
+    #[test]
+    fn constructor_rejects_bucket_mismatch_with_client() {
+        let client = Arc::new(FakeS3Client::new([Ok(Vec::new())]));
+
+        let err = S3PollingSource::with_previously_observed_paths(
+            "other-bucket",
+            Some("kb/".to_string()),
+            client,
+            HashSet::new(),
+        )
+        .expect_err("expected bucket mismatch");
+
+        assert_eq!(err.kind, crate::RagloomErrorKind::Config);
+        assert!(err.to_string().contains("does not match S3 client bucket"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #108 by wiring a runnable polling S3 source into Ragloom's runtime.

## Related issue

Closes #108

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- add a minimal shared S3 client abstraction plus a `rust-s3`-backed runtime client
- add `S3PollingSource` and `S3Utf8Loader`, then wire `source.kind: s3` into startup/runtime preparation
- add regression coverage for first discovery, ETag-based updates, deletes, startup wiring, and document loading; update README and SUPPORT to reflect runnable S3 polling

## How to test

1. Run `cargo qa`
2. Run `cargo test source::s3_scanner -- --nocapture`
3. Run `cargo test doc::s3 -- --nocapture`

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

- S3 object identity remains `s3://{bucket}/{exact-key}` and preserves opaque object keys without normalization.
- AWS auth and region continue to come from the process environment (`AWS_REGION` / `AWS_DEFAULT_REGION` plus the default AWS credential chain).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 polling ingestion now supported; configure source with bucket name and optional key prefix
  * AWS credentials and region resolved from environment variables

* **Documentation**
  * Configuration guide updated with S3 source setup instructions
  * Feature boundaries documentation updated for v0.3 release scope

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->