### PR TITLE
fix: persist and replay exhausted failed work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+- Persistent local failed-work journal at `failed.ndjson` beside the WAL so
+  exhausted or terminal ingest work can be inspected and operator-replayed
+  without changing WAL acknowledgement or startup replay semantics.
+- Minimal `replay-failed` CLI command that requeues pending failed work back
+  into the WAL using only `--state-path` or `--config`.
+
+### Changed
+- Retry exhaustion no longer stops at logs and counters: worker terminal
+  failures now persist a sanitized failure class plus the original scheduled
+  work record, without recording secrets or full document contents.
+
 ## [0.4.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Experimental or best-effort paths:
 
 Not supported yet:
 
-- persistent dead-letter queues
+- broad job-management or dead-letter queue subsystems beyond the local failed-work journal
 - built-in collection lifecycle management
 
 ### v0.4 support matrix
@@ -430,6 +430,36 @@ Retries are not persisted as separate WAL records. If the process stops while
 retries are queued, unacknowledged work is replayed from the WAL on the next
 startup.
 
+When a work item exhausts retries or fails terminally without retry, Ragloom
+also appends a sanitized failed-work record to `failed.ndjson` in the same
+directory as the WAL. Failed-work records include the original scheduled
+`WalRecord`, retry attempt count, and a small failure classification only; they
+do not include secrets, embedding payloads, or full document contents.
+
+Inspect failed work directly from the local NDJSON file, for example:
+
+```bash
+cat .ragloom/failed.ndjson
+```
+
+To requeue pending failed work back into the WAL for operator replay, run:
+
+```bash
+ragloom replay-failed --state-path .ragloom/wal.ndjson
+```
+
+Or, if you already keep the state path in YAML:
+
+```bash
+ragloom replay-failed --config ./ragloom.yaml
+```
+
+`replay-failed` requires either `--state-path` or `--config`. It does not require
+runtime ingest flags such as `--dir`, `--qdrant-url`, or `--collection`.
+Replay is intentionally at-least-once: if a prior replay appended work into the
+WAL but crashed before marking the failed record requeued, rerunning
+`replay-failed` may append that work again rather than silently losing it.
+
 ## Architecture
 
 ```text
@@ -768,7 +798,7 @@ Do not share command output if it includes credentials or other sensitive respon
 - only Qdrant as a built-in sink
 - only UTF-8 text, Markdown, source code, text-extractable PDF loading, and deterministic DOCX text extraction
 - no general collection lifecycle management beyond optional first-run bootstrap
-- no persistent dead-letter queue yet
+- no broad persistent dead-letter queue or job-management subsystem
 
 ## Contributing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -662,6 +662,7 @@ fn build_replay_failed_config(raw: RawCliArgs) -> Result<ReplayFailedConfig, Rag
         ));
     }
 
+    let config_provided = raw.config_path.is_some();
     let file_state_path = raw
         .config_path
         .as_deref()
@@ -669,10 +670,16 @@ fn build_replay_failed_config(raw: RawCliArgs) -> Result<ReplayFailedConfig, Rag
         .transpose()?
         .and_then(|cfg| cfg.state.map(|state| state.path));
 
+    if raw.state_path.is_none() && config_provided && file_state_path.is_none() {
+        return Err(cli_config_error(
+            "replay-failed requires state.path in --config or an explicit --state-path",
+        ));
+    }
+
     let state_path = raw
         .state_path
         .or(file_state_path)
-        .unwrap_or_else(|| DEFAULT_STATE_PATH.to_string());
+        .ok_or_else(|| cli_config_error("replay-failed requires --state-path or --config"))?;
 
     if state_path.trim().is_empty() {
         return Err(cli_config_error("--state-path or state.path is empty"));
@@ -2357,6 +2364,28 @@ state:
             ParsedCommand::ReplayFailed(ReplayFailedConfig {
                 state_path: ".state/from-config.ndjson".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn parse_args_replay_failed_rejects_config_without_state_path() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(b"chunking:\n  strategy: recursive\n")
+            .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "replay-failed".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("must reject config without state.path");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(
+            err.to_string().contains(
+                "replay-failed requires state.path in --config or an explicit --state-path"
+            )
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,15 +15,20 @@ use ragloom::observability::health::{HealthServer, HealthState};
 use ragloom::observability::metrics::IngestionMetrics;
 use ragloom::pipeline::runtime::{
     AckingExecutor, AsyncRuntime, IngestionSummary, LiveRetryPolicy, PipelineExecutor, RetryPolicy,
-    Runtime, RuntimeExitReason, run_worker_with_live_retry_and_metrics,
+    Runtime, RuntimeExitReason, run_worker_with_live_retry_failed_work_and_metrics,
 };
 use ragloom::sink::qdrant::{QdrantConfig, QdrantSink};
-use ragloom::source::runtime::{RunSource, USAGE, prepare_source_runtime, resolve_run_source};
+use ragloom::source::runtime::{RunSource, prepare_source_runtime, resolve_run_source};
+use ragloom::state::failed::{
+    FailedWorkJournal, FailedWorkRecord, FileFailedWorkStore, failed_work_path_from_state_path,
+    pending_failed_work,
+};
 
 #[cfg(test)]
 mod test_support;
 
 const CONFIG_RELOAD_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const CLI_USAGE: &str = "usage: ragloom [check|dry-run|replay-failed] [--config <path>] [--source-kind <filesystem|s3>] [--dir <path>] [--s3-bucket <name>] [--s3-prefix <prefix>] --qdrant-url <url> --collection <name> [--state-path <path>] [--health-addr <host:port>] [--retry-max-attempts <n>] [--embed-backend <openai|http>] (omit command to run ingestion)";
 
 /// Runtime configuration constructed from CLI arguments.
 ///
@@ -57,6 +62,11 @@ pub struct RunConfig {
     pub retry_max_backoff_ms: u64,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ReplayFailedConfig {
+    pub state_path: String,
+}
+
 /// Top-level CLI command selected by argument parsing.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ParsedCommand {
@@ -65,6 +75,7 @@ pub enum ParsedCommand {
     Run(Box<RunConfig>),
     Check(Box<RunConfig>),
     DryRun(Box<RunConfig>),
+    ReplayFailed(ReplayFailedConfig),
     Help,
     Version,
 }
@@ -109,6 +120,7 @@ enum RawParsedCommand {
     Run(Box<RawCliArgs>),
     Check(Box<RawCliArgs>),
     DryRun(Box<RawCliArgs>),
+    ReplayFailed(Box<RawCliArgs>),
     Help,
     Version,
 }
@@ -162,6 +174,9 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
                 file_config.as_ref(),
             )?)))
         }
+        RawParsedCommand::ReplayFailed(raw) => Ok(ParsedCommand::ReplayFailed(
+            build_replay_failed_config(*raw)?,
+        )),
         RawParsedCommand::Run(raw) => {
             let file_config = raw
                 .config_path
@@ -185,7 +200,7 @@ fn parse_reload_run_config_from_contents(
         RawParsedCommand::Run(raw)
         | RawParsedCommand::Check(raw)
         | RawParsedCommand::DryRun(raw) => *raw,
-        RawParsedCommand::Help | RawParsedCommand::Version => {
+        RawParsedCommand::ReplayFailed(_) | RawParsedCommand::Help | RawParsedCommand::Version => {
             return Err(
                 RagloomError::from_kind(RagloomErrorKind::Config).with_context(format!(
                     "config reload expected runtime command for {}",
@@ -209,9 +224,10 @@ fn parse_raw_cli_args(args: &[String]) -> Result<RawParsedCommand, RagloomError>
         command = match arg.as_str() {
             "check" => "check",
             "dry-run" => "dry-run",
+            "replay-failed" => "replay-failed",
             other => {
                 return Err(cli_invalid_input(format!(
-                    "unknown command: {other} (expected: check|dry-run, or omit command to run ingestion)"
+                    "unknown command: {other} (expected: check|dry-run|replay-failed, or omit command to run ingestion)"
                 )));
             }
         };
@@ -294,6 +310,7 @@ fn parse_raw_cli_args(args: &[String]) -> Result<RawParsedCommand, RagloomError>
         "run" => RawParsedCommand::Run(Box::new(raw)),
         "check" => RawParsedCommand::Check(Box::new(raw)),
         "dry-run" => RawParsedCommand::DryRun(Box::new(raw)),
+        "replay-failed" => RawParsedCommand::ReplayFailed(Box::new(raw)),
         _ => unreachable!("validated command"),
     })
 }
@@ -625,6 +642,123 @@ fn build_run_config(
     })
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct ReplayFailedFileConfig {
+    #[serde(default)]
+    state: Option<ReplayFailedStateConfig>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ReplayFailedStateConfig {
+    path: String,
+}
+
+fn build_replay_failed_config(raw: RawCliArgs) -> Result<ReplayFailedConfig, RagloomError> {
+    ensure_replay_failed_flags_supported(&raw)?;
+
+    if raw.state_path.is_none() && raw.config_path.is_none() {
+        return Err(cli_config_error(
+            "replay-failed requires --state-path or --config",
+        ));
+    }
+
+    let file_state_path = raw
+        .config_path
+        .as_deref()
+        .map(load_replay_failed_file_config)
+        .transpose()?
+        .and_then(|cfg| cfg.state.map(|state| state.path));
+
+    let state_path = raw
+        .state_path
+        .or(file_state_path)
+        .unwrap_or_else(|| DEFAULT_STATE_PATH.to_string());
+
+    if state_path.trim().is_empty() {
+        return Err(cli_config_error("--state-path or state.path is empty"));
+    }
+
+    Ok(ReplayFailedConfig { state_path })
+}
+
+fn ensure_replay_failed_flags_supported(raw: &RawCliArgs) -> Result<(), RagloomError> {
+    let unsupported = [
+        raw.source_kind.as_ref().map(|_| "--source-kind"),
+        raw.dir.as_ref().map(|_| "--dir"),
+        raw.s3_bucket.as_ref().map(|_| "--s3-bucket"),
+        raw.s3_prefix.as_ref().map(|_| "--s3-prefix"),
+        raw.embed_backend.as_ref().map(|_| "--embed-backend"),
+        raw.embed_url.as_ref().map(|_| "--embed-url"),
+        raw.embed_model.as_ref().map(|_| "--embed-model"),
+        raw.openai_endpoint.as_ref().map(|_| "--openai-endpoint"),
+        raw.openai_api_key.as_ref().map(|_| "--openai-api-key"),
+        raw.openai_model.as_ref().map(|_| "--openai-model"),
+        raw.qdrant_url.as_ref().map(|_| "--qdrant-url"),
+        raw.collection.as_ref().map(|_| "--collection"),
+        raw.health_addr.as_ref().map(|_| "--health-addr"),
+        raw.collection_vector_size
+            .as_ref()
+            .map(|_| "--collection-vector-size"),
+        raw.chunker_strategy.as_ref().map(|_| "--chunker-strategy"),
+        raw.size_metric.as_ref().map(|_| "--size-metric"),
+        raw.size_max.as_ref().map(|_| "--size-max"),
+        raw.size_min.as_ref().map(|_| "--size-min"),
+        raw.size_overlap.as_ref().map(|_| "--size-overlap"),
+        raw.tokenizer.as_ref().map(|_| "--tokenizer"),
+        raw.chunker_mode.as_ref().map(|_| "--chunker-mode"),
+        raw.chunker_single.as_ref().map(|_| "--chunker-single"),
+        raw.semantic_provider
+            .as_ref()
+            .map(|_| "--semantic-provider"),
+        raw.semantic_percentile
+            .as_ref()
+            .map(|_| "--semantic-percentile"),
+        raw.retry_max_attempts
+            .as_ref()
+            .map(|_| "--retry-max-attempts"),
+        raw.retry_max_queued.as_ref().map(|_| "--retry-max-queued"),
+        raw.retry_initial_backoff_ms
+            .as_ref()
+            .map(|_| "--retry-initial-backoff-ms"),
+        raw.retry_max_backoff_ms
+            .as_ref()
+            .map(|_| "--retry-max-backoff-ms"),
+    ]
+    .into_iter()
+    .flatten()
+    .next();
+
+    if raw.create_collection_if_missing {
+        return Err(cli_invalid_input(
+            "replay-failed only accepts --config and --state-path",
+        ));
+    }
+    if raw.enable_semantic {
+        return Err(cli_invalid_input(
+            "replay-failed only accepts --config and --state-path",
+        ));
+    }
+    if unsupported.is_some() {
+        return Err(cli_invalid_input(
+            "replay-failed only accepts --config and --state-path",
+        ));
+    }
+
+    Ok(())
+}
+
+fn load_replay_failed_file_config(path: &str) -> Result<ReplayFailedFileConfig, RagloomError> {
+    let yaml = std::fs::read_to_string(path).map_err(|e| {
+        RagloomError::new(RagloomErrorKind::Io, e)
+            .with_context(format!("failed to read config file: {path}"))
+    })?;
+
+    serde_yaml::from_str(&yaml).map_err(|e| {
+        RagloomError::from_kind(RagloomErrorKind::Config)
+            .with_context(format!("failed to parse config file: {path}: {e}"))
+    })
+}
+
 fn load_pipeline_config(path: &str) -> Result<PipelineConfig, RagloomError> {
     let yaml = std::fs::read_to_string(path).map_err(|e| {
         RagloomError::new(RagloomErrorKind::Io, e)
@@ -640,7 +774,7 @@ fn load_pipeline_config(path: &str) -> Result<PipelineConfig, RagloomError> {
 fn cli_invalid_input(message: impl Into<String>) -> RagloomError {
     let message = message.into();
     RagloomError::from_kind(RagloomErrorKind::InvalidInput)
-        .with_context(format!("{message}\n{USAGE}"))
+        .with_context(format!("{message}\n{CLI_USAGE}"))
 }
 
 fn validate_boolean_flag(
@@ -666,7 +800,8 @@ where
 
 fn cli_config_error(message: impl Into<String>) -> RagloomError {
     let message = message.into();
-    RagloomError::from_kind(RagloomErrorKind::Config).with_context(format!("{message}\n{USAGE}"))
+    RagloomError::from_kind(RagloomErrorKind::Config)
+        .with_context(format!("{message}\n{CLI_USAGE}"))
 }
 
 fn parse_code_lang(s: &str) -> Result<ragloom::transform::chunker::code::Language, RagloomError> {
@@ -1063,7 +1198,7 @@ async fn try_main() -> Result<(), RagloomError> {
     let args: Vec<String> = std::env::args().collect();
     let cfg = match parse_args(&args)? {
         ParsedCommand::Help => {
-            println!("{USAGE}");
+            println!("{CLI_USAGE}");
             return Ok(());
         }
         ParsedCommand::Version => {
@@ -1078,6 +1213,11 @@ async fn try_main() -> Result<(), RagloomError> {
         ParsedCommand::DryRun(cfg) => {
             let summary = validate_startup(&cfg).await?;
             println!("{}", summary.render());
+            return Ok(());
+        }
+        ParsedCommand::ReplayFailed(cfg) => {
+            let replayed = replay_failed_command(&cfg).await?;
+            println!("ragloom replay-failed requeued {replayed} work items");
             return Ok(());
         }
         ParsedCommand::Run(cfg) => *cfg,
@@ -1191,6 +1331,47 @@ async fn try_main() -> Result<(), RagloomError> {
     }
 }
 
+async fn replay_failed_command(cfg: &ReplayFailedConfig) -> Result<usize, RagloomError> {
+    let failed_path = failed_work_path_from_state_path(&cfg.state_path);
+    let mut wal = ragloom::state::wal::FileWal::open(&cfg.state_path)
+        .map_err(|e| e.with_context("failed to initialize persistent WAL"))?;
+    let mut failed_store = FileFailedWorkStore::open(&failed_path)
+        .map_err(|e| e.with_context("failed to initialize failed-work store"))?;
+
+    replay_failed_into_wal(&mut wal, &mut failed_store)
+}
+
+fn replay_failed_into_wal(
+    wal: &mut impl ragloom::state::wal::WalStore,
+    failed_store: &mut impl ragloom::state::failed::FailedWorkStore,
+) -> Result<usize, RagloomError> {
+    let records = failed_store
+        .read_all()
+        .map_err(|e| e.with_context("failed to read failed-work store"))?;
+
+    let pending = pending_failed_work(&records);
+    let replayed = pending.len();
+    for item in pending {
+        wal.append(item.work.clone())
+            .map_err(|e| e.with_context("failed to append replayed work into WAL"))?;
+        failed_store
+            .append(FailedWorkRecord::Requeued {
+                exhausted_id: item.id,
+            })
+            .map_err(|e| e.with_context("failed to mark failed work as requeued"))?;
+
+        tracing::info!(
+            event.name = "ragloom.failed_work.requeued",
+            exhausted_id = item.id,
+            terminal_reason = ?item.terminal_reason,
+            attempts = item.attempts,
+            "ragloom.failed_work.requeued"
+        );
+    }
+
+    Ok(replayed)
+}
+
 async fn start_running_system(cfg: &RunConfig) -> Result<RunningSystem, RagloomError> {
     let health_state = HealthState::starting();
     let metrics = IngestionMetrics::default();
@@ -1225,6 +1406,17 @@ async fn start_running_system(cfg: &RunConfig) -> Result<RunningSystem, RagloomE
             return Err(err);
         }
     };
+    let failed_work =
+        match FileFailedWorkStore::open(failed_work_path_from_state_path(&cfg.state_path))
+            .map(FailedWorkJournal::new)
+            .map_err(|e| e.with_context("failed to initialize failed-work store"))
+        {
+            Ok(store) => Some(store),
+            Err(err) => {
+                health_state.mark_startup_failed();
+                return Err(err);
+            }
+        };
 
     let previously_observed_paths = {
         let guard = wal.lock().await;
@@ -1281,12 +1473,14 @@ async fn start_running_system(cfg: &RunConfig) -> Result<RunningSystem, RagloomE
     let summary_for_worker = summary.clone();
     let metrics_for_worker = metrics.clone();
     let live_retry_policy_for_worker = live_retry_policy.clone();
+    let failed_work_for_worker = failed_work.clone();
 
     let worker = tokio::spawn(async move {
-        run_worker_with_live_retry_and_metrics(
+        run_worker_with_live_retry_failed_work_and_metrics(
             queue,
             executor,
             live_retry_policy_for_worker,
+            failed_work_for_worker,
             Some(summary_for_worker),
             Some(metrics_for_worker),
         )
@@ -2119,6 +2313,79 @@ sink:
 
         let cmd = parse_args(&args).expect("help command");
         assert_eq!(cmd, ParsedCommand::Help);
+    }
+
+    #[test]
+    fn parse_args_returns_replay_failed_command() {
+        let args = vec![
+            "ragloom".to_string(),
+            "replay-failed".to_string(),
+            "--state-path".to_string(),
+            ".state/ragloom.ndjson".to_string(),
+        ];
+
+        let cmd = parse_args(&args).expect("replay-failed command");
+        assert_eq!(
+            cmd,
+            ParsedCommand::ReplayFailed(ReplayFailedConfig {
+                state_path: ".state/ragloom.ndjson".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_args_replay_failed_reads_state_path_from_config_only() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(
+            br#"
+state:
+  path: ".state/from-config.ndjson"
+"#,
+        )
+        .expect("write config");
+
+        let args = vec![
+            "ragloom".to_string(),
+            "replay-failed".to_string(),
+            "--config".to_string(),
+            file.path().to_string_lossy().to_string(),
+        ];
+
+        let cmd = parse_args(&args).expect("replay-failed command");
+        assert_eq!(
+            cmd,
+            ParsedCommand::ReplayFailed(ReplayFailedConfig {
+                state_path: ".state/from-config.ndjson".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_args_replay_failed_rejects_runtime_flags() {
+        let args = vec![
+            "ragloom".to_string(),
+            "replay-failed".to_string(),
+            "--state-path".to_string(),
+            ".state/ragloom.ndjson".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("must reject runtime flags");
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(err.to_string().contains("replay-failed only accepts"));
+    }
+
+    #[test]
+    fn parse_args_replay_failed_requires_state_path_or_config() {
+        let args = vec!["ragloom".to_string(), "replay-failed".to_string()];
+
+        let err = parse_args(&args).expect_err("must require explicit replay input");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(
+            err.to_string()
+                .contains("replay-failed requires --state-path or --config")
+        );
     }
 
     #[test]
@@ -3228,5 +3495,108 @@ sink:
         let err = parse_args(&args).expect_err("should fail parse");
         assert_eq!(err.kind, RagloomErrorKind::Config);
         assert!(err.to_string().contains("failed to parse config file"));
+    }
+
+    #[test]
+    fn replay_failed_into_wal_appends_original_work_and_marks_requeued() {
+        let mut wal = ragloom::state::wal::InMemoryWal::new();
+        let mut failed = ragloom::state::failed::InMemoryFailedWorkStore::new();
+        let work = ragloom::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: ragloom::ids::FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: None,
+            },
+        };
+
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: work.clone(),
+                failure_kind: ragloom::state::failed::FailedWorkFailureKind::Embed,
+                terminal_reason: ragloom::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            })
+            .expect("append exhausted");
+
+        let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
+        assert_eq!(replayed, 1);
+        assert_eq!(wal.read_all().expect("read wal"), vec![work]);
+        assert_eq!(
+            failed.read_all().expect("read failed"),
+            vec![
+                FailedWorkRecord::Exhausted {
+                    id: 1,
+                    work: ragloom::state::wal::WalRecord::WorkItemV2 {
+                        fingerprint: ragloom::ids::FileFingerprint {
+                            canonical_path: "/x/a.txt".to_string(),
+                            size_bytes: 10,
+                            mtime_unix_secs: 100,
+                            etag: None,
+                        },
+                    },
+                    failure_kind: ragloom::state::failed::FailedWorkFailureKind::Embed,
+                    terminal_reason:
+                        ragloom::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                    attempts: 2,
+                },
+                FailedWorkRecord::Requeued { exhausted_id: 1 },
+            ]
+        );
+    }
+
+    #[test]
+    fn replay_failed_into_wal_skips_already_requeued_entries() {
+        let mut wal = ragloom::state::wal::InMemoryWal::new();
+        let mut failed = ragloom::state::failed::InMemoryFailedWorkStore::new();
+
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: ragloom::state::wal::WalRecord::DeleteDocument {
+                    canonical_path: "/x/a.txt".to_string(),
+                },
+                failure_kind: ragloom::state::failed::FailedWorkFailureKind::InvalidInput,
+                terminal_reason: ragloom::state::failed::FailedWorkTerminalReason::NonRetryable,
+                attempts: 1,
+            })
+            .expect("append exhausted");
+        failed
+            .append(FailedWorkRecord::Requeued { exhausted_id: 1 })
+            .expect("append requeued");
+
+        let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
+        assert_eq!(replayed, 0);
+        assert!(wal.read_all().expect("read wal").is_empty());
+    }
+
+    #[test]
+    fn replay_failed_into_wal_is_at_least_once_after_partial_prior_replay() {
+        let mut wal = ragloom::state::wal::InMemoryWal::new();
+        let mut failed = ragloom::state::failed::InMemoryFailedWorkStore::new();
+        let work = ragloom::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: ragloom::ids::FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: None,
+            },
+        };
+
+        wal.append(work.clone()).expect("append prior replay");
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: work.clone(),
+                failure_kind: ragloom::state::failed::FailedWorkFailureKind::Embed,
+                terminal_reason: ragloom::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            })
+            .expect("append exhausted");
+
+        let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
+        assert_eq!(replayed, 1);
+        assert_eq!(wal.read_all().expect("read wal"), vec![work.clone(), work]);
     }
 }

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -9,9 +9,7 @@ use crate::error::{RagloomError, RagloomErrorKind};
 use crate::observability::metrics::IngestionMetrics;
 use crate::pipeline::planner::Planner;
 use crate::source::Source;
-use crate::state::failed::{
-    FailedWorkFailureKind, FailedWorkJournal, FailedWorkRecord, FailedWorkTerminalReason,
-};
+use crate::state::failed::{FailedWorkFailureKind, FailedWorkJournal, FailedWorkTerminalReason};
 use crate::state::wal::{InMemoryWal, WalRecord, WalStore, unacked_work_items};
 
 use std::collections::VecDeque;
@@ -656,38 +654,23 @@ async fn run_worker_with_retry_inner(
                         FailedWorkTerminalReason::NonRetryable
                     };
 
-                    match failed_work.next_id().await {
-                        Ok(id) => {
-                            if let Err(persist_err) = failed_work
-                                .append(FailedWorkRecord::Exhausted {
-                                    id,
-                                    work: record.clone(),
-                                    failure_kind: FailedWorkFailureKind::from_error_kind(err.kind),
-                                    terminal_reason,
-                                    attempts: attempt,
-                                })
-                                .await
-                            {
-                                tracing::error!(
-                                    event.name = "ragloom.failed_work.persist_failed",
-                                    record_type,
-                                    canonical_path = canonical_path,
-                                    error.kind = %persist_err.kind,
-                                    error.message = %persist_err,
-                                    "ragloom.failed_work.persist_failed"
-                                );
-                            }
-                        }
-                        Err(persist_err) => {
-                            tracing::error!(
-                                event.name = "ragloom.failed_work.read_failed",
-                                record_type,
-                                canonical_path = canonical_path,
-                                error.kind = %persist_err.kind,
-                                error.message = %persist_err,
-                                "ragloom.failed_work.read_failed"
-                            );
-                        }
+                    if let Err(persist_err) = failed_work
+                        .append_exhausted(
+                            record.clone(),
+                            FailedWorkFailureKind::from_error_kind(err.kind),
+                            terminal_reason,
+                            attempt,
+                        )
+                        .await
+                    {
+                        tracing::error!(
+                            event.name = "ragloom.failed_work.persist_failed",
+                            record_type,
+                            canonical_path = canonical_path,
+                            error.kind = %persist_err.kind,
+                            error.message = %persist_err,
+                            "ragloom.failed_work.persist_failed"
+                        );
                     }
                 }
 

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -9,6 +9,9 @@ use crate::error::{RagloomError, RagloomErrorKind};
 use crate::observability::metrics::IngestionMetrics;
 use crate::pipeline::planner::Planner;
 use crate::source::Source;
+use crate::state::failed::{
+    FailedWorkFailureKind, FailedWorkJournal, FailedWorkRecord, FailedWorkTerminalReason,
+};
 use crate::state::wal::{InMemoryWal, WalRecord, WalStore, unacked_work_items};
 
 use std::collections::VecDeque;
@@ -494,7 +497,7 @@ struct RetryItem {
 /// processing (executor), making backpressure and shutdown behavior easy to test.
 pub async fn run_worker(mut queue: WorkQueue, executor: impl WorkExecutor) {
     let live_policy = LiveRetryPolicy::new(RetryPolicy::disabled()).expect("disabled policy");
-    run_worker_with_retry_inner(&mut queue, executor, live_policy, None, None).await;
+    run_worker_with_retry_inner(&mut queue, executor, live_policy, None, None, None).await;
 }
 
 /// Runs a worker loop with a bounded in-process retry queue.
@@ -529,7 +532,7 @@ pub async fn run_worker_with_retry_and_metrics(
         return;
     }
     let live_policy = LiveRetryPolicy::new(policy).expect("validated retry policy");
-    run_worker_with_retry_inner(&mut queue, executor, live_policy, summary, metrics).await;
+    run_worker_with_retry_inner(&mut queue, executor, live_policy, None, summary, metrics).await;
 }
 
 pub async fn run_worker_with_live_retry_and_metrics(
@@ -539,13 +542,25 @@ pub async fn run_worker_with_live_retry_and_metrics(
     summary: Option<IngestionSummary>,
     metrics: Option<IngestionMetrics>,
 ) {
-    run_worker_with_retry_inner(&mut queue, executor, policy, summary, metrics).await;
+    run_worker_with_retry_inner(&mut queue, executor, policy, None, summary, metrics).await;
+}
+
+pub async fn run_worker_with_live_retry_failed_work_and_metrics(
+    mut queue: WorkQueue,
+    executor: impl WorkExecutor,
+    policy: LiveRetryPolicy,
+    failed_work: Option<FailedWorkJournal>,
+    summary: Option<IngestionSummary>,
+    metrics: Option<IngestionMetrics>,
+) {
+    run_worker_with_retry_inner(&mut queue, executor, policy, failed_work, summary, metrics).await;
 }
 
 async fn run_worker_with_retry_inner(
     queue: &mut WorkQueue,
     executor: impl WorkExecutor,
     policy: LiveRetryPolicy,
+    failed_work: Option<FailedWorkJournal>,
     summary: Option<IngestionSummary>,
     metrics: Option<IngestionMetrics>,
 ) {
@@ -596,69 +611,108 @@ async fn run_worker_with_retry_inner(
         };
         let canonical_path = canonical_path.as_deref();
 
-        tracing::info_span!(
+        if let Err(err) = tracing::info_span!(
             "ragloom.worker.execute",
             record_type,
             canonical_path = canonical_path,
             retry.attempt = attempt,
             retry.max_attempts = policy_snapshot.max_attempts,
         )
-        .in_scope(|| executor.execute(record.clone()))
+        .in_scope(|| async { executor.execute(record.clone()).await })
         .await
-        .map_or_else(
-            |err| {
-                let retryable = is_retryable_error_kind(err.kind);
-                let should_retry = policy_snapshot.should_retry(&err, attempt);
-                if should_retry && retries.len() < policy_snapshot.max_queued_retries {
-                    let next_attempt = attempt + 1;
-                    let delay = policy_snapshot.delay_before_attempt(next_attempt);
-                    tracing::warn!(
-                        event.name = "ragloom.retry.scheduled",
-                        record_type,
-                        canonical_path = canonical_path,
-                        retry.attempt = attempt,
-                        retry.next_attempt = next_attempt,
-                        retry.max_attempts = policy_snapshot.max_attempts,
-                        retry.backoff_ms = delay.as_millis() as u64,
-                        retry.queue_len = retries.len() + 1,
-                        retry.max_queued_retries = policy_snapshot.max_queued_retries,
-                        error.kind = %err.kind,
-                        error.message = %err,
-                        "ragloom.retry.scheduled"
-                    );
-                    if let Some(metrics) = &metrics {
-                        metrics.record_retry_scheduled(retries.len() + 1);
-                    }
-                    retries.push_back(RetryItem {
-                        record,
-                        attempt: next_attempt,
-                        delay,
-                    });
-                } else {
-                    if let Some(summary) = &summary {
-                        summary.record_failure();
-                    }
-                    if let Some(metrics) = &metrics {
-                        metrics.record_failure();
-                        if retryable {
-                            metrics.record_retry_exhausted(retries.len());
+        {
+            let retryable = is_retryable_error_kind(err.kind);
+            let should_retry = policy_snapshot.should_retry(&err, attempt);
+            if should_retry && retries.len() < policy_snapshot.max_queued_retries {
+                let next_attempt = attempt + 1;
+                let delay = policy_snapshot.delay_before_attempt(next_attempt);
+                tracing::warn!(
+                    event.name = "ragloom.retry.scheduled",
+                    record_type,
+                    canonical_path = canonical_path,
+                    retry.attempt = attempt,
+                    retry.next_attempt = next_attempt,
+                    retry.max_attempts = policy_snapshot.max_attempts,
+                    retry.backoff_ms = delay.as_millis() as u64,
+                    retry.queue_len = retries.len() + 1,
+                    retry.max_queued_retries = policy_snapshot.max_queued_retries,
+                    error.kind = %err.kind,
+                    error.message = %err,
+                    "ragloom.retry.scheduled"
+                );
+                if let Some(metrics) = &metrics {
+                    metrics.record_retry_scheduled(retries.len() + 1);
+                }
+                retries.push_back(RetryItem {
+                    record,
+                    attempt: next_attempt,
+                    delay,
+                });
+            } else {
+                if let Some(failed_work) = &failed_work {
+                    let terminal_reason = if retryable {
+                        FailedWorkTerminalReason::RetryExhausted
+                    } else {
+                        FailedWorkTerminalReason::NonRetryable
+                    };
+
+                    match failed_work.next_id().await {
+                        Ok(id) => {
+                            if let Err(persist_err) = failed_work
+                                .append(FailedWorkRecord::Exhausted {
+                                    id,
+                                    work: record.clone(),
+                                    failure_kind: FailedWorkFailureKind::from_error_kind(err.kind),
+                                    terminal_reason,
+                                    attempts: attempt,
+                                })
+                                .await
+                            {
+                                tracing::error!(
+                                    event.name = "ragloom.failed_work.persist_failed",
+                                    record_type,
+                                    canonical_path = canonical_path,
+                                    error.kind = %persist_err.kind,
+                                    error.message = %persist_err,
+                                    "ragloom.failed_work.persist_failed"
+                                );
+                            }
+                        }
+                        Err(persist_err) => {
+                            tracing::error!(
+                                event.name = "ragloom.failed_work.read_failed",
+                                record_type,
+                                canonical_path = canonical_path,
+                                error.kind = %persist_err.kind,
+                                error.message = %persist_err,
+                                "ragloom.failed_work.read_failed"
+                            );
                         }
                     }
-                    tracing::warn!(
-                        event.name = "ragloom.ingest.failed",
-                        record_type,
-                        canonical_path = canonical_path,
-                        retry.attempt = attempt,
-                        retry.max_attempts = policy_snapshot.max_attempts,
-                        retry.queue_len = retries.len(),
-                        error.kind = %err.kind,
-                        error.message = %err,
-                        "ragloom.ingest.failed"
-                    );
                 }
-            },
-            |_| {},
-        );
+
+                if let Some(summary) = &summary {
+                    summary.record_failure();
+                }
+                if let Some(metrics) = &metrics {
+                    metrics.record_failure();
+                    if retryable {
+                        metrics.record_retry_exhausted(retries.len());
+                    }
+                }
+                tracing::warn!(
+                    event.name = "ragloom.ingest.failed",
+                    record_type,
+                    canonical_path = canonical_path,
+                    retry.attempt = attempt,
+                    retry.max_attempts = policy_snapshot.max_attempts,
+                    retry.queue_len = retries.len(),
+                    error.kind = %err.kind,
+                    error.message = %err,
+                    "ragloom.ingest.failed"
+                );
+            }
+        }
     }
 }
 
@@ -2274,6 +2328,110 @@ mod tests {
         let snapshot = summary.snapshot();
         assert_eq!(snapshot.failed_files, 1);
         assert_eq!(snapshot.pending_files, 0);
+    }
+
+    #[tokio::test]
+    async fn retry_worker_persists_retry_exhausted_work_item() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let failed_work = crate::state::failed::FailedWorkJournal::new(
+            crate::state::failed::InMemoryFailedWorkStore::new(),
+        );
+        let failed_work_for_worker = failed_work.clone();
+        let executor = ScriptedExecutor::new(vec![
+            Err(RagloomErrorKind::Embed),
+            Err(RagloomErrorKind::Embed),
+        ]);
+
+        let worker = tokio::spawn(async move {
+            run_worker_with_live_retry_failed_work_and_metrics(
+                rx,
+                executor,
+                LiveRetryPolicy::new(RetryPolicy {
+                    max_attempts: 2,
+                    max_queued_retries: 1,
+                    initial_backoff: std::time::Duration::ZERO,
+                    max_backoff: std::time::Duration::ZERO,
+                })
+                .expect("policy"),
+                Some(failed_work_for_worker),
+                None,
+                None,
+            )
+            .await;
+        });
+
+        let work = WalRecord::WorkItemV2 {
+            fingerprint: crate::ids::FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: None,
+            },
+        };
+
+        tx.send(work.clone()).await.expect("send");
+        drop(tx);
+        worker.await.expect("worker");
+
+        let records = failed_work.read_all().await.expect("read failed-work");
+        assert_eq!(
+            records,
+            vec![crate::state::failed::FailedWorkRecord::Exhausted {
+                id: 1,
+                work,
+                failure_kind: crate::state::failed::FailedWorkFailureKind::Embed,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_worker_persists_non_retryable_terminal_failure() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let failed_work = crate::state::failed::FailedWorkJournal::new(
+            crate::state::failed::InMemoryFailedWorkStore::new(),
+        );
+        let failed_work_for_worker = failed_work.clone();
+        let executor = ScriptedExecutor::new(vec![Err(RagloomErrorKind::InvalidInput)]);
+
+        let worker = tokio::spawn(async move {
+            run_worker_with_live_retry_failed_work_and_metrics(
+                rx,
+                executor,
+                LiveRetryPolicy::new(RetryPolicy {
+                    max_attempts: 3,
+                    max_queued_retries: 2,
+                    initial_backoff: std::time::Duration::ZERO,
+                    max_backoff: std::time::Duration::ZERO,
+                })
+                .expect("policy"),
+                Some(failed_work_for_worker),
+                None,
+                None,
+            )
+            .await;
+        });
+
+        let work = WalRecord::DeleteDocument {
+            canonical_path: "/x/a.txt".to_string(),
+        };
+
+        tx.send(work.clone()).await.expect("send");
+        drop(tx);
+        worker.await.expect("worker");
+
+        let records = failed_work.read_all().await.expect("read failed-work");
+        assert_eq!(
+            records,
+            vec![crate::state::failed::FailedWorkRecord::Exhausted {
+                id: 1,
+                work,
+                failure_kind: crate::state::failed::FailedWorkFailureKind::InvalidInput,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::NonRetryable,
+                attempts: 1,
+            }]
+        );
     }
 
     #[tokio::test]

--- a/src/state/failed.rs
+++ b/src/state/failed.rs
@@ -354,12 +354,12 @@ fn open_failed_work_append_file(path: &Path) -> Result<File, RagloomError> {
 fn sync_failed_work_parent_dir(path: &Path) -> Result<(), RagloomError> {
     #[cfg(unix)]
     {
-        let parent = path.parent().ok_or_else(|| {
-            RagloomError::from_kind(RagloomErrorKind::State).with_context(format!(
-                "failed to sync failed-work parent directory: missing parent for {}",
-                path.display()
-            ))
-        })?;
+        let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        else {
+            return Ok(());
+        };
         File::open(parent)
             .map_err(|e| {
                 RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
@@ -563,5 +563,11 @@ mod tests {
         let store = FileFailedWorkStore::open(&path).expect("open new store");
         assert!(path.exists());
         assert!(store.is_empty());
+    }
+
+    #[test]
+    fn failed_work_path_without_parent_skips_parent_sync_requirement() {
+        let path = Path::new("failed.ndjson");
+        sync_failed_work_parent_dir(path).expect("sync current-dir file parent should noop");
     }
 }

--- a/src/state/failed.rs
+++ b/src/state/failed.rs
@@ -97,14 +97,28 @@ impl FailedWorkJournal {
         guard.append(record)
     }
 
+    pub async fn append_exhausted(
+        &self,
+        work: WalRecord,
+        failure_kind: FailedWorkFailureKind,
+        terminal_reason: FailedWorkTerminalReason,
+        attempts: u32,
+    ) -> Result<u64, RagloomError> {
+        let mut guard = self.inner.lock().await;
+        let id = next_failed_work_id(&guard.read_all()?);
+        guard.append(FailedWorkRecord::Exhausted {
+            id,
+            work,
+            failure_kind,
+            terminal_reason,
+            attempts,
+        })?;
+        Ok(id)
+    }
+
     pub async fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError> {
         let guard = self.inner.lock().await;
         guard.read_all()
-    }
-
-    pub async fn next_id(&self) -> Result<u64, RagloomError> {
-        let records = self.read_all().await?;
-        Ok(next_failed_work_id(&records))
     }
 }
 
@@ -309,23 +323,72 @@ pub fn failed_work_path_from_state_path(path: impl AsRef<Path>) -> PathBuf {
 }
 
 fn open_failed_work_append_file(path: &Path) -> Result<File, RagloomError> {
-    std::fs::OpenOptions::new()
-        .create(true)
+    match std::fs::OpenOptions::new()
+        .create_new(true)
         .append(true)
         .open(path)
-        .map_err(|e| {
-            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+    {
+        Ok(file) => {
+            sync_failed_work_parent_dir(path)?;
+            Ok(file)
+        }
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to open failed-work file: {}",
+                    path.display()
+                ))
+            }),
+        Err(err) => Err(
+            RagloomError::new(RagloomErrorKind::State, err).with_context(format!(
                 "failed to open failed-work file: {}",
                 path.display()
+            )),
+        ),
+    }
+}
+
+fn sync_failed_work_parent_dir(path: &Path) -> Result<(), RagloomError> {
+    #[cfg(unix)]
+    {
+        let parent = path.parent().ok_or_else(|| {
+            RagloomError::from_kind(RagloomErrorKind::State).with_context(format!(
+                "failed to sync failed-work parent directory: missing parent for {}",
+                path.display()
             ))
-        })
+        })?;
+        File::open(parent)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to open failed-work parent directory: {}",
+                    parent.display()
+                ))
+            })?
+            .sync_all()
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to sync failed-work parent directory: {}",
+                    parent.display()
+                ))
+            })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ids::FileFingerprint;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, tempdir};
 
     fn sample_work(path: &str) -> WalRecord {
         WalRecord::WorkItemV2 {
@@ -454,5 +517,51 @@ mod tests {
             failed_work_path_from_state_path(".ragloom/wal.ndjson"),
             PathBuf::from(".ragloom").join("failed.ndjson")
         );
+    }
+
+    #[tokio::test]
+    async fn failed_work_journal_allocates_unique_ids_under_concurrency() {
+        let journal = FailedWorkJournal::new(InMemoryFailedWorkStore::new());
+        let mut tasks = Vec::new();
+
+        for idx in 0..8u64 {
+            let journal = journal.clone();
+            tasks.push(tokio::spawn(async move {
+                journal
+                    .append_exhausted(
+                        sample_work(&format!("/x/{idx}.txt")),
+                        FailedWorkFailureKind::Embed,
+                        FailedWorkTerminalReason::RetryExhausted,
+                        2,
+                    )
+                    .await
+                    .expect("append exhausted")
+            }));
+        }
+
+        let mut ids = Vec::new();
+        for task in tasks {
+            ids.push(task.await.expect("task join"));
+        }
+
+        ids.sort_unstable();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+        let pending = pending_failed_work(&journal.read_all().await.expect("read records"));
+        assert_eq!(pending.len(), 8);
+        assert_eq!(
+            pending.iter().map(|record| record.id).collect::<Vec<_>>(),
+            ids
+        );
+    }
+
+    #[test]
+    fn file_failed_work_open_creates_missing_file() {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("failed.ndjson");
+
+        let store = FileFailedWorkStore::open(&path).expect("open new store");
+        assert!(path.exists());
+        assert!(store.is_empty());
     }
 }

--- a/src/state/failed.rs
+++ b/src/state/failed.rs
@@ -1,0 +1,458 @@
+//! Failed-work journal for exhausted ingest items.
+//!
+//! # Why
+//! Exhausted work should be inspectable and operator-replayable without
+//! changing the WAL's acknowledgement/replay semantics.
+
+use std::fs::File;
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+
+use crate::error::{RagloomError, RagloomErrorKind};
+use crate::state::wal::WalRecord;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailedWorkFailureKind {
+    InvalidInput,
+    Io,
+    Config,
+    Internal,
+    Embed,
+    Sink,
+    State,
+}
+
+impl FailedWorkFailureKind {
+    pub fn from_error_kind(kind: RagloomErrorKind) -> Self {
+        match kind {
+            RagloomErrorKind::InvalidInput => Self::InvalidInput,
+            RagloomErrorKind::Io => Self::Io,
+            RagloomErrorKind::Config => Self::Config,
+            RagloomErrorKind::Internal => Self::Internal,
+            RagloomErrorKind::Embed => Self::Embed,
+            RagloomErrorKind::Sink => Self::Sink,
+            RagloomErrorKind::State => Self::State,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailedWorkTerminalReason {
+    RetryExhausted,
+    NonRetryable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FailedWorkRecord {
+    Exhausted {
+        id: u64,
+        work: WalRecord,
+        failure_kind: FailedWorkFailureKind,
+        terminal_reason: FailedWorkTerminalReason,
+        attempts: u32,
+    },
+    Requeued {
+        exhausted_id: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingFailedWork {
+    pub id: u64,
+    pub work: WalRecord,
+    pub failure_kind: FailedWorkFailureKind,
+    pub terminal_reason: FailedWorkTerminalReason,
+    pub attempts: u32,
+}
+
+pub trait FailedWorkStore: Send {
+    fn append(&mut self, record: FailedWorkRecord) -> Result<(), RagloomError>;
+    fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError>;
+    fn is_empty(&self) -> bool;
+}
+
+#[derive(Clone)]
+pub struct FailedWorkJournal {
+    inner: std::sync::Arc<tokio::sync::Mutex<Box<dyn FailedWorkStore>>>,
+}
+
+impl std::fmt::Debug for FailedWorkJournal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FailedWorkJournal").finish_non_exhaustive()
+    }
+}
+
+impl FailedWorkJournal {
+    pub fn new<S: FailedWorkStore + 'static>(store: S) -> Self {
+        Self {
+            inner: std::sync::Arc::new(tokio::sync::Mutex::new(Box::new(store))),
+        }
+    }
+
+    pub async fn append(&self, record: FailedWorkRecord) -> Result<(), RagloomError> {
+        let mut guard = self.inner.lock().await;
+        guard.append(record)
+    }
+
+    pub async fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError> {
+        let guard = self.inner.lock().await;
+        guard.read_all()
+    }
+
+    pub async fn next_id(&self) -> Result<u64, RagloomError> {
+        let records = self.read_all().await?;
+        Ok(next_failed_work_id(&records))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryFailedWorkStore {
+    records: Vec<FailedWorkRecord>,
+}
+
+impl InMemoryFailedWorkStore {
+    pub fn new() -> Self {
+        Self {
+            records: Vec::new(),
+        }
+    }
+
+    pub fn append(&mut self, record: FailedWorkRecord) -> Result<(), RagloomError> {
+        <Self as FailedWorkStore>::append(self, record)
+    }
+
+    pub fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError> {
+        <Self as FailedWorkStore>::read_all(self)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        <Self as FailedWorkStore>::is_empty(self)
+    }
+}
+
+impl FailedWorkStore for InMemoryFailedWorkStore {
+    fn append(&mut self, record: FailedWorkRecord) -> Result<(), RagloomError> {
+        self.records.push(record);
+        Ok(())
+    }
+
+    fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError> {
+        Ok(self.records.clone())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+#[derive(Debug)]
+pub struct FileFailedWorkStore {
+    path: PathBuf,
+    file: File,
+}
+
+impl FileFailedWorkStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, RagloomError> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to create failed-work directory: {}",
+                    parent.display()
+                ))
+            })?;
+        }
+
+        let store = Self {
+            file: open_failed_work_append_file(&path)?,
+            path,
+        };
+        store.read_all().map_err(|e| {
+            RagloomError::new(e.kind, e).with_context("failed to validate failed-work file")
+        })?;
+        Ok(store)
+    }
+
+    pub fn append(&mut self, record: FailedWorkRecord) -> Result<(), RagloomError> {
+        <Self as FailedWorkStore>::append(self, record)
+    }
+
+    pub fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError> {
+        <Self as FailedWorkStore>::read_all(self)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        <Self as FailedWorkStore>::is_empty(self)
+    }
+}
+
+impl FailedWorkStore for FileFailedWorkStore {
+    fn append(&mut self, record: FailedWorkRecord) -> Result<(), RagloomError> {
+        let encoded = serde_json::to_string(&record).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e)
+                .with_context("failed to encode failed-work record")
+        })?;
+
+        writeln!(self.file, "{encoded}").map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to append failed-work file: {}",
+                self.path.display()
+            ))
+        })?;
+        self.file.sync_data().map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to sync failed-work file: {}",
+                self.path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn read_all(&self) -> Result<Vec<FailedWorkRecord>, RagloomError> {
+        let contents = std::fs::read_to_string(&self.path).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to read failed-work file: {}",
+                self.path.display()
+            ))
+        })?;
+
+        let mut records = Vec::new();
+        for (idx, line) in contents.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let record = serde_json::from_str::<FailedWorkRecord>(line).map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to parse failed-work record at line {} in {}",
+                    idx + 1,
+                    self.path.display()
+                ))
+            })?;
+            records.push(record);
+        }
+        Ok(records)
+    }
+
+    fn is_empty(&self) -> bool {
+        match std::fs::metadata(&self.path) {
+            Ok(metadata) => metadata.len() == 0,
+            Err(err) if err.kind() == ErrorKind::NotFound => true,
+            Err(err) => {
+                tracing::warn!(
+                    event.name = "ragloom.failed_work.metadata_failed",
+                    path = %self.path.display(),
+                    error.message = %err,
+                    "ragloom.failed_work.metadata_failed"
+                );
+                false
+            }
+        }
+    }
+}
+
+pub fn pending_failed_work(records: &[FailedWorkRecord]) -> Vec<PendingFailedWork> {
+    let mut pending = std::collections::BTreeMap::<u64, PendingFailedWork>::new();
+
+    for record in records {
+        match record {
+            FailedWorkRecord::Exhausted {
+                id,
+                work,
+                failure_kind,
+                terminal_reason,
+                attempts,
+            } => {
+                pending.insert(
+                    *id,
+                    PendingFailedWork {
+                        id: *id,
+                        work: work.clone(),
+                        failure_kind: *failure_kind,
+                        terminal_reason: *terminal_reason,
+                        attempts: *attempts,
+                    },
+                );
+            }
+            FailedWorkRecord::Requeued { exhausted_id } => {
+                pending.remove(exhausted_id);
+            }
+        }
+    }
+
+    pending.into_values().collect()
+}
+
+pub fn next_failed_work_id(records: &[FailedWorkRecord]) -> u64 {
+    records
+        .iter()
+        .filter_map(|record| match record {
+            FailedWorkRecord::Exhausted { id, .. } => Some(*id),
+            FailedWorkRecord::Requeued { .. } => None,
+        })
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+pub fn failed_work_path_from_state_path(path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(|parent| parent.join("failed.ndjson"))
+        .unwrap_or_else(|| PathBuf::from("failed.ndjson"))
+}
+
+fn open_failed_work_append_file(path: &Path) -> Result<File, RagloomError> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to open failed-work file: {}",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::FileFingerprint;
+    use tempfile::NamedTempFile;
+
+    fn sample_work(path: &str) -> WalRecord {
+        WalRecord::WorkItemV2 {
+            fingerprint: FileFingerprint {
+                canonical_path: path.to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: None,
+            },
+        }
+    }
+
+    #[test]
+    fn file_failed_work_roundtrips_records_after_reopen() {
+        let file = NamedTempFile::new().expect("temp failed-work");
+        let path = file.path().to_path_buf();
+
+        let mut store = FileFailedWorkStore::open(&path).expect("open");
+        store
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: sample_work("/x/a.txt"),
+                failure_kind: FailedWorkFailureKind::Embed,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 3,
+            })
+            .expect("append exhausted");
+        store
+            .append(FailedWorkRecord::Requeued { exhausted_id: 1 })
+            .expect("append requeued");
+
+        let reopened = FileFailedWorkStore::open(&path).expect("reopen");
+        assert_eq!(
+            reopened.read_all().expect("read"),
+            vec![
+                FailedWorkRecord::Exhausted {
+                    id: 1,
+                    work: sample_work("/x/a.txt"),
+                    failure_kind: FailedWorkFailureKind::Embed,
+                    terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                    attempts: 3,
+                },
+                FailedWorkRecord::Requeued { exhausted_id: 1 },
+            ]
+        );
+    }
+
+    #[test]
+    fn pending_failed_work_filters_requeued_entries() {
+        let records = vec![
+            FailedWorkRecord::Exhausted {
+                id: 1,
+                work: sample_work("/x/a.txt"),
+                failure_kind: FailedWorkFailureKind::Sink,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            },
+            FailedWorkRecord::Exhausted {
+                id: 2,
+                work: sample_work("/x/b.txt"),
+                failure_kind: FailedWorkFailureKind::Embed,
+                terminal_reason: FailedWorkTerminalReason::NonRetryable,
+                attempts: 1,
+            },
+            FailedWorkRecord::Requeued { exhausted_id: 1 },
+        ];
+
+        assert_eq!(
+            pending_failed_work(&records),
+            vec![PendingFailedWork {
+                id: 2,
+                work: sample_work("/x/b.txt"),
+                failure_kind: FailedWorkFailureKind::Embed,
+                terminal_reason: FailedWorkTerminalReason::NonRetryable,
+                attempts: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn later_exhaustion_after_prior_requeue_stays_pending() {
+        let records = vec![
+            FailedWorkRecord::Exhausted {
+                id: 1,
+                work: sample_work("/x/a.txt"),
+                failure_kind: FailedWorkFailureKind::Io,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            },
+            FailedWorkRecord::Requeued { exhausted_id: 1 },
+            FailedWorkRecord::Exhausted {
+                id: 2,
+                work: sample_work("/x/a.txt"),
+                failure_kind: FailedWorkFailureKind::Io,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            },
+        ];
+
+        assert_eq!(pending_failed_work(&records).len(), 1);
+        assert_eq!(pending_failed_work(&records)[0].id, 2);
+    }
+
+    #[test]
+    fn invalid_failed_work_file_fails_open_with_state_context() {
+        let mut file = NamedTempFile::new().expect("temp failed-work");
+        file.write_all(b"{not json}\n").expect("write");
+
+        let err = FileFailedWorkStore::open(file.path()).expect_err("invalid store should fail");
+        assert_eq!(err.kind, RagloomErrorKind::State);
+        assert!(
+            err.to_string()
+                .contains("failed to validate failed-work file")
+        );
+        let source = std::error::Error::source(&err).expect("source");
+        assert!(
+            source
+                .to_string()
+                .contains("failed to parse failed-work record")
+        );
+    }
+
+    #[test]
+    fn failed_work_path_uses_state_directory() {
+        assert_eq!(
+            failed_work_path_from_state_path(".ragloom/wal.ndjson"),
+            PathBuf::from(".ragloom").join("failed.ndjson")
+        );
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,6 +5,7 @@
 //! not be tied to a specific storage engine, so we define a small trait surface
 //! that keeps the system open for extension.
 
+pub mod failed;
 pub mod wal;
 
 /// Persistent state store abstraction.


### PR DESCRIPTION
## Summary

Persist exhausted ingest work into a local failed-work journal and add an operator `replay-failed` command to requeue pending entries back into the WAL.

## Related issue

Closes #134

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- Add a dedicated append-only `failed.ndjson` journal beside the WAL for retry-exhausted and terminal non-retryable work.
- Persist sanitized failure metadata without changing WAL acknowledgement semantics, and add `ragloom replay-failed` for operator requeue.
- Cover failed-work persistence, replay, crash-safe at-least-once replay, and CLI parsing with regression tests and README/CHANGELOG updates.

## How to test

1. Run `cargo test failed_work -- --nocapture`.
2. Run `cargo test parse_args_replay_failed -- --nocapture`.
3. Run `cargo qa`.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

- `replay-failed` intentionally requires explicit `--state-path` or `--config` so operator replay does not silently target a default state directory.
- Replay remains at-least-once by design: if WAL append succeeds but the requeue marker write does not, rerunning `replay-failed` may append the same work again rather than losing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent local failed-work journal to record exhausted/terminal ingest items (sanitized failure class, retry count) while avoiding secrets or full document contents.
  * New ragloom replay-failed command to requeue pending failed work back into the WAL (supports --state-path or --config) with at-least-once replay semantics.

* **Documentation**
  * README and changelog updated with failure-record format, inspection commands, replay usage, and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->