### PR TITLE
feat(doc): broaden document loader boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ Discovers document versions from a location such as a local folder.
 
 ### Loader
 
-Reads document content. The built-in loader reads UTF-8 files from disk.
+Reads document content. The built-in loaders currently extract UTF-8 text from
+local files and S3 objects behind the same document-loading boundary.
 
 ### Chunker
 

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -13,10 +13,15 @@ pub use s3::S3Utf8Loader;
 /// Ingestion pipelines should depend on a small abstraction rather than hard-coding
 /// filesystem, HTTP, or object-store logic. This trait provides a stable surface
 /// for the pipeline while enabling alternate loaders in tests or other runtimes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedDocument {
+    pub text: String,
+}
+
 #[async_trait]
 pub trait DocumentLoader: Send + Sync {
-    /// Loads a UTF-8 document and returns its text.
-    async fn load_utf8(&self, path: &str) -> Result<String, RagloomError>;
+    /// Loads a document and returns extracted text.
+    async fn load(&self, path: &str) -> Result<LoadedDocument, RagloomError>;
 }
 
 /// Loads UTF-8 documents from the local filesystem.
@@ -29,17 +34,17 @@ pub struct FsUtf8Loader;
 
 #[async_trait]
 impl DocumentLoader for FsUtf8Loader {
-    async fn load_utf8(&self, path: &str) -> Result<String, RagloomError> {
+    async fn load(&self, path: &str) -> Result<LoadedDocument, RagloomError> {
         let bytes = tokio::fs::read(path).await.map_err(|e| {
-            RagloomError::new(RagloomErrorKind::Io, e).with_context("failed to read utf-8 file")
+            RagloomError::new(RagloomErrorKind::Io, e).with_context("failed to load document bytes")
         })?;
 
         let text = String::from_utf8(bytes).map_err(|e| {
             RagloomError::new(RagloomErrorKind::InvalidInput, e)
-                .with_context("failed to read utf-8 file")
+                .with_context("failed to extract UTF-8 text from document bytes")
         })?;
 
-        Ok(text)
+        Ok(LoadedDocument { text })
     }
 }
 
@@ -57,11 +62,11 @@ mod tests {
 
         let loader = FsUtf8Loader;
         let loaded = loader
-            .load_utf8(path.to_str().expect("utf-8 path"))
+            .load(path.to_str().expect("utf-8 path"))
             .await
             .expect("load file");
 
-        assert_eq!(loaded, "hello\nworld");
+        assert_eq!(loaded.text, "hello\nworld");
     }
 
     #[tokio::test]
@@ -71,11 +76,32 @@ mod tests {
 
         let loader = FsUtf8Loader;
         let err = loader
-            .load_utf8(path.to_str().expect("utf-8 path"))
+            .load(path.to_str().expect("utf-8 path"))
             .await
             .expect_err("expected error");
 
         assert_eq!(err.kind, RagloomErrorKind::Io);
-        assert!(err.to_string().contains("failed to read utf-8 file"));
+        assert!(err.to_string().contains("failed to load document bytes"));
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_surfaces_utf8_extraction_context() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("invalid.bin");
+        tokio::fs::write(&path, [0xff, 0xfe, 0xfd])
+            .await
+            .expect("write file");
+
+        let loader = FsUtf8Loader;
+        let err = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("expected invalid utf-8");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("failed to extract UTF-8 text from document bytes")
+        );
     }
 }

--- a/src/doc/s3.rs
+++ b/src/doc/s3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::doc::DocumentLoader;
+use crate::doc::{DocumentLoader, LoadedDocument};
 use crate::s3::{S3Client, parse_s3_uri};
 use crate::{RagloomError, RagloomErrorKind};
 
