### PR TITLE
feat(doc): add deterministic PDF text extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +355,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -367,6 +402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +421,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cff-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-if"
@@ -425,6 +475,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -832,6 +892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +962,15 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "exr"
@@ -1579,6 +1657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1819,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.3.4",
+ "indexmap",
+ "itoa",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand",
+ "rangemap",
+ "sha2",
+ "stringprep",
+ "thiserror",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1912,16 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1939,6 +2065,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -2161,6 +2298,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pdf-extract"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
+dependencies = [
+ "adobe-cmap-parser",
+ "cff-parser",
+ "encoding_rs",
+ "euclid",
+ "log",
+ "lopdf",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2402,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -2466,6 +2632,7 @@ dependencies = [
  "criterion",
  "fastembed",
  "loom",
+ "pdf-extract",
  "proptest",
  "pulldown-cmark",
  "reqwest",
@@ -2532,6 +2699,12 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rav1e"
@@ -3098,6 +3271,17 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3669,6 +3853,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,10 +3886,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3700,6 +3914,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-bash = "0.25"
+pdf-extract = "0.10"
 
 [dev-dependencies]
 criterion = "0.8"

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Do not share command output if it includes credentials or other sensitive respon
 
 - only local filesystem and polling S3 input
 - only Qdrant as a built-in sink
-- only UTF-8 file loading
+- only UTF-8 text, Markdown, source code, and text-extractable PDF loading
 - no general collection lifecycle management beyond optional first-run bootstrap
 - no persistent dead-letter queue yet
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Core path the project is hardening for v0.3 release-readiness:
 
 - local filesystem source
 - recursive scanning of regular files under one configured directory
-- UTF-8 text, Markdown, and source code files
+- UTF-8 text, Markdown, source code, and PDF files
 - recursive, Markdown-aware, and code-aware chunking
 - OpenAI and generic HTTP embedding APIs
 - Qdrant sink
@@ -54,7 +54,7 @@ Experimental or best-effort paths:
 
 Not supported yet:
 
-- PDF or DOCX parsing
+- DOCX parsing
 - persistent dead-letter queues
 - built-in collection lifecycle management
 
@@ -312,8 +312,14 @@ Discovers document versions from a location such as a local folder.
 
 ### Loader
 
-Reads document content. The built-in loaders currently extract UTF-8 text from
-local files and S3 objects behind the same document-loading boundary.
+Reads document content. The built-in loaders currently extract UTF-8 text and
+deterministic PDF text from local files and S3 objects behind the same
+document-loading boundary.
+
+PDF extraction is text-only. Ragloom does not perform OCR, does not reconstruct
+rich layout, and may return an empty string for image-only or scan-only PDFs.
+Encrypted or malformed PDFs fail at the loader boundary with project-level
+errors.
 
 ### Chunker
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -80,7 +80,7 @@ Release after the supported Linux and Windows assets have already published.
 Core support boundary maintainers are hardening for `v0.3` release-readiness:
 
 - local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix
-- UTF-8 text, Markdown, and source code loading
+- UTF-8 text, Markdown, source code, and deterministic PDF text loading
 - recursive, Markdown-aware, and code-aware chunking
 - OpenAI and generic HTTP embedding backends
 - Qdrant sink behavior, deterministic point IDs, local WAL replay, bounded retry, and the loopback-only health and metrics endpoint
@@ -96,9 +96,13 @@ Experimental or best-effort paths:
 
 Out of scope for the current support contract:
 
-- PDF, DOCX, or broader parser guarantees
+- DOCX or broader parser guarantees
 - non-local operator surfaces
 - collection lifecycle management beyond optional first-run bootstrap of the configured target collection
+
+Current PDF support is limited to embedded text extraction. OCR, rich layout
+reconstruction, and guarantees for image-only, scan-only, encrypted, or
+otherwise unsupported PDFs remain outside the current support contract.
 
 ## Getting Help
 

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -224,7 +224,7 @@ mod tests {
             .await
             .expect("load pdf");
 
-        assert_eq!(loaded.text.trim(), "Hello PDF");
+        assert_eq!(loaded.text, "\n\nHello PDF");
     }
 
     #[tokio::test]

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -1,6 +1,9 @@
 //! Document loading abstractions.
 
+use std::path::Path;
+
 use async_trait::async_trait;
+use pdf_extract::{Document as PdfDocument, Error as PdfError, OutputError as PdfOutputError};
 
 use crate::{RagloomError, RagloomErrorKind};
 
@@ -24,6 +27,50 @@ pub trait DocumentLoader: Send + Sync {
     async fn load(&self, path: &str) -> Result<LoadedDocument, RagloomError>;
 }
 
+pub(crate) fn extract_document_text(path: &str, bytes: Vec<u8>) -> Result<String, RagloomError> {
+    if is_pdf_path(path) {
+        return extract_pdf_text(&bytes);
+    }
+
+    String::from_utf8(bytes).map_err(|e| {
+        RagloomError::new(RagloomErrorKind::InvalidInput, e)
+            .with_context("failed to extract UTF-8 text from document bytes")
+    })
+}
+
+fn is_pdf_path(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
+}
+
+fn extract_pdf_text(bytes: &[u8]) -> Result<String, RagloomError> {
+    let document = PdfDocument::load_mem(bytes).map_err(map_pdf_parse_error)?;
+    if document.is_encrypted() {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+            .with_context("encrypted PDFs are not supported for text extraction"));
+    }
+
+    pdf_extract::extract_text_from_mem(bytes).map_err(map_pdf_extract_error)
+}
+
+fn map_pdf_parse_error(error: PdfError) -> RagloomError {
+    RagloomError::new(RagloomErrorKind::InvalidInput, error)
+        .with_context("failed to parse PDF document bytes")
+}
+
+fn map_pdf_extract_error(error: PdfOutputError) -> RagloomError {
+    let context = match &error {
+        PdfOutputError::PdfError(PdfError::UnsupportedSecurityHandler(_)) => {
+            "unsupported PDF security handler prevents text extraction"
+        }
+        _ => "failed to extract PDF text from document bytes",
+    };
+
+    RagloomError::new(RagloomErrorKind::InvalidInput, error).with_context(context)
+}
+
 /// Loads UTF-8 documents from the local filesystem.
 ///
 /// # Why
@@ -39,10 +86,7 @@ impl DocumentLoader for FsUtf8Loader {
             RagloomError::new(RagloomErrorKind::Io, e).with_context("failed to load document bytes")
         })?;
 
