### PR TITLE
feat(doc): add deterministic DOCX text extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -230,10 +230,10 @@ dependencies = [
  "attohttpc",
  "home",
  "log",
- "quick-xml",
+ "quick-xml 0.38.4",
  "rust-ini",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "url",
 ]
@@ -244,7 +244,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -892,6 +892,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docx-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66db35e6c788cf5624ac83aefbea59f8f7ab9f26a276a73dea53645f66119f8"
+dependencies = [
+ "quick-xml 0.36.2",
+ "thiserror 1.0.69",
+ "zip",
+]
+
+[[package]]
 name = "ecb"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,7 +1341,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -1841,7 +1852,7 @@ dependencies = [
  "rangemap",
  "sha2",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
 ]
@@ -2538,6 +2549,15 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -2560,7 +2580,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2581,7 +2601,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2630,6 +2650,7 @@ dependencies = [
  "blake3",
  "chunk",
  "criterion",
+ "docx-lite",
  "fastembed",
  "loom",
  "pdf-extract",
@@ -2641,7 +2662,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tiktoken-rs",
  "time",
  "tokio",
@@ -2660,6 +2681,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "unicode-segmentation",
+ "zip",
 ]
 
 [[package]]
@@ -2736,7 +2758,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2801,7 +2823,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2930,12 +2952,12 @@ dependencies = [
  "maybe-async",
  "md5",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "url",
 ]
@@ -3362,11 +3384,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3520,7 +3562,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -4683,6 +4725,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tree-sitter-cpp = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-bash = "0.25"
 pdf-extract = "0.10"
+docx-lite = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.8"
@@ -51,6 +52,7 @@ loom = "0.7"
 tempfile = "3"
 tracing-test = "0.2"
 proptest = "1"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [features]
 loom = []

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Core path the project is hardening for v0.3 release-readiness:
 
 - local filesystem source
 - recursive scanning of regular files under one configured directory
-- UTF-8 text, Markdown, source code, and PDF files
+- UTF-8 text, Markdown, source code, PDF files, and deterministic DOCX text extraction
 - recursive, Markdown-aware, and code-aware chunking
 - OpenAI and generic HTTP embedding APIs
 - Qdrant sink
@@ -54,7 +54,6 @@ Experimental or best-effort paths:
 
 Not supported yet:
 
-- DOCX parsing
 - persistent dead-letter queues
 - built-in collection lifecycle management
 
@@ -312,14 +311,20 @@ Discovers document versions from a location such as a local folder.
 
 ### Loader
 
-Reads document content. The built-in loaders currently extract UTF-8 text and
-deterministic PDF text from local files and S3 objects behind the same
+Reads document content. The built-in loaders currently extract UTF-8 text,
+deterministic PDF text, and deterministic DOCX text from local files and S3
+objects behind the same
 document-loading boundary.
 
 PDF extraction is text-only. Ragloom does not perform OCR, does not reconstruct
 rich layout, and may return an empty string for image-only or scan-only PDFs.
 Encrypted or malformed PDFs fail at the loader boundary with project-level
 errors.
+
+DOCX extraction is also text-only. Ragloom linearizes paragraphs with newline
+separators and table cells with tab separators, does not preserve rich
+formatting or embedded assets, and fails malformed DOCX inputs at the loader
+boundary with project-level errors.
 
 ### Chunker
 
@@ -693,7 +698,7 @@ Do not share command output if it includes credentials or other sensitive respon
 
 - only local filesystem and polling S3 input
 - only Qdrant as a built-in sink
-- only UTF-8 text, Markdown, source code, and text-extractable PDF loading
+- only UTF-8 text, Markdown, source code, text-extractable PDF loading, and deterministic DOCX text extraction
 - no general collection lifecycle management beyond optional first-run bootstrap
 - no persistent dead-letter queue yet
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -80,7 +80,7 @@ Release after the supported Linux and Windows assets have already published.
 Core support boundary maintainers are hardening for `v0.3` release-readiness:
 
 - local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix
