### PR TITLE
docs: align v0.4 support boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Docs
+- Aligned the `README.md`, `SUPPORT.md`, and `CHANGELOG.md` support story around
+  the current `v0.4` source and document support matrix instead of the older
+  `v0.3` framing.
+- Added a concrete polling S3 configuration example plus explicit operator
+  limits for PDF text extraction, DOCX text extraction, and out-of-scope remote
+  sources.
+
 ## [0.3.0] - 2026-05-22
 
 ### Docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The local verification commands are:
 
 - `cargo qa`: the fast default contributor gate
 - `cargo maintainer-qa`: the authoritative deeper maintainer gate for
-  release-sensitive and v0.3 stability work
+  release-sensitive and current support-boundary work
 
 `cargo qa` runs:
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ Ragloom is currently alpha software.
 
 It is useful for local-folder to Qdrant ingestion experiments and small automation tasks.
 
-The v0.3 direction is to harden a narrow core instead of widening scope.
+The v0.4 direction is to widen the ingestion surface carefully without losing
+the project's explicit support boundaries.
 
-Core path the project is hardening for v0.3 release-readiness:
+Core path the project is hardening for the current v0.4 support boundary:
 
 - local filesystem source
+- polling S3 source
 - recursive scanning of regular files under one configured directory
-- UTF-8 text, Markdown, source code, PDF files, and deterministic DOCX text extraction
+- UTF-8 text, Markdown, source code, text-extractable PDF loading, and deterministic DOCX text extraction
 - recursive, Markdown-aware, and code-aware chunking
 - OpenAI and generic HTTP embedding APIs
 - Qdrant sink
@@ -56,6 +58,14 @@ Not supported yet:
 
 - persistent dead-letter queues
 - built-in collection lifecycle management
+
+### v0.4 support matrix
+
+| Area | Supported in v0.4 | Explicitly out of scope |
+| --- | --- | --- |
+| sources | local filesystem, polling S3 | non-S3 remote sources |
+| document loading | UTF-8 text, Markdown, source code, embedded-text PDF extraction, deterministic DOCX text extraction | OCR, rich layout reconstruction, broader office-suite parsing |
+| operations | local health endpoint, local metrics endpoint, optional first-run collection bootstrap | non-local operator surfaces, broader collection lifecycle management |
 
 ## Quickstart
 
@@ -216,6 +226,36 @@ Run with:
 
 ```bash
 ragloom --config ./ragloom.yaml --openai-api-key "$OPENAI_API_KEY"
+```
+
+### S3 source configuration
+
+For polling S3 ingestion, use the canonical S3 config shape:
+
+```yaml
+source:
+  kind: "s3"
+  bucket: "docs-bucket"
+  prefix: "kb/"
+
+embed:
+  endpoint: "https://api.openai.com/v1/embeddings"
+
+sink:
+  qdrant_url: "http://localhost:6333"
+  collection: "docs"
+```
+
+Example CLI startup for the same source:
+
+```bash
+ragloom \
+  --source-kind s3 \
+  --s3-bucket docs-bucket \
+  --s3-prefix kb/ \
+  --qdrant-url http://localhost:6333 \
+  --collection docs \
+  --openai-api-key "$OPENAI_API_KEY"
 ```
 
 ### Generic HTTP embedding
@@ -599,13 +639,13 @@ Status: shipped in `v0.2.0`, with restart-safe delete synchronization refined in
 - health endpoint
 - metrics endpoint
 
-### v0.3 - Stability, workflow, and code quality hardening
+### v0.4 - Explicit platform expansion boundaries
 
-- keep the local-filesystem to Qdrant path release-ready on supported Linux and Windows targets
+- keep the local-filesystem and polling-S3 ingest paths release-ready on supported Linux and Windows targets
 - require green `ci` and `quality-deep` workflow states, or equivalent local maintainer verification, before cutting the release
 - keep feature-gated paths such as `fastembed` exercised by dedicated checks without making them the default runtime path
-- document experimental and best-effort boundaries explicitly instead of implying broader parser or platform guarantees
-- defer broader document-format expansion until the existing ingestion path is easier to verify and ship repeatedly
+- document PDF and DOCX extraction limits explicitly instead of implying broader parser guarantees
+- keep remote-source scope narrow by supporting S3 only rather than expanding into a general remote-ingestion platform
 
 ## Limitations
 
@@ -723,7 +763,7 @@ Before opening a pull request, run:
 cargo qa
 ```
 
-Maintainers preparing release-sensitive or v0.3 stability work should also run
+Maintainers preparing release-sensitive or v0.4 support-boundary work should also run
 the authoritative deeper local gate:
 
 ```bash

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -50,9 +50,9 @@ Each published archive also includes a matching `.sha256.txt` checksum file and
 `.spdx.json` SBOM. Release checksums are generated with a platform-aware
 command so Linux targets use `sha256sum` while macOS targets use `shasum -a 256`.
 