-        let text = String::from_utf8(bytes).map_err(|e| {
-            RagloomError::new(RagloomErrorKind::InvalidInput, e)
-                .with_context("failed to extract UTF-8 text from document bytes")
-        })?;
+        let text = extract_document_text(path, bytes)?;
 
         Ok(LoadedDocument { text })
     }
@@ -52,13 +96,76 @@ impl DocumentLoader for FsUtf8Loader {
 mod tests {
     use super::*;
 
+    fn write_test_file(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes).expect("write test file");
+        path
+    }
+
+    fn minimal_pdf_bytes(stream: &str) -> Vec<u8> {
+        let objects = [
+            "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n".to_string(),
+            "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n".to_string(),
+            "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n".to_string(),
+            format!(
+                "4 0 obj\n<< /Length {} >>\nstream\n{stream}endstream\nendobj\n",
+                stream.len()
+            ),
+            "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+                .to_string(),
+        ];
+
+        let mut pdf = String::from("%PDF-1.4\n");
+        let mut offsets = vec![0usize];
+        for object in &objects {
+            offsets.push(pdf.len());
+            pdf.push_str(object);
+        }
+
+        let xref_offset = pdf.len();
+        pdf.push_str("xref\n0 6\n");
+        pdf.push_str("0000000000 65535 f \n");
+        for offset in offsets.iter().skip(1) {
+            pdf.push_str(&format!("{offset:010} 00000 n \n"));
+        }
+        pdf.push_str("trailer\n<< /Root 1 0 R /Size 6 >>\n");
+        pdf.push_str(&format!("startxref\n{xref_offset}\n%%EOF\n"));
+        pdf.into_bytes()
+    }
+
+    fn encrypted_pdf_bytes() -> Vec<u8> {
+        let mut document = PdfDocument::load_mem(&minimal_pdf_bytes(
+            "BT\n/F1 18 Tf\n50 100 Td\n(Secret PDF) Tj\nET\n",
+        ))
+        .expect("parse plaintext pdf");
+        document.trailer.set(
+            "ID",
+            pdf_extract::Object::Array(vec![
+                pdf_extract::Object::string_literal(b"ABC"),
+                pdf_extract::Object::string_literal(b"DEF"),
+            ]),
+        );
+
+        let version = pdf_extract::EncryptionVersion::V2 {
+            document: &document,
+            owner_password: "owner",
+            user_password: "user",
+            key_length: 40,
+            permissions: pdf_extract::Permissions::all(),
+        };
+
+        let state = pdf_extract::EncryptionState::try_from(version).expect("build encryption");
+        document.encrypt(&state).expect("encrypt pdf");
+
+        let mut encrypted = Vec::new();
+        document.save_to(&mut encrypted).expect("serialize pdf");
+        encrypted
+    }
+
     #[tokio::test]
     async fn fs_utf8_loader_reads_text_file() {
         let dir = tempfile::tempdir().expect("create tempdir");
-        let path = dir.path().join("hello.txt");
-        tokio::fs::write(&path, "hello\nworld")
-            .await
-            .expect("write file");
+        let path = write_test_file(&dir, "hello.txt", b"hello\nworld");
 
         let loader = FsUtf8Loader;
         let loaded = loader
@@ -87,10 +194,7 @@ mod tests {
     #[tokio::test]
     async fn fs_utf8_loader_surfaces_utf8_extraction_context() {
         let dir = tempfile::tempdir().expect("create tempdir");
-        let path = dir.path().join("invalid.bin");
-        tokio::fs::write(&path, [0xff, 0xfe, 0xfd])
-            .await
-            .expect("write file");
+        let path = write_test_file(&dir, "invalid.bin", &[0xff, 0xfe, 0xfd]);
 
         let loader = FsUtf8Loader;
         let err = loader
@@ -102,6 +206,74 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("failed to extract UTF-8 text from document bytes")
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_extracts_text_from_pdf() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(
+            &dir,
+            "hello.pdf",
+            &minimal_pdf_bytes("BT\n/F1 18 Tf\n50 100 Td\n(Hello PDF) Tj\nET\n"),
+        );
+
+        let loader = FsUtf8Loader;
+        let loaded = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect("load pdf");
+
+        assert_eq!(loaded.text.trim(), "Hello PDF");
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_returns_empty_string_for_pdf_without_extractable_text() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "empty.pdf", &minimal_pdf_bytes(""));
+
+        let loader = FsUtf8Loader;
+        let loaded = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect("load empty pdf");
+
+        assert_eq!(loaded.text, "");
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_rejects_malformed_pdf_with_context() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "broken.pdf", b"%PDF-1.4\nnot a real pdf\n");
+
+        let loader = FsUtf8Loader;
+        let err = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("expected malformed pdf to fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("failed to parse PDF document bytes")
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_rejects_encrypted_pdf_with_clear_error() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "secret.pdf", &encrypted_pdf_bytes());
+
+        let loader = FsUtf8Loader;
+        let err = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("expected encrypted pdf to fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("encrypted PDFs are not supported for text extraction")
         );
     }
 }