-- UTF-8 text, Markdown, source code, and deterministic PDF text loading
+- UTF-8 text, Markdown, source code, deterministic PDF text loading, and deterministic DOCX text extraction
 - recursive, Markdown-aware, and code-aware chunking
 - OpenAI and generic HTTP embedding backends
 - Qdrant sink behavior, deterministic point IDs, local WAL replay, bounded retry, and the loopback-only health and metrics endpoint
@@ -96,13 +96,17 @@ Experimental or best-effort paths:
 
 Out of scope for the current support contract:
 
-- DOCX or broader parser guarantees
+- broader parser guarantees beyond built-in DOCX text extraction
 - non-local operator surfaces
 - collection lifecycle management beyond optional first-run bootstrap of the configured target collection
 
 Current PDF support is limited to embedded text extraction. OCR, rich layout
 reconstruction, and guarantees for image-only, scan-only, encrypted, or
 otherwise unsupported PDFs remain outside the current support contract.
+
+Current DOCX support is limited to deterministic extracted text. Ragloom
+linearizes paragraphs and tables into chunkable text, but does not preserve
+rich formatting, embedded assets, or full page layout fidelity.
 
 ## Getting Help
 

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use async_trait::async_trait;
+use docx_lite::DocxError;
 use pdf_extract::{Document as PdfDocument, Error as PdfError, OutputError as PdfOutputError};
 
 use crate::{RagloomError, RagloomErrorKind};
@@ -31,6 +32,9 @@ pub(crate) fn extract_document_text(path: &str, bytes: Vec<u8>) -> Result<String
     if is_pdf_path(path) {
         return extract_pdf_text(&bytes);
     }