@@ -19,7 +19,7 @@ impl S3Utf8Loader {
 
 #[async_trait]
 impl DocumentLoader for S3Utf8Loader {
-    async fn load_utf8(&self, path: &str) -> Result<String, RagloomError> {
+    async fn load(&self, path: &str) -> Result<LoadedDocument, RagloomError> {
         let location = parse_s3_uri(path)?;
         if location.bucket != self.client.bucket_name() {
             return Err(
@@ -38,12 +38,16 @@ impl DocumentLoader for S3Utf8Loader {
                 RagloomError::new(RagloomErrorKind::Internal, e)
                     .with_context("failed to join S3 object read task")
             })?
-            .map_err(|e| RagloomError::new(e.kind, e).with_context("failed to read utf-8 file"))?;
+            .map_err(|e| {
+                RagloomError::new(e.kind, e).with_context("failed to load document bytes")
+            })?;
 
-        String::from_utf8(bytes).map_err(|e| {
+        let text = String::from_utf8(bytes).map_err(|e| {
             RagloomError::new(RagloomErrorKind::InvalidInput, e)
-                .with_context("failed to read utf-8 file")
-        })
+                .with_context("failed to extract UTF-8 text from document bytes")
+        })?;
+
+        Ok(LoadedDocument { text })
     }
 }
 
@@ -56,6 +60,7 @@ mod tests {
     #[derive(Debug)]
     struct FakeS3Client {
         bytes: Vec<u8>,
+        fail_get_object: bool,
     }
 
     impl S3Client for FakeS3Client {
@@ -68,6 +73,11 @@ mod tests {
         }
 
         fn get_object(&self, _key: &str) -> Result<Vec<u8>, RagloomError> {
+            if self.fail_get_object {
+                return Err(RagloomError::from_kind(RagloomErrorKind::Io)
+                    .with_context("failed to get S3 object s3://docs-bucket/kb/hello.txt"));
+            }
+
             Ok(self.bytes.clone())
         }
     }
@@ -76,10 +86,11 @@ mod tests {
     async fn rejects_non_s3_canonical_path() {
         let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
             bytes: b"hello".to_vec(),
+            fail_get_object: false,
         }));
 
         let err = loader
-            .load_utf8("/tmp/hello.txt")
+            .load("/tmp/hello.txt")
             .await
             .expect_err("expected invalid input");
 
@@ -90,28 +101,65 @@ mod tests {
     async fn reads_utf8_text_from_s3() {
         let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
             bytes: b"hello from s3".to_vec(),
+            fail_get_object: false,
         }));
 
         let text = loader
-            .load_utf8("s3://docs-bucket/kb/hello.txt")
+            .load("s3://docs-bucket/kb/hello.txt")
             .await
             .expect("load text");
 
-        assert_eq!(text, "hello from s3");
+        assert_eq!(text.text, "hello from s3");
     }
 
     #[tokio::test]
     async fn rejects_bucket_mismatch() {
         let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
             bytes: b"hello from s3".to_vec(),
+            fail_get_object: false,
         }));
 
         let err = loader
-            .load_utf8("s3://other-bucket/kb/hello.txt")
+            .load("s3://other-bucket/kb/hello.txt")
             .await
             .expect_err("expected invalid input");
 
         assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
         assert!(err.to_string().contains("does not match configured bucket"));
