### PR TITLE
fix: restore fastembed fork PR checkout

### DIFF
--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ github.ref }}
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -220,6 +220,16 @@ fn quality_deep_workflow_exposes_pre_merge_stability_gate() {
     let loom_yaml = serde_yaml::to_string(loom).expect("serialize loom job");
     let docs_and_security_yaml =
         serde_yaml::to_string(docs_and_security).expect("serialize docs-and-security job");
+    let fastembed_steps = fastembed
+        .get(serde_yaml::Value::String("steps".to_string()))
+        .and_then(serde_yaml::Value::as_sequence)
+        .expect("expected fastembed job to define steps");
+    let fastembed_checkout = fastembed_steps
+        .iter()
+        .find(|step| step.get("name").and_then(serde_yaml::Value::as_str) == Some("Checkout"))
+        .expect("expected fastembed job to define a Checkout step");
+    let fastembed_checkout_yaml =
+        serde_yaml::to_string(fastembed_checkout).expect("serialize fastembed checkout step");
 
     assert!(
         fastembed_yaml.contains("cargo build --features fastembed")
@@ -235,6 +245,18 @@ fn quality_deep_workflow_exposes_pre_merge_stability_gate() {
             && docs_and_security_yaml.contains("cargo audit")
             && docs_and_security_yaml.contains("cargo doc --workspace --no-deps"),
         "expected PR-visible stability checks to cover docs, cargo-deny, and cargo-audit"
+    );
+    assert!(
+        fastembed_checkout_yaml.contains("persist-credentials: false"),
+        "expected fastembed checkout to preserve disabled credential persistence"
+    );
+    assert!(
+        fastembed_checkout_yaml.contains("ref: ${{ github.ref }}"),
+        "expected fastembed checkout to pin pull_request runs to the merge ref explicitly"
+    );
+    assert!(
+        !workflow_yaml.contains("pull_request_target"),
+        "expected deep quality workflow to avoid pull_request_target for PR code execution"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes the `fastembed` checkout path in `quality-deep.yml` so fork-based PR runs keep testing the merge ref without re-enabling credential persistence.

## Related issue

Closes #116

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [x] Build / CI change
- [ ] Other

## Changes made

- add a workflow contract assertion that `fastembed` keeps `persist-credentials: false` and explicitly checks out the PR merge ref
- pin the `fastembed` checkout step to `${{ github.ref }}` so fork PR runs use the merge ref explicitly
- keep the workflow on `pull_request` instead of widening to `pull_request_target`

## How to test

1. Run `cargo test --test release_workflow_contract`.
2. Run `cargo qa`.
3. Verify the `fastembed` job checks out cleanly on a fork-based PR run in GitHub Actions.

## Screenshots or recordings

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [ ] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

- Local verification covered the repository workflow contract tests and `cargo qa`.
- A real fork-PR GitHub Actions run is still the remaining end-to-end confirmation for the checkout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration for improved release stability and security verification processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ragloom/ragloom/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->