### PR TITLE
fix: harden the semantic chunking support boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 - Retry exhaustion no longer stops at logs and counters: worker terminal
   failures now persist a sanitized failure class plus the original scheduled
   work record, without recording secrets or full document contents.
+- Semantic chunking remains experimental and opt-in for `v0.4.1`, while
+  `--semantic-provider` and `--semantic-percentile` now only apply when the
+  semantic path is active in router or single-semantic mode.
+
+### Docs
+- Clarified that semantic chunking remains experimental and opt-in, and that
+  `fastembed` remains a feature-gated semantic provider for both router and
+  single-semantic mode.
 
 ## [0.4.0] - 2026-05-26
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Feature-gated paths:
 
 Experimental or best-effort paths:
 
-- semantic chunking remains opt-in and experimental
+- semantic chunking remains experimental and opt-in
+- `fastembed` remains a feature-gated semantic provider
 - macOS release artifacts remain best-effort convenience binaries rather than release-blocking targets
 
 Not supported yet:
@@ -534,8 +535,14 @@ Useful flags:
 - `--size-max`, `--size-min`, and `--size-overlap` tune boundaries
 - `--enable-semantic` enables semantic chunking in router mode
 - `--semantic-provider adapter|fastembed` selects the semantic signal source
+- `--semantic-percentile <1..=99>` tunes semantic split sensitivity when semantic chunking is active
 
-Semantic chunking is opt-in. `fastembed` requires building with `--features fastembed`.
+Semantic chunking remains experimental and opt-in. It is only active with
+`--enable-semantic` in router mode or with `--chunker-mode single --chunker-single semantic`.
+When active, `--semantic-provider` and `--semantic-percentile` apply to both router and
+single semantic modes. In router mode, semantic chunking replaces the Markdown and generic
+text fallback paths while code extensions continue to use the code chunker. `fastembed`
+remains a feature-gated semantic provider and requires building with `--features fastembed`.
 
 ## Indexed Payload
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -89,11 +89,19 @@ support boundary:
 Feature-gated paths:
 
 - `fastembed` support is opt-in at build time and must keep passing its dedicated checks, but it is not the default shipped runtime path
+- `fastembed` remains a feature-gated semantic provider
 
 Experimental or best-effort paths:
 
 - semantic chunking remains experimental and opt-in even when the required provider path is available
+- semantic chunking remains experimental and opt-in
 - macOS release artifacts remain convenience builds rather than part of the formal support contract
+
+Semantic chunking is only active with `--enable-semantic` in router mode or with
+`--chunker-mode single --chunker-single semantic`. When active, `--semantic-provider`
+and `--semantic-percentile` are part of the experimental semantic surface in both modes.
+In router mode, semantic chunking replaces the Markdown and generic text fallback paths
+while code extensions continue to use the code chunker.
 
 Out of scope for the current support contract:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,12 +523,14 @@ fn build_run_config(
         raw.enable_semantic,
     );
     if raw.semantic_provider.is_some() && !semantic_chunking_active {
-        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
-            .with_context("--semantic-provider requires semantic chunking to be active"));
+        return Err(cli_invalid_input(
+            "--semantic-provider requires semantic chunking to be active",
+        ));
     }
     if raw.semantic_percentile.is_some() && !semantic_chunking_active {
-        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
-            .with_context("--semantic-percentile requires semantic chunking to be active"));
+        return Err(cli_invalid_input(
+            "--semantic-percentile requires semantic chunking to be active",
+        ));
     }
 
     let semantic_provider = raw
@@ -3375,6 +3377,15 @@ state:
         cfg.semantic_provider = "adapter".to_string();
 
         assert_eq!(chunker_selection(&cfg), "single:semantic(provider=adapter)");
+    }
+
+    #[test]
+    fn router_semantic_chunker_selection_includes_provider() {
+        let mut cfg = sample_run_config();
+        cfg.enable_semantic = true;
+        cfg.semantic_provider = "adapter".to_string();
+
+        assert_eq!(chunker_selection(&cfg), "router+semantic(provider=adapter)");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,6 +517,20 @@ fn build_run_config(
         );
     }
 
+    let semantic_chunking_active = semantic_chunking_active(
+        chunker_mode.as_str(),
+        raw.chunker_single.as_deref(),
+        raw.enable_semantic,
+    );
+    if raw.semantic_provider.is_some() && !semantic_chunking_active {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+            .with_context("--semantic-provider requires semantic chunking to be active"));
+    }
+    if raw.semantic_percentile.is_some() && !semantic_chunking_active {
+        return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+            .with_context("--semantic-percentile requires semantic chunking to be active"));
+    }
+
     let semantic_provider = raw
         .semantic_provider
         .unwrap_or_else(|| "adapter".to_string());
