### PR TITLE
ci(release): trim v0.4.1 release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,6 @@ jobs:
             -Path "dist/${{ matrix.target }}/${{ matrix.binary_name }}" `
             -DestinationPath "dist/$archiveBasename.zip"
 
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
-        with:
-          path: dist/${{ matrix.target }}
-          output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
       - name: Generate checksums
         shell: bash
         env:
@@ -165,7 +157,6 @@ jobs:
           path: |
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.${{ matrix.archive_extension }}
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.sha256.txt
-            ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
 
   release-binaries-best-effort:
     name: release-binaries-best-effort (${{ matrix.target }})
@@ -220,14 +211,6 @@ jobs:
           archive_basename="ragloom-${RELEASE_TAG}-${{ matrix.target }}"
           tar -C "dist/${{ matrix.target }}" -czf "dist/${archive_basename}.tar.gz" "${{ matrix.binary_name }}"
 
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
-        with:
-          path: dist/${{ matrix.target }}
-          output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
       - name: Generate checksums
         shell: bash
         env:
@@ -249,7 +232,6 @@ jobs:
           path: |
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.${{ matrix.archive_extension }}
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.sha256.txt
-            ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
 
   publish-release:
     name: publish-release
@@ -292,7 +274,9 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          pattern: release-*
           path: release-artifacts
+          merge-multiple: true
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-02
+
 ### Added
 - Persistent local failed-work journal at `failed.ndjson` beside the WAL so
   exhausted or terminal ingest work can be inspected and operator-replayed
@@ -16,11 +18,16 @@
 - Semantic chunking remains experimental and opt-in for `v0.4.1`, while
   `--semantic-provider` and `--semantic-percentile` now only apply when the
   semantic path is active in router or single-semantic mode.
+- GitHub Release publication now uploads only the packaged archives plus their
+  `.sha256.txt` verification files, and filters out unrelated workflow
+  artifacts such as coverage outputs.
 
 ### Docs
 - Clarified that semantic chunking remains experimental and opt-in, and that
   `fastembed` remains a feature-gated semantic provider for both router and
   single-semantic mode.
+- Aligned the installation and support docs with the slimmer release-asset set
+  and the `v0.4.1` archive examples.
 
 ## [0.4.0] - 2026-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ragloom"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ragloom"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Bizer <3411596361@qq.com>"]
 description = "The minimalist RAG ingestion engine"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Best-effort macOS assets are published with the same naming pattern when those j
 - `ragloom-v<version>-x86_64-apple-darwin.tar.gz`
 - `ragloom-v<version>-aarch64-apple-darwin.tar.gz`
 
-Each release also includes a matching `.sha256.txt` checksum file and `.spdx.json` SBOM.
+Each release also includes a matching `.sha256.txt` checksum file for archive verification.
 
 ### Install a release binary
 
@@ -172,12 +172,12 @@ Download the archive for your platform from the GitHub Release page, extract it,
 Examples:
 
 ```bash
-tar -xzf ragloom-v0.4.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf ragloom-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
 ./ragloom --version
 ```
 
 ```powershell
-Expand-Archive .\ragloom-v0.4.0-x86_64-pc-windows-msvc.zip -DestinationPath .
+Expand-Archive .\ragloom-v0.4.1-x86_64-pc-windows-msvc.zip -DestinationPath .
 .\ragloom.exe --version
 ```
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -25,7 +25,7 @@ Ragloom publishes artifacts through:
 
 Maintainers should start releases from `.github/workflows/release.yml` using
 `workflow_dispatch` with an explicit crate version from `Cargo.toml`
-(for example `0.4.0`).
+(for example `0.4.1`).
 
 The release workflow verifies that:
 
@@ -43,12 +43,12 @@ published notes come from the repository event history rather than ad hoc local
 release text.
 
 GitHub Release archives are published with explicit target names such as
-`ragloom-v0.4.0-x86_64-unknown-linux-gnu.tar.gz` and
-`ragloom-v0.4.0-x86_64-pc-windows-msvc.zip`.
+`ragloom-v0.4.1-x86_64-unknown-linux-gnu.tar.gz` and
+`ragloom-v0.4.1-x86_64-pc-windows-msvc.zip`.
 
-Each published archive also includes a matching `.sha256.txt` checksum file and
-`.spdx.json` SBOM. Release checksums are generated with a platform-aware
-command so Linux targets use `sha256sum` while macOS targets use `shasum -a 256`.
+Each published archive also includes a matching `.sha256.txt` checksum file.
+Release checksums are generated with a platform-aware command so Linux targets
+use `sha256sum` while macOS targets use `shasum -a 256`.
 
 ## v0.4 Support Readiness
 

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -348,10 +348,8 @@ fn release_workflow_packages_named_assets_and_keeps_macos_best_effort() {
         "expected release workflow to package Windows assets as zip archives"
     );
     assert!(
-        supported_job_yaml.matches("upload-artifact: false").count() == 1
-            && best_effort_yaml.matches("upload-artifact: false").count() == 1
-            && !workflow_yaml.contains("upload-release-assets: true"),
-        "expected SBOM generation to avoid duplicate artifact uploads and let the explicit release artifact step own publication"
+        !workflow_yaml.contains("anchore/sbom-action") && !workflow_yaml.contains(".spdx.json"),
+        "expected the release workflow to avoid publishing low-value SBOM sidecar assets"
     );
     assert!(
         supported_job_yaml.contains("x86_64-unknown-linux-gnu")
@@ -368,6 +366,12 @@ fn release_workflow_packages_named_assets_and_keeps_macos_best_effort() {
             && best_effort_yaml.contains("aarch64-apple-darwin")
             && best_effort_yaml.contains("continue-on-error: true"),
         "expected macOS artifacts to remain best-effort and non-blocking"
+    );
+    assert!(
+        publish_release_yaml.contains("pattern: release-*")
+            && publish_release_yaml.contains("merge-multiple: true")
+            && !publish_release_yaml.contains("name: lcov"),
+        "expected publish-release to download only named release artifacts instead of unrelated workflow artifacts"
     );
     assert!(
         !publish_release_yaml.contains("release-binaries-best-effort"),


### PR DESCRIPTION
## Summary

Prepare the `v0.4.1` release cut and slim the GitHub Release asset set to only the platform archives plus their checksums.

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [x] Build / CI change
- [ ] Other

## Changes made

- bump `Cargo.toml` and `Cargo.lock` to `0.4.1`
- trim `release.yml` so GitHub Releases publish only archives and `.sha256.txt` files
- restrict release artifact download to `release-*` so coverage artifacts like `lcov.info` cannot leak into the Release
- align `README.md`, `SUPPORT.md`, and `CHANGELOG.md` with the `v0.4.1` release and slimmer asset policy
- add workflow contract coverage for the filtered release artifact behavior

## How to test

1. `cargo test --test release_workflow_contract --test docs_support_contract`
2. `cargo qa`
3. Inspect `.github/workflows/release.yml` and confirm `publish-release` downloads only `release-*` artifacts.

## Screenshots or recordings

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

This keeps the release page focused on installable artifacts while leaving deeper provenance or coverage outputs to workflow artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.4.1.
  * Release artifacts now include `.sha256.txt` checksum verification files.
  * Removed SBOM files from release distributions.
  * Updated installation instructions and documentation to reflect release artifact changes and new version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->