--- a/src/doc/s3.rs
+++ b/src/doc/s3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::doc::{DocumentLoader, LoadedDocument};
+use crate::doc::{DocumentLoader, LoadedDocument, extract_document_text};
 use crate::s3::{S3Client, parse_s3_uri};
 use crate::{RagloomError, RagloomErrorKind};
 
@@ -42,10 +42,7 @@ impl DocumentLoader for S3Utf8Loader {
                 RagloomError::new(e.kind, e).with_context("failed to load document bytes")
             })?;
 
-        let text = String::from_utf8(bytes).map_err(|e| {
-            RagloomError::new(RagloomErrorKind::InvalidInput, e)
-                .with_context("failed to extract UTF-8 text from document bytes")
-        })?;
+        let text = extract_document_text(path, bytes)?;
 
         Ok(LoadedDocument { text })
     }
@@ -56,6 +53,37 @@ mod tests {
     use super::*;
 
     use crate::s3::S3ObjectMeta;
+
+    fn minimal_pdf_bytes(stream: &str) -> Vec<u8> {
+        let objects = [
+            "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n".to_string(),
+            "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n".to_string(),
+            "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n".to_string(),
+            format!(
+                "4 0 obj\n<< /Length {} >>\nstream\n{stream}endstream\nendobj\n",
+                stream.len()
+            ),
+            "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+                .to_string(),
+        ];
+
+        let mut pdf = String::from("%PDF-1.4\n");
+        let mut offsets = vec![0usize];
+        for object in &objects {
+            offsets.push(pdf.len());
+            pdf.push_str(object);
+        }
+
+        let xref_offset = pdf.len();
+        pdf.push_str("xref\n0 6\n");
+        pdf.push_str("0000000000 65535 f \n");
+        for offset in offsets.iter().skip(1) {
+            pdf.push_str(&format!("{offset:010} 00000 n \n"));
+        }
+        pdf.push_str("trailer\n<< /Root 1 0 R /Size 6 >>\n");
+        pdf.push_str(&format!("startxref\n{xref_offset}\n%%EOF\n"));
+        pdf.into_bytes()
+    }
 
     #[derive(Debug)]
     struct FakeS3Client {
@@ -161,5 +189,20 @@ mod tests {
 
         assert_eq!(err.kind, RagloomErrorKind::Io);
         assert!(err.to_string().contains("failed to load document bytes"));
+    }
+
+    #[tokio::test]
+    async fn extracts_pdf_text_from_s3_bytes() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: minimal_pdf_bytes("BT\n/F1 18 Tf\n50 100 Td\n(Hello from S3 PDF) Tj\nET\n"),
+            fail_get_object: false,
+        }));
+
+        let loaded = loader
+            .load("s3://docs-bucket/kb/hello.pdf")
+            .await
+            .expect("load pdf");
+
+        assert_eq!(loaded.text.trim(), "Hello from S3 PDF");
     }
 }