@@ -928,8 +942,19 @@ impl StartupValidationSummary {
 
 fn chunker_selection(cfg: &RunConfig) -> String {
     match cfg.chunker_mode.as_str() {
-        "router" if cfg.enable_semantic => {
+        "router"
+            if semantic_chunking_active(cfg.chunker_mode.as_str(), None, cfg.enable_semantic) =>
+        {
             format!("router+semantic(provider={})", cfg.semantic_provider)
+        }
+        "single"
+            if semantic_chunking_active(
+                cfg.chunker_mode.as_str(),
+                cfg.chunker_single.as_deref(),
+                cfg.enable_semantic,
+            ) =>
+        {
+            format!("single:semantic(provider={})", cfg.semantic_provider)
         }
         "router" => "router".to_string(),
         "single" => format!(
@@ -938,6 +963,45 @@ fn chunker_selection(cfg: &RunConfig) -> String {
         ),
         _ => unreachable!("validated in parse_args"),
     }
+}
+
+fn semantic_chunking_active(
+    chunker_mode: &str,
+    chunker_single: Option<&str>,
+    enable_semantic: bool,
+) -> bool {
+    match chunker_mode {
+        "router" => enable_semantic,
+        "single" => chunker_single == Some("semantic"),
+        _ => false,
+    }
+}
+
+fn build_semantic_signal_provider(
+    cfg: &RunConfig,
+    embedding: &std::sync::Arc<dyn ragloom::embed::EmbeddingProvider + Send + Sync>,
+    embed_fingerprint: &str,
+) -> Result<std::sync::Arc<dyn ragloom::transform::chunker::SemanticSignalProvider>, RagloomError> {
+    use ragloom::transform::chunker::{EmbeddingProviderAdapter, SemanticSignalProvider};
+
+    let signal: std::sync::Arc<dyn SemanticSignalProvider> = match cfg.semantic_provider.as_str() {
+        "adapter" => std::sync::Arc::new(EmbeddingProviderAdapter::new(
+            std::sync::Arc::clone(embedding),
+            embed_fingerprint.to_string(),
+        )),
+        #[cfg(feature = "fastembed")]
+        "fastembed" => std::sync::Arc::new(
+            ragloom::transform::chunker::FastembedSignalProvider::new().map_err(|e| {
+                RagloomError::new(RagloomErrorKind::Config, e).with_context("fastembed init")
+            })?,
+        ),
+        other => {
+            return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
+                .with_context(format!("unsupported --semantic-provider: {other}")));
+        }
+    };
+
+    Ok(signal)
 }
 
 fn bootstrap_plan(cfg: &RunConfig) -> Result<BootstrapPlan, RagloomError> {
@@ -1059,31 +1123,17 @@ async fn prepare_startup(
     }
 
     use ragloom::transform::chunker::{
-        Chunker, EmbeddingProviderAdapter, MarkdownChunker, SemanticChunker,
-        SemanticSignalProvider, default_router, recursive::RecursiveChunker, semantic_router,
+        Chunker, MarkdownChunker, SemanticChunker, default_router, recursive::RecursiveChunker,
+        semantic_router,
     };
 
-    let chunker: std::sync::Arc<dyn Chunker> = if cfg.chunker_mode == "router"
-        && cfg.enable_semantic
+    let chunker: std::sync::Arc<dyn Chunker> = if semantic_chunking_active(
+        cfg.chunker_mode.as_str(),
+        cfg.chunker_single.as_deref(),
+        cfg.enable_semantic,
+    ) && cfg.chunker_mode == "router"
     {
-        let signal: std::sync::Arc<dyn SemanticSignalProvider> =
-            match cfg.semantic_provider.as_str() {
-                "adapter" => std::sync::Arc::new(EmbeddingProviderAdapter::new(
-                    std::sync::Arc::clone(&embedding),
-                    embed_fingerprint.clone(),
-                )),
-                #[cfg(feature = "fastembed")]
-                "fastembed" => std::sync::Arc::new(
-                    ragloom::transform::chunker::FastembedSignalProvider::new().map_err(|e| {
-                        RagloomError::new(RagloomErrorKind::Config, e)
-                            .with_context("fastembed init")
-                    })?,
-                ),
-                other => {
-                    return Err(RagloomError::from_kind(RagloomErrorKind::InvalidInput)
-                        .with_context(format!("unsupported --semantic-provider: {other}")));
-                }
-            };
+        let signal = build_semantic_signal_provider(cfg, &embedding, &embed_fingerprint)?;
         let semantic_chunker: std::sync::Arc<dyn Chunker> = std::sync::Arc::new(
             SemanticChunker::new(signal, rec_cfg, cfg.semantic_percentile).map_err(|e| {
                 RagloomError::new(RagloomErrorKind::Config, e)
@@ -1103,11 +1153,8 @@ async fn prepare_startup(
                 let kind = cfg.chunker_single.as_deref().unwrap();
                 match kind {
                     "semantic" => {
-                        let signal: std::sync::Arc<dyn SemanticSignalProvider> =
-                            std::sync::Arc::new(EmbeddingProviderAdapter::new(
-                                std::sync::Arc::clone(&embedding),
-                                embed_fingerprint.clone(),
-                            ));
+                        let signal =
+                            build_semantic_signal_provider(cfg, &embedding, &embed_fingerprint)?;
                         std::sync::Arc::new(
                             SemanticChunker::new(signal, rec_cfg, cfg.semantic_percentile)
                                 .map_err(|e| {
@@ -2639,6 +2686,102 @@ state:
     }
 
     #[test]
+    fn parse_args_rejects_semantic_provider_without_semantic_chunking() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+            "--semantic-provider".to_string(),
+            "adapter".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("expected semantic provider to be rejected");
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("--semantic-provider requires semantic chunking to be active")
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_semantic_percentile_without_semantic_chunking() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+            "--chunker-mode".to_string(),
+            "single".to_string(),
+            "--chunker-single".to_string(),
+            "recursive".to_string(),
+            "--semantic-percentile".to_string(),
+            "90".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("expected semantic percentile to be rejected");
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("--semantic-percentile requires semantic chunking to be active")
+        );
+    }
+
+    #[test]
+    fn parse_args_accepts_semantic_flags_for_single_semantic_mode() {
+        let args = vec![
+            "ragloom".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+            "--embed-backend".to_string(),
+            "http".to_string(),
+            "--embed-url".to_string(),
+            "http://embed".to_string(),
+            "--embed-model".to_string(),
+            "default".to_string(),
+            "--qdrant-url".to_string(),
+            "http://qdrant".to_string(),
+            "--collection".to_string(),
+            "docs".to_string(),
+            "--chunker-mode".to_string(),
+            "single".to_string(),
+            "--chunker-single".to_string(),
+            "semantic".to_string(),
+            "--semantic-provider".to_string(),
+            "adapter".to_string(),
+            "--semantic-percentile".to_string(),
+            "90".to_string(),
+        ];
+
+        let ParsedCommand::Run(cfg) = parse_args(&args).expect("config") else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(cfg.chunker_mode, "single");
+        assert_eq!(cfg.chunker_single.as_deref(), Some("semantic"));
+        assert_eq!(cfg.semantic_provider, "adapter");
+        assert_eq!(cfg.semantic_percentile, 90);
+    }
+
+    #[test]
     fn parse_args_accepts_collection_vector_size_inline_value() {
         let args = vec![
             "ragloom".to_string(),
@@ -3222,6 +3365,16 @@ state:
         ];
         let err = parse_args(&args).expect_err("must reject");
         assert!(err.to_string().contains("--enable-semantic"));
+    }
+
+    #[test]
+    fn single_semantic_chunker_selection_includes_provider() {
+        let mut cfg = sample_run_config();
+        cfg.chunker_mode = "single".to_string();
+        cfg.chunker_single = Some("semantic".to_string());
+        cfg.semantic_provider = "adapter".to_string();
+
+        assert_eq!(chunker_selection(&cfg), "single:semantic(provider=adapter)");
     }
 
     #[test]

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -68,3 +68,26 @@ fn changelog_records_v0_4_release_alignment() {
         "expected the changelog to record the v0.4 release docs alignment work"
     );
 }
+
+#[test]
+fn semantic_support_boundary_is_consistent_across_docs() {
+    let readme = read_repo_file("README.md");
+    let support = read_repo_file("SUPPORT.md");
+    let changelog = read_repo_file("CHANGELOG.md");
+
+    let support_phrase = "semantic chunking remains experimental and opt-in";
+    let fastembed_phrase = "`fastembed` remains a feature-gated semantic provider";
+
+    assert!(
+        readme.contains(support_phrase) && readme.contains(fastembed_phrase),
+        "expected README to describe the experimental semantic support boundary"
+    );
+    assert!(
+        support.contains(support_phrase) && support.contains(fastembed_phrase),
+        "expected SUPPORT.md to describe the experimental semantic support boundary"
+    );
+    assert!(
+        changelog.contains(support_phrase) && changelog.contains(fastembed_phrase),
+        "expected CHANGELOG.md to record the semantic support-boundary decision"
+    );
+}


### PR DESCRIPTION
## Summary

Clarify that semantic chunking remains experimental in v0.4.1, while hardening the CLI and startup wiring so semantic-only flags are only honored when the semantic path is actually active.

## Related issue

Closes #135

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- reject `--semantic-provider` and `--semantic-percentile` unless semantic chunking is active
- reuse the same semantic provider wiring for router mode and `single:semantic`, including dry-run chunker selection output
- align README, SUPPORT, CHANGELOG, and a docs contract test around the experimental semantic support boundary

## How to test

1. `cargo test --bin ragloom parse_args_accepts_semantic_flags_for_single_semantic_mode`
2. `cargo test --test docs_support_contract semantic_support_boundary_is_consistent_across_docs`
3. `cargo qa`

## Screenshots or recordings

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This keeps semantic chunking experimental for v0.4.1 instead of promoting it to the formal support boundary, but it removes the current CLI/runtime ambiguity around when semantic-specific flags take effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that semantic chunking remains experimental and opt-in across CHANGELOG, README, and SUPPORT documentation.
  * Updated chunking flag descriptions to specify activation conditions for semantic features.
  * Confirmed fastembed semantic provider is feature-gated.

* **Bug Fixes**
  * Added validation to reject semantic-related CLI flags when semantic chunking is inactive.

* **Tests**
  * Added documentation consistency verification test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->