-## v0.3 Release Readiness
+## v0.4 Support Readiness
 
-For the stability-focused `v0.3` line, maintainers should treat the following
+For the current `v0.4` support surface, maintainers should treat the following
 as release-blocking for the commit being released:
 
 - `ci` is green for the release commit or release branch tip
@@ -77,7 +77,8 @@ Release after the supported Linux and Windows assets have already published.
 
 ## Feature Boundaries
 
-Core support boundary maintainers are hardening for `v0.3` release-readiness:
+Core support boundary maintainers are hardening for the current `v0.4`
+support boundary:
 
 - local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix
 - UTF-8 text, Markdown, source code, deterministic PDF text loading, and deterministic DOCX text extraction

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -61,7 +61,8 @@ fn changelog_unreleased_mentions_v0_4_docs_alignment() {
     let changelog = read_repo_file("CHANGELOG.md");
 
     assert!(
-        changelog.contains("## [Unreleased]\n\n### Docs\n")
+        changelog.contains("## [Unreleased]")
+            && changelog.contains("### Docs")
             && changelog.contains("v0.4")
             && changelog.contains("support matrix"),
         "expected the unreleased changelog to record the v0.4 docs alignment work"

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -1,0 +1,69 @@
+use std::fs;
+use std::path::Path;
+
+fn read_repo_file(path: &str) -> String {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(repo_root.join(path)).expect("read repository file")
+}
+
+#[test]
+fn readme_describes_v0_4_sources_formats_and_s3_example() {
+    let readme = read_repo_file("README.md");
+
+    assert!(
+        readme.contains("v0.4"),
+        "expected README to frame the current support story around v0.4"
+    );
+    assert!(
+        readme.contains("local filesystem source")
+            && readme.contains("kind: \"filesystem\"")
+            && readme.contains("root: \"./docs\"")
+            && readme.contains("source.kind: s3"),
+        "expected README to document both filesystem and S3 source shapes with concrete examples"
+    );
+    assert!(
+        readme.contains("PDF extraction is text-only")
+            && readme.contains("DOCX extraction is also text-only"),
+        "expected README to keep the PDF and DOCX loader limits explicit"
+    );
+    assert!(
+        readme.contains("bucket: \"docs-bucket\"") && readme.contains("prefix: \"kb/\""),
+        "expected README to include a concrete S3 configuration example"
+    );
+}
+
+#[test]
+fn support_policy_describes_current_v0_4_support_boundary() {
+    let support = read_repo_file("SUPPORT.md");
+
+    assert!(
+        support.contains("v0.4"),
+        "expected SUPPORT.md to describe the current support boundary in v0.4 terms"
+    );
+    assert!(
+        support.contains("local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix"),
+        "expected SUPPORT.md to describe both supported source shapes"
+    );
+    assert!(
+        support.contains("deterministic PDF text loading")
+            && support.contains("deterministic DOCX text extraction"),
+        "expected SUPPORT.md to keep PDF and DOCX support boundaries explicit"
+    );
+    assert!(
+        support.contains("Current PDF support is limited to embedded text extraction")
+            && support.contains("Current DOCX support is limited to deterministic extracted text"),
+        "expected SUPPORT.md to preserve the parser limitation details"
+    );
+}
+
+#[test]
+fn changelog_unreleased_mentions_v0_4_docs_alignment() {
+    let changelog = read_repo_file("CHANGELOG.md");
+
+    assert!(
+        changelog.contains("## [Unreleased]\n\n### Docs\n")
+            && changelog.contains("v0.4")
+            && changelog.contains("support matrix"),
+        "expected the unreleased changelog to record the v0.4 docs alignment work"
+    );
+}


### PR DESCRIPTION
## Summary

Align the issue #112 docs story around the current v0.4 support surface so the repository describes the shipped S3/PDF/DOCX boundaries consistently.

## Related issue

Closes #112

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- updated `README.md` status and roadmap framing from the older v0.3 language to the current v0.4 support-boundary story
- added an explicit v0.4 support matrix plus a concrete polling S3 configuration example and CLI invocation
- aligned `SUPPORT.md`, `CHANGELOG.md`, and `CONTRIBUTING.md` wording with the current support surface and added a docs contract test to guard the matrix/examples

## How to test

1. Run `cargo test --test docs_support_contract`
2. Run `cargo qa`
3. Review `README.md` and `SUPPORT.md` to confirm they explicitly bound S3/PDF/DOCX support without claiming broader parser or remote-source coverage

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This keeps the docs version framing on `v0.4` while intentionally not changing release artifact examples or the crate version, because the repository is still at `0.3.0` today.