--- a/src/doc/s3.rs
+++ b/src/doc/s3.rs
@@ -203,6 +203,6 @@ mod tests {
             .await
             .expect("load pdf");
 
-        assert_eq!(loaded.text.trim(), "Hello from S3 PDF");
+        assert_eq!(loaded.text, "\n\nHello from S3 PDF");
     }
 }


### PR DESCRIPTION
## Summary

Adds deterministic PDF text extraction at the document-loader boundary so local files and S3 objects can ingest `.pdf` content without leaking parser logic into the pipeline.

## Related issue

Closes #110

## Type of change

- [x] New feature
- [x] Documentation update
- [x] Test update

## Changes made

- added shared PDF-aware document text extraction in `src/doc`, including clear errors for malformed and encrypted PDFs
- reused the same extraction path for filesystem and S3 loaders, keeping the change scoped to the document-loading boundary
- added regression tests for text extraction, empty-text PDFs, malformed PDFs, encrypted PDFs, and S3-backed PDF bytes; updated README and SUPPORT to document PDF support and limits

## How to test

1. `cargo test --lib fs_utf8_loader_extracts_text_from_pdf`
2. `cargo test --lib fs_utf8_loader_rejects_encrypted_pdf_with_clear_error`
3. `cargo qa`

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

PDF support is intentionally limited to deterministic embedded-text extraction. OCR, rich layout reconstruction, and broader document parser expansion remain out of scope for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF text extraction support for document ingestion from local and S3 sources.

* **Documentation**
  * Updated supported file types to explicitly include PDFs alongside UTF-8 text, Markdown, and source code.
  * Clarified PDF limitations: text extraction only, no OCR; image-only, encrypted, or malformed PDFs produce errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->