+    if is_docx_path(path) {
+        return extract_docx_text(&bytes);
+    }
 
     String::from_utf8(bytes).map_err(|e| {
         RagloomError::new(RagloomErrorKind::InvalidInput, e)
@@ -39,10 +43,18 @@ pub(crate) fn extract_document_text(path: &str, bytes: Vec<u8>) -> Result<String
 }
 
 fn is_pdf_path(path: &str) -> bool {
+    has_extension(path, "pdf")
+}
+
+fn is_docx_path(path: &str) -> bool {
+    has_extension(path, "docx")
+}
+
+fn has_extension(path: &str, extension: &str) -> bool {
     Path::new(path)
         .extension()
         .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(extension))
 }
 
 fn extract_pdf_text(bytes: &[u8]) -> Result<String, RagloomError> {
@@ -53,6 +65,10 @@ fn extract_pdf_text(bytes: &[u8]) -> Result<String, RagloomError> {
     }
 
     pdf_extract::extract_text_from_mem(bytes).map_err(map_pdf_extract_error)
+}
+
+fn extract_docx_text(bytes: &[u8]) -> Result<String, RagloomError> {
+    docx_lite::extract_text_from_bytes(bytes).map_err(map_docx_extract_error)
 }
 
 fn map_pdf_parse_error(error: PdfError) -> RagloomError {
@@ -66,6 +82,19 @@ fn map_pdf_extract_error(error: PdfOutputError) -> RagloomError {
             "unsupported PDF security handler prevents text extraction"
         }
         _ => "failed to extract PDF text from document bytes",
+    };
+
+    RagloomError::new(RagloomErrorKind::InvalidInput, error).with_context(context)
+}
+
+fn map_docx_extract_error(error: DocxError) -> RagloomError {
+    let context = match &error {
+        DocxError::FileNotFound(path) => format!("DOCX is missing required OOXML part {path}"),
+        DocxError::UnsupportedFormat(message) => {
+            format!("unsupported DOCX format prevents text extraction: {message}")
+        }
+        DocxError::Structure(message) => format!("invalid DOCX structure: {message}"),
+        _ => "failed to extract DOCX text from document bytes".to_string(),
     };
 
     RagloomError::new(RagloomErrorKind::InvalidInput, error).with_context(context)
@@ -94,12 +123,89 @@ impl DocumentLoader for FsUtf8Loader {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::*;
+    use zip::write::FileOptions;
 
     fn write_test_file(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> std::path::PathBuf {
         let path = dir.path().join(name);
         std::fs::write(&path, bytes).expect("write test file");
         path
+    }
+
+    fn minimal_docx_bytes(paragraphs: &[&str]) -> Vec<u8> {
+        let body = paragraphs
+            .iter()
+            .map(|paragraph| format!("<w:p><w:r><w:t>{paragraph}</w:t></w:r></w:p>"))
+            .collect::<String>();
+        let document_xml = format!(
+            concat!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>"#,
+                r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">"#,
+                r#"<w:body>{}</w:body>"#,
+                r#"</w:document>"#
+            ),
+            format!("{body}<w:sectPr/>")
+        );
+
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let options = FileOptions::default();
+        zip.start_file("[Content_Types].xml", options)
+            .expect("start content types");
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#,
+        )
+        .expect("write content types");
+        zip.add_directory("_rels/", options)
+            .expect("add rels directory");
+        zip.start_file("_rels/.rels", options).expect("start rels");
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#,
+        )
+        .expect("write rels");
+        zip.add_directory("word/", options)
+            .expect("add word directory");
+        zip.start_file("word/document.xml", options)
+            .expect("start document xml");
+        zip.write_all(document_xml.as_bytes())
+            .expect("write document xml");
+        zip.finish().expect("finish docx").into_inner()
+    }
+
+    fn docx_without_document_xml_bytes() -> Vec<u8> {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let options = FileOptions::default();
+        zip.start_file("[Content_Types].xml", options)
+            .expect("start content types");
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#,
+        )
+        .expect("write content types");
+        zip.add_directory("_rels/", options)
+            .expect("add rels directory");
+        zip.start_file("_rels/.rels", options).expect("start rels");
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#,
+        )
+        .expect("write rels");
+        zip.finish().expect("finish docx").into_inner()
     }
 
     fn minimal_pdf_bytes(stream: &str) -> Vec<u8> {
@@ -274,6 +380,92 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("encrypted PDFs are not supported for text extraction")
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_extracts_text_from_docx() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(
+            &dir,
+            "hello.docx",
+            &minimal_docx_bytes(&["Hello DOCX", "Second paragraph"]),
+        );
+
+        let loader = FsUtf8Loader;
+        let loaded = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect("load docx");
+
+        assert_eq!(loaded.text, "Hello DOCX\nSecond paragraph\n");
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_returns_empty_string_for_docx_without_extractable_text() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "empty.docx", &minimal_docx_bytes(&[]));
+
+        let loader = FsUtf8Loader;
+        let loaded = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect("load empty docx");
+
+        assert_eq!(loaded.text, "");
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_extracts_docx_text_deterministically() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "stable.docx", &minimal_docx_bytes(&["Stable text"]));
+
+        let loader = FsUtf8Loader;
+        let first = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect("first load");
+        let second = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect("second load");
+
+        assert_eq!(first.text, second.text);
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_rejects_malformed_docx_with_context() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "broken.docx", b"not a zip archive");
+
+        let loader = FsUtf8Loader;
+        let err = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("expected malformed docx to fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("failed to extract DOCX text from document bytes")
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_utf8_loader_rejects_docx_missing_document_xml_with_clear_error() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = write_test_file(&dir, "missing.xml.docx", &docx_without_document_xml_bytes());
+
+        let loader = FsUtf8Loader;
+        let err = loader
+            .load(path.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("expected missing document xml to fail");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("DOCX is missing required OOXML part word/document.xml")
         );
     }
 }