+    }
+
+    #[tokio::test]
+    async fn surfaces_utf8_extraction_context_for_s3_bytes() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: vec![0xff, 0xfe, 0xfd],
+            fail_get_object: false,
+        }));
+
+        let err = loader
+            .load("s3://docs-bucket/kb/hello.txt")
+            .await
+            .expect_err("expected invalid utf-8");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("failed to extract UTF-8 text from document bytes")
+        );
+    }
+
+    #[tokio::test]
+    async fn surfaces_load_context_for_s3_read_failures() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: Vec::new(),
+            fail_get_object: true,
+        }));
+
+        let err = loader
+            .load("s3://docs-bucket/kb/hello.txt")
+            .await
+            .expect_err("expected read failure");
+
+        assert_eq!(err.kind, RagloomErrorKind::Io);
+        assert!(err.to_string().contains("failed to load document bytes"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2753,12 +2753,8 @@ sink:
         assert!(prepared.source.poll().is_empty());
         let text = tokio::runtime::Runtime::new()
             .expect("runtime")
-            .block_on(
-                prepared
-                    .loader
-                    .load_utf8("s3://docs-bucket/knowledge/hello.txt"),
-            )
+            .block_on(prepared.loader.load("s3://docs-bucket/knowledge/hello.txt"))
             .expect("load text");
-        assert_eq!(text, "loaded knowledge/hello.txt");
+        assert_eq!(text.text, "loaded knowledge/hello.txt");
     }
 }

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -809,14 +809,14 @@ impl WorkExecutor for PipelineExecutor {
                 )
                 .in_scope(|| async {
                     let load_elapsed = std::time::Instant::now();
-                    let text = match self.loader.load_utf8(&fingerprint.canonical_path).await {
-                        Ok(text) => {
+                    let document = match self.loader.load(&fingerprint.canonical_path).await {
+                        Ok(document) => {
                             tracing::debug!(
                                 canonical_path = fingerprint.canonical_path.as_str(),
                                 elapsed_ms = load_elapsed.elapsed().as_millis() as u64,
                                 "ragloom.doc.load_utf8"
                             );
-                            text
+                            document
                         }
                         Err(err) => {
                             tracing::warn!(
@@ -829,7 +829,10 @@ impl WorkExecutor for PipelineExecutor {
                         }
                     };
 
-                    let points = match self.build_points_from_text(&fingerprint, &text).await {
+                    let points = match self
+                        .build_points_from_text(&fingerprint, &document.text)
+                        .await
+                    {
                         Ok(points) => points,
                         Err(err) => {
                             tracing::warn!(
@@ -1547,8 +1550,13 @@ mod tests {
 
         #[async_trait::async_trait]
         impl crate::doc::DocumentLoader for StubDocumentLoader {
-            async fn load_utf8(&self, _path: &str) -> Result<String, crate::error::RagloomError> {
-                Ok("hello from stub loader".to_string())
+            async fn load(
+                &self,
+                _path: &str,
+            ) -> Result<crate::doc::LoadedDocument, crate::error::RagloomError> {
+                Ok(crate::doc::LoadedDocument {
+                    text: "hello from stub loader".to_string(),
+                })
             }
         }
 
@@ -1671,8 +1679,13 @@ mod tests {
 
         #[async_trait::async_trait]
         impl crate::doc::DocumentLoader for StubDocumentLoader {
-            async fn load_utf8(&self, _path: &str) -> Result<String, crate::error::RagloomError> {
-                Ok("hello from stub loader".to_string())
+            async fn load(
+                &self,
+                _path: &str,
+            ) -> Result<crate::doc::LoadedDocument, crate::error::RagloomError> {
+                Ok(crate::doc::LoadedDocument {
+                    text: "hello from stub loader".to_string(),
+                })
             }
         }
 
@@ -1790,8 +1803,13 @@ mod tests {
 
         #[async_trait::async_trait]
         impl crate::doc::DocumentLoader for StubDocumentLoader {
-            async fn load_utf8(&self, _path: &str) -> Result<String, crate::error::RagloomError> {
-                Ok("hello from stub loader".to_string())
+            async fn load(
+                &self,
+                _path: &str,
+            ) -> Result<crate::doc::LoadedDocument, crate::error::RagloomError> {
+                Ok(crate::doc::LoadedDocument {
+                    text: "hello from stub loader".to_string(),
+                })
             }
         }
 
@@ -1909,8 +1927,13 @@ mod tests {
 
         #[async_trait::async_trait]
         impl crate::doc::DocumentLoader for StubDocumentLoader {
-            async fn load_utf8(&self, _path: &str) -> Result<String, crate::error::RagloomError> {
-                Ok("hello from stub loader".to_string())
+            async fn load(
+                &self,
+                _path: &str,
+            ) -> Result<crate::doc::LoadedDocument, crate::error::RagloomError> {
+                Ok(crate::doc::LoadedDocument {
+                    text: "hello from stub loader".to_string(),
+                })
             }
         }
 

--- a/tests/canonical_path_file_uri.rs
+++ b/tests/canonical_path_file_uri.rs
@@ -37,8 +37,13 @@ async fn payload_canonical_path_is_file_uri() {
 
     #[async_trait::async_trait]
     impl ragloom::doc::DocumentLoader for StubDocumentLoader {
-        async fn load_utf8(&self, _path: &str) -> Result<String, ragloom::error::RagloomError> {
-            Ok("hello".to_string())
+        async fn load(
+            &self,
+            _path: &str,
+        ) -> Result<ragloom::doc::LoadedDocument, ragloom::error::RagloomError> {
+            Ok(ragloom::doc::LoadedDocument {
+                text: "hello".to_string(),
+            })
         }
     }
 

--- a/tests/pipeline_chunk_payload.rs
+++ b/tests/pipeline_chunk_payload.rs
@@ -8,8 +8,13 @@ async fn points_payload_includes_chunk_metadata_and_optional_text() {
 
     #[async_trait::async_trait]
     impl ragloom::doc::DocumentLoader for StubDocumentLoader {
-        async fn load_utf8(&self, _path: &str) -> Result<String, ragloom::error::RagloomError> {
-            Ok("hello from stub loader".to_string())
+        async fn load(
+            &self,
+            _path: &str,
+        ) -> Result<ragloom::doc::LoadedDocument, ragloom::error::RagloomError> {
+            Ok(ragloom::doc::LoadedDocument {
+                text: "hello from stub loader".to_string(),
+            })
         }
     }
 

--- a/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
+++ b/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ragloom::doc::DocumentLoader;
+use ragloom::doc::{DocumentLoader, LoadedDocument};
 use ragloom::pipeline::runtime::{
     AckingExecutor, AsyncRuntime, PipelineExecutor, Runtime, run_worker,
 };
@@ -66,9 +66,11 @@ struct StubLoader {
 
 #[async_trait::async_trait]
 impl DocumentLoader for StubLoader {
-    async fn load_utf8(&self, path: &str) -> Result<String, ragloom::RagloomError> {
+    async fn load(&self, path: &str) -> Result<LoadedDocument, ragloom::RagloomError> {
         self.calls.lock().await.push(path.to_string());
-        Ok("hello\nfrom\nloader".to_string())
+        Ok(LoadedDocument {
+            text: "hello\nfrom\nloader".to_string(),
+        })
     }
 }
 

--- a/tests/pipeline_point_id_strategy.rs
+++ b/tests/pipeline_point_id_strategy.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use ragloom::RagloomError;
-use ragloom::doc::DocumentLoader;
+use ragloom::doc::{DocumentLoader, LoadedDocument};
 use ragloom::embed::EmbeddingProvider;
 use ragloom::ids::FileFingerprint;
 use ragloom::sink::{Sink, VectorPoint};
@@ -55,8 +55,10 @@ struct FakeLoader;
 
 #[async_trait]
 impl DocumentLoader for FakeLoader {
-    async fn load_utf8(&self, _path: &str) -> Result<String, RagloomError> {
-        Ok(String::new())
+    async fn load(&self, _path: &str) -> Result<LoadedDocument, RagloomError> {
+        Ok(LoadedDocument {
+            text: String::new(),
+        })
     }
 }
 

--- a/tests/pipeline_router_dispatch.rs
+++ b/tests/pipeline_router_dispatch.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use ragloom::RagloomError;
-use ragloom::doc::DocumentLoader;
+use ragloom::doc::{DocumentLoader, LoadedDocument};
 use ragloom::embed::EmbeddingProvider;
 use ragloom::ids::FileFingerprint;
 use ragloom::sink::{Sink, VectorPoint};
@@ -37,8 +37,10 @@ impl Sink for FakeSink {
 struct FakeLoader;
 #[async_trait]
 impl DocumentLoader for FakeLoader {
-    async fn load_utf8(&self, _path: &str) -> Result<String, RagloomError> {
-        Ok(String::new())
+    async fn load(&self, _path: &str) -> Result<LoadedDocument, RagloomError> {
+        Ok(LoadedDocument {
+            text: String::new(),
+        })
     }
 }
 

--- a/tests/pipeline_router_fingerprint_distinct.rs
+++ b/tests/pipeline_router_fingerprint_distinct.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use ragloom::RagloomError;
-use ragloom::doc::DocumentLoader;
+use ragloom::doc::{DocumentLoader, LoadedDocument};
 use ragloom::embed::EmbeddingProvider;
 use ragloom::ids::FileFingerprint;
 use ragloom::sink::{Sink, VectorPoint};
@@ -34,8 +34,10 @@ impl Sink for FakeSink {
 struct FakeLoader;
 #[async_trait]
 impl DocumentLoader for FakeLoader {
-    async fn load_utf8(&self, _: &str) -> Result<String, RagloomError> {
-        Ok(String::new())
+    async fn load(&self, _: &str) -> Result<LoadedDocument, RagloomError> {
+        Ok(LoadedDocument {
+            text: String::new(),
+        })
     }
 }
 

--- a/tests/pipeline_semantic_flag.rs
+++ b/tests/pipeline_semantic_flag.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use ragloom::RagloomError;
-use ragloom::doc::DocumentLoader;
+use ragloom::doc::{DocumentLoader, LoadedDocument};
 use ragloom::embed::EmbeddingProvider;
 use ragloom::ids::FileFingerprint;
 use ragloom::sink::{Sink, VectorPoint};
@@ -37,8 +37,10 @@ impl Sink for FakeSink {
 struct FakeLoader;
 #[async_trait]
 impl DocumentLoader for FakeLoader {
-    async fn load_utf8(&self, _: &str) -> Result<String, RagloomError> {
-        Ok(String::new())
+    async fn load(&self, _: &str) -> Result<LoadedDocument, RagloomError> {
+        Ok(LoadedDocument {
+            text: String::new(),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Broaden Ragloom's document-loading boundary so the pipeline depends on a small document abstraction rather than a UTF-8-by-path contract.

## Related issue

Closes #109

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- replace `DocumentLoader::load_utf8(&str) -> String` with `DocumentLoader::load(&str) -> LoadedDocument`
- keep filesystem and S3 loaders small while splitting load-boundary and UTF-8 extraction error context
- update runtime wiring, loader test doubles, and README terminology to reflect the wider document-loading boundary

## How to test

1. Run `cargo test --workspace --all-targets --all-features doc::s3::tests::`.
2. Run `cargo test --workspace --all-targets --all-features pipeline_embeds_text_loaded_from_fingerprint_v2`.
3. Run `cargo qa`.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This change keeps canonical path, document ID, and point-ID behavior unchanged. It widens only the loader boundary so future object-backed and richer parsed document loaders can plug in without leaking transport details into the pipeline.