--- a/src/doc/s3.rs
+++ b/src/doc/s3.rs
@@ -50,9 +50,12 @@ impl DocumentLoader for S3Utf8Loader {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::*;
 
     use crate::s3::S3ObjectMeta;
+    use zip::write::FileOptions;
 
     fn minimal_pdf_bytes(stream: &str) -> Vec<u8> {
         let objects = [
@@ -83,6 +86,53 @@ mod tests {
         pdf.push_str("trailer\n<< /Root 1 0 R /Size 6 >>\n");
         pdf.push_str(&format!("startxref\n{xref_offset}\n%%EOF\n"));
         pdf.into_bytes()
+    }
+
+    fn minimal_docx_bytes(paragraphs: &[&str]) -> Vec<u8> {
+        let body = paragraphs
+            .iter()
+            .map(|paragraph| format!("<w:p><w:r><w:t>{paragraph}</w:t></w:r></w:p>"))
+            .collect::<String>();
+        let document_xml = format!(
+            concat!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>"#,
+                r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">"#,
+                r#"<w:body>{}</w:body>"#,
+                r#"</w:document>"#
+            ),
+            format!("{body}<w:sectPr/>")
+        );
+
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let options = FileOptions::default();
+        zip.start_file("[Content_Types].xml", options)
+            .expect("start content types");
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#,
+        )
+        .expect("write content types");
+        zip.add_directory("_rels/", options)
+            .expect("add rels directory");
+        zip.start_file("_rels/.rels", options).expect("start rels");
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#,
+        )
+        .expect("write rels");
+        zip.add_directory("word/", options)
+            .expect("add word directory");
+        zip.start_file("word/document.xml", options)
+            .expect("start document xml");
+        zip.write_all(document_xml.as_bytes())
+            .expect("write document xml");
+        zip.finish().expect("finish docx").into_inner()
     }
 
     #[derive(Debug)]
@@ -204,5 +254,39 @@ mod tests {
             .expect("load pdf");
 
         assert_eq!(loaded.text, "\n\nHello from S3 PDF");
+    }
+
+    #[tokio::test]
+    async fn extracts_docx_text_from_s3_bytes() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: minimal_docx_bytes(&["Hello from S3 DOCX"]),
+            fail_get_object: false,
+        }));
+
+        let loaded = loader
+            .load("s3://docs-bucket/kb/hello.docx")
+            .await
+            .expect("load docx");
+
+        assert_eq!(loaded.text, "Hello from S3 DOCX\n");
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_docx_from_s3_with_context() {
+        let loader = S3Utf8Loader::new(Arc::new(FakeS3Client {
+            bytes: b"not a zip archive".to_vec(),
+            fail_get_object: false,
+        }));
+
+        let err = loader
+            .load("s3://docs-bucket/kb/broken.docx")
+            .await
+            .expect_err("expected malformed docx");
+
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("failed to extract DOCX text from document bytes")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add first-class DOCX ingestion at the existing document loader boundary so local and S3-backed `.docx` files are converted into deterministic chunkable text.

## Related issue

Closes #111

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- add `.docx` dispatch to `extract_document_text()` using `docx-lite`, with project-level `InvalidInput` error mapping for malformed archives and missing `word/document.xml`
- add TDD coverage for local and S3 DOCX loading, including success, empty-text, deterministic repeat loads, malformed bytes, and missing OOXML parts
- update `README.md` and `SUPPORT.md` to list deterministic DOCX text extraction as supported and document the text-only formatting/table limitations

## How to test

1. Run `cargo test docx --lib`
2. Run `cargo test rejects_malformed_docx_from_s3_with_context --lib`
3. Run `cargo qa`

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

DOCX extraction intentionally stays text-only and deterministic. Ragloom linearizes paragraphs with newlines and table cells with tabs, without attempting rich layout reconstruction or embedded asset extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DOCX files can now be processed for deterministic text extraction alongside existing PDF and UTF-8 support, with consistent output across repeated loads.

* **Documentation**
  * Updated README and support documentation to document DOCX extraction behavior, supported use cases, and clear limitations regarding formatting, embedded assets, and layout preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->