### PR TITLE
fix: add explicit compact-state command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,6 @@ jobs:
             -Path "dist/${{ matrix.target }}/${{ matrix.binary_name }}" `
             -DestinationPath "dist/$archiveBasename.zip"
 
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
-        with:
-          path: dist/${{ matrix.target }}
-          output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
       - name: Generate checksums
         shell: bash
         env:
@@ -165,7 +157,6 @@ jobs:
           path: |
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.${{ matrix.archive_extension }}
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.sha256.txt
-            ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
 
   release-binaries-best-effort:
     name: release-binaries-best-effort (${{ matrix.target }})
@@ -220,14 +211,6 @@ jobs:
           archive_basename="ragloom-${RELEASE_TAG}-${{ matrix.target }}"
           tar -C "dist/${{ matrix.target }}" -czf "dist/${archive_basename}.tar.gz" "${{ matrix.binary_name }}"
 
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
-        with:
-          path: dist/${{ matrix.target }}
-          output-file: ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
       - name: Generate checksums
         shell: bash
         env:
@@ -249,7 +232,6 @@ jobs:
           path: |
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.${{ matrix.archive_extension }}
             dist/ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.sha256.txt
-            ragloom-${{ needs.prepare-release.outputs.tag }}-${{ matrix.target }}.spdx.json
 
   publish-release:
     name: publish-release
@@ -292,7 +274,9 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          pattern: release-*
           path: release-artifacts
+          merge-multiple: true
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-02
+
 ### Added
 - Persistent local failed-work journal at `failed.ndjson` beside the WAL so
   exhausted or terminal ingest work can be inspected and operator-replayed
@@ -16,11 +18,16 @@
 - Semantic chunking remains experimental and opt-in for `v0.4.1`, while
   `--semantic-provider` and `--semantic-percentile` now only apply when the
   semantic path is active in router or single-semantic mode.
+- GitHub Release publication now uploads only the packaged archives plus their
+  `.sha256.txt` verification files, and filters out unrelated workflow
+  artifacts such as coverage outputs.
 
 ### Docs
 - Clarified that semantic chunking remains experimental and opt-in, and that
   `fastembed` remains a feature-gated semantic provider for both router and
   single-semantic mode.
+- Aligned the installation and support docs with the slimmer release-asset set
+  and the `v0.4.1` archive examples.
 
 ## [0.4.0] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- Explicit `ragloom compact-state` command to crash-safely compact
+  `wal.ndjson` and `failed.ndjson` without changing startup replay,
+  planner de-duplication, delete-sync behavior, or failed-work replay
+  semantics.
+
+### Docs
+- Documented the state-compaction safety boundary, including Linux/Unix
+  rename-plus-directory-sync behavior and Windows native file replacement.
+
 ## [0.4.1] - 2026-06-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ragloom"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ragloom"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Bizer <3411596361@qq.com>"]
 description = "The minimalist RAG ingestion engine"

--- a/README.md
+++ b/README.md
@@ -461,6 +461,33 @@ Replay is intentionally at-least-once: if a prior replay appended work into the
 WAL but crashed before marking the failed record requeued, rerunning
 `replay-failed` may append that work again rather than silently losing it.
 
+To compact both journals without changing replay semantics, run:
+
+```bash
+ragloom compact-state --state-path .ragloom/wal.ndjson
+```
+
+Or reuse YAML state configuration:
+
+```bash
+ragloom compact-state --config ./ragloom.yaml
+```
+
+`compact-state` is an explicit operator command. Ragloom does not compact state
+implicitly during normal ingest. The command rewrites `wal.ndjson` and
+`failed.ndjson` to the minimum records needed to preserve startup replay,
+planner de-duplication, delete synchronization, pending failed work, and
+`replay-failed` behavior.
+
+Compaction writes a same-directory temporary file, flushes it with
+`sync_data()`, and only then replaces the original journal. On Linux and other
+Unix targets, Ragloom uses same-directory rename plus parent-directory sync. On
+Windows, Ragloom uses the native file-replacement primitive so compaction can
+replace an existing journal without first deleting it. If validation, writing,
+or replacement fails, the original readable journal remains the safety
+boundary and Ragloom returns a `state` error instead of silently discarding
+records.
+
 ## Architecture
 
 ```text

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Best-effort macOS assets are published with the same naming pattern when those j
 - `ragloom-v<version>-x86_64-apple-darwin.tar.gz`
 - `ragloom-v<version>-aarch64-apple-darwin.tar.gz`
 
-Each release also includes a matching `.sha256.txt` checksum file and `.spdx.json` SBOM.
+Each release also includes a matching `.sha256.txt` checksum file for archive verification.
 
 ### Install a release binary
 
@@ -172,12 +172,12 @@ Download the archive for your platform from the GitHub Release page, extract it,
 Examples:
 
 ```bash
-tar -xzf ragloom-v0.4.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf ragloom-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
 ./ragloom --version
 ```
 
 ```powershell
-Expand-Archive .\ragloom-v0.4.0-x86_64-pc-windows-msvc.zip -DestinationPath .
+Expand-Archive .\ragloom-v0.4.1-x86_64-pc-windows-msvc.zip -DestinationPath .
 .\ragloom.exe --version
 ```
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -25,7 +25,7 @@ Ragloom publishes artifacts through:
 
 Maintainers should start releases from `.github/workflows/release.yml` using
 `workflow_dispatch` with an explicit crate version from `Cargo.toml`
-(for example `0.4.0`).
+(for example `0.4.1`).
 
 The release workflow verifies that:
 
@@ -43,12 +43,12 @@ published notes come from the repository event history rather than ad hoc local
 release text.
 
 GitHub Release archives are published with explicit target names such as
-`ragloom-v0.4.0-x86_64-unknown-linux-gnu.tar.gz` and
-`ragloom-v0.4.0-x86_64-pc-windows-msvc.zip`.
+`ragloom-v0.4.1-x86_64-unknown-linux-gnu.tar.gz` and
+`ragloom-v0.4.1-x86_64-pc-windows-msvc.zip`.
 
-Each published archive also includes a matching `.sha256.txt` checksum file and
-`.spdx.json` SBOM. Release checksums are generated with a platform-aware
-command so Linux targets use `sha256sum` while macOS targets use `shasum -a 256`.
+Each published archive also includes a matching `.sha256.txt` checksum file.
+Release checksums are generated with a platform-aware command so Linux targets
+use `sha256sum` while macOS targets use `shasum -a 256`.
 
 ## v0.4 Support Readiness
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -75,6 +75,13 @@ macOS binaries are provided as convenience artifacts. They should compile and pu
 When a macOS build succeeds, its archive is appended to the existing GitHub
 Release after the supported Linux and Windows assets have already published.
 
+State-journal compaction is part of that Linux and Windows support boundary.
+On Unix targets, compaction uses same-directory rename plus parent-directory
+sync after writing and syncing the temporary file. On Windows, compaction uses
+the native replacement primitive for existing files. If replacement fails, the
+original journal is the durability boundary and the command returns a `state`
+error instead of dropping records.
+
 ## Feature Boundaries
 
 Core support boundary maintainers are hardening for the current `v0.4`

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,15 +18,16 @@ use ragloom::pipeline::runtime::{
 };
 use ragloom::source::runtime::{prepare_source_runtime, resolve_run_source};
 use ragloom::startup::{
-    EmbedBackend, PreparedStartup, ReplayFailedConfig, RunConfig, prepare_startup,
-    replay_failed_command, validate_reloadable_changes, validate_startup,
+    CompactStateConfig, EmbedBackend, PreparedStartup, ReplayFailedConfig, RunConfig,
+    compact_state_command, prepare_startup, replay_failed_command, validate_reloadable_changes,
+    validate_startup,
 };
 use ragloom::state::failed::{
     FailedWorkJournal, FileFailedWorkStore, failed_work_path_from_state_path,
 };
 
 const CONFIG_RELOAD_POLL_INTERVAL: Duration = Duration::from_secs(1);
-const CLI_USAGE: &str = "usage: ragloom [check|dry-run|replay-failed] [--config <path>] [--source-kind <filesystem|s3>] [--dir <path>] [--s3-bucket <name>] [--s3-prefix <prefix>] --qdrant-url <url> --collection <name> [--state-path <path>] [--health-addr <host:port>] [--retry-max-attempts <n>] [--embed-backend <openai|http>] (omit command to run ingestion)";
+const CLI_USAGE: &str = "usage: ragloom [check|dry-run|replay-failed|compact-state] [--config <path>] [--source-kind <filesystem|s3>] [--dir <path>] [--s3-bucket <name>] [--s3-prefix <prefix>] --qdrant-url <url> --collection <name> [--state-path <path>] [--health-addr <host:port>] [--retry-max-attempts <n>] [--embed-backend <openai|http>] (omit command to run ingestion)";
 
 /// Top-level CLI command selected by argument parsing.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -37,6 +38,7 @@ pub enum ParsedCommand {
     Check(Box<RunConfig>),
     DryRun(Box<RunConfig>),
     ReplayFailed(ReplayFailedConfig),
+    CompactState(CompactStateConfig),
     Help,
     Version,
 }
@@ -82,6 +84,7 @@ enum RawParsedCommand {
     Check(Box<RawCliArgs>),
     DryRun(Box<RawCliArgs>),
     ReplayFailed(Box<RawCliArgs>),
+    CompactState(Box<RawCliArgs>),
     Help,
     Version,
 }
@@ -120,6 +123,9 @@ pub fn parse_args(args: &[String]) -> Result<ParsedCommand, RagloomError> {
         RawParsedCommand::ReplayFailed(raw) => Ok(ParsedCommand::ReplayFailed(
             build_replay_failed_config(*raw)?,
         )),
+        RawParsedCommand::CompactState(raw) => Ok(ParsedCommand::CompactState(
+            build_compact_state_config(*raw)?,
+        )),
         RawParsedCommand::Run(raw) => {
             let file_config = raw
                 .config_path
@@ -143,7 +149,10 @@ fn parse_reload_run_config_from_contents(
         RawParsedCommand::Run(raw)
         | RawParsedCommand::Check(raw)
         | RawParsedCommand::DryRun(raw) => *raw,
-        RawParsedCommand::ReplayFailed(_) | RawParsedCommand::Help | RawParsedCommand::Version => {
+        RawParsedCommand::ReplayFailed(_)
+        | RawParsedCommand::CompactState(_)
+        | RawParsedCommand::Help
+        | RawParsedCommand::Version => {
             return Err(
                 RagloomError::from_kind(RagloomErrorKind::Config).with_context(format!(
                     "config reload expected runtime command for {}",
@@ -168,9 +177,10 @@ fn parse_raw_cli_args(args: &[String]) -> Result<RawParsedCommand, RagloomError>
             "check" => "check",
             "dry-run" => "dry-run",
             "replay-failed" => "replay-failed",
+            "compact-state" => "compact-state",
             other => {
                 return Err(cli_invalid_input(format!(
-                    "unknown command: {other} (expected: check|dry-run|replay-failed, or omit command to run ingestion)"
+                    "unknown command: {other} (expected: check|dry-run|replay-failed|compact-state, or omit command to run ingestion)"
                 )));
             }
         };
@@ -254,6 +264,7 @@ fn parse_raw_cli_args(args: &[String]) -> Result<RawParsedCommand, RagloomError>
         "check" => RawParsedCommand::Check(Box::new(raw)),
         "dry-run" => RawParsedCommand::DryRun(Box::new(raw)),
         "replay-failed" => RawParsedCommand::ReplayFailed(Box::new(raw)),
+        "compact-state" => RawParsedCommand::CompactState(Box::new(raw)),
         _ => unreachable!("validated command"),
     })
 }
@@ -647,7 +658,50 @@ fn build_replay_failed_config(raw: RawCliArgs) -> Result<ReplayFailedConfig, Rag
     Ok(ReplayFailedConfig { state_path })
 }
 
+fn build_compact_state_config(raw: RawCliArgs) -> Result<CompactStateConfig, RagloomError> {
+    ensure_compact_state_flags_supported(&raw)?;
+
+    if raw.state_path.is_none() && raw.config_path.is_none() {
+        return Err(cli_config_error(
+            "compact-state requires --state-path or --config",
+        ));
+    }
+
+    let config_provided = raw.config_path.is_some();
+    let file_state_path = raw
+        .config_path
+        .as_deref()
+        .map(load_replay_failed_file_config)
+        .transpose()?
+        .and_then(|cfg| cfg.state.map(|state| state.path));
+
+    if raw.state_path.is_none() && config_provided && file_state_path.is_none() {
+        return Err(cli_config_error(
+            "compact-state requires state.path in --config or an explicit --state-path",
+        ));
+    }
+
+    let state_path = raw
+        .state_path
+        .or(file_state_path)
+        .ok_or_else(|| cli_config_error("compact-state requires --state-path or --config"))?;
+
+    if state_path.trim().is_empty() {
+        return Err(cli_config_error("--state-path or state.path is empty"));
+    }
+
+    Ok(CompactStateConfig { state_path })
+}
+
 fn ensure_replay_failed_flags_supported(raw: &RawCliArgs) -> Result<(), RagloomError> {
+    ensure_state_only_flags_supported(raw, "replay-failed")
+}
+
+fn ensure_compact_state_flags_supported(raw: &RawCliArgs) -> Result<(), RagloomError> {
+    ensure_state_only_flags_supported(raw, "compact-state")
+}
+
+fn ensure_state_only_flags_supported(raw: &RawCliArgs, command: &str) -> Result<(), RagloomError> {
     let unsupported = [
         raw.source_kind.as_ref().map(|_| "--source-kind"),
         raw.dir.as_ref().map(|_| "--dir"),
@@ -695,19 +749,19 @@ fn ensure_replay_failed_flags_supported(raw: &RawCliArgs) -> Result<(), RagloomE
     .next();
 
     if raw.create_collection_if_missing {
-        return Err(cli_invalid_input(
-            "replay-failed only accepts --config and --state-path",
-        ));
+        return Err(cli_invalid_input(format!(
+            "{command} only accepts --config and --state-path"
+        )));
     }
     if raw.enable_semantic {
-        return Err(cli_invalid_input(
-            "replay-failed only accepts --config and --state-path",
-        ));
+        return Err(cli_invalid_input(format!(
+            "{command} only accepts --config and --state-path"
+        )));
     }
     if unsupported.is_some() {
-        return Err(cli_invalid_input(
-            "replay-failed only accepts --config and --state-path",
-        ));
+        return Err(cli_invalid_input(format!(
+            "{command} only accepts --config and --state-path"
+        )));
     }
 
     Ok(())
@@ -855,6 +909,21 @@ async fn try_main() -> Result<(), RagloomError> {
         ParsedCommand::ReplayFailed(cfg) => {
             let replayed = replay_failed_command(&cfg).await?;
             println!("ragloom replay-failed requeued {replayed} work items");
+            return Ok(());
+        }
+        ParsedCommand::CompactState(cfg) => {
+            let summary = compact_state_command(&cfg).await?;
+            println!(
+                "ragloom compact-state wal records {} -> {}, bytes {} -> {}; failed-work records {} -> {}, bytes {} -> {}",
+                summary.wal.records_before,
+                summary.wal.records_after,
+                summary.wal.bytes_before,
+                summary.wal.bytes_after,
+                summary.failed_work.records_before,
+                summary.failed_work.records_after,
+                summary.failed_work.bytes_before,
+                summary.failed_work.bytes_after
+            );
             return Ok(());
         }
         ParsedCommand::Run(cfg) => *cfg,
@@ -1718,6 +1787,24 @@ sink:
     }
 
     #[test]
+    fn parse_args_returns_compact_state_command() {
+        let args = vec![
+            "ragloom".to_string(),
+            "compact-state".to_string(),
+            "--state-path".to_string(),
+            ".state/ragloom.ndjson".to_string(),
+        ];
+
+        let cmd = parse_args(&args).expect("compact-state command");
+        assert_eq!(
+            cmd,
+            ParsedCommand::CompactState(CompactStateConfig {
+                state_path: ".state/ragloom.ndjson".to_string(),
+            })
+        );
+    }
+
+    #[test]
     fn parse_args_replay_failed_reads_state_path_from_config_only() {
         let mut file = NamedTempFile::new().expect("temp file");
         file.write_all(
@@ -1783,6 +1870,22 @@ state:
     }
 
     #[test]
+    fn parse_args_compact_state_rejects_runtime_flags() {
+        let args = vec![
+            "ragloom".to_string(),
+            "compact-state".to_string(),
+            "--state-path".to_string(),
+            ".state/ragloom.ndjson".to_string(),
+            "--dir".to_string(),
+            "/tmp/docs".to_string(),
+        ];
+
+        let err = parse_args(&args).expect_err("must reject runtime flags");
+        assert_eq!(err.kind, RagloomErrorKind::InvalidInput);
+        assert!(err.to_string().contains("compact-state only accepts"));
+    }
+
+    #[test]
     fn parse_args_replay_failed_requires_state_path_or_config() {
         let args = vec!["ragloom".to_string(), "replay-failed".to_string()];
 
@@ -1791,6 +1894,18 @@ state:
         assert!(
             err.to_string()
                 .contains("replay-failed requires --state-path or --config")
+        );
+    }
+
+    #[test]
+    fn parse_args_compact_state_requires_state_path_or_config() {
+        let args = vec!["ragloom".to_string(), "compact-state".to_string()];
+
+        let err = parse_args(&args).expect_err("missing state-path or config");
+        assert_eq!(err.kind, RagloomErrorKind::Config);
+        assert!(
+            err.to_string()
+                .contains("compact-state requires --state-path or --config")
         );
     }
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use crate::error::{RagloomError, RagloomErrorKind};
 use crate::sink::qdrant::{QdrantConfig, QdrantSink};
 use crate::source::runtime::{RunSource, prepare_source_runtime};
+use crate::state::compact::{StateCompactionSummary, compact_state_files};
 use crate::state::failed::{
     FailedWorkRecord, FailedWorkStore, FileFailedWorkStore, failed_work_path_from_state_path,
     pending_failed_work,
@@ -89,6 +90,11 @@ pub struct RunConfig {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ReplayFailedConfig {
+    pub state_path: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CompactStateConfig {
     pub state_path: String,
 }
 
@@ -612,6 +618,13 @@ pub async fn replay_failed_command(cfg: &ReplayFailedConfig) -> Result<usize, Ra
         .map_err(|e| e.with_context("failed to initialize failed-work store"))?;
 
     replay_failed_into_wal(&mut wal, &mut failed_store)
+}
+
+pub async fn compact_state_command(
+    cfg: &CompactStateConfig,
+) -> Result<StateCompactionSummary, RagloomError> {
+    let failed_path = failed_work_path_from_state_path(&cfg.state_path);
+    compact_state_files(std::path::Path::new(&cfg.state_path), &failed_path)
 }
 
 #[cfg(test)]
@@ -1356,6 +1369,150 @@ mod tests {
         let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
         assert_eq!(replayed, 1);
         assert_eq!(wal.read_all().expect("read wal"), vec![work.clone(), work]);
+    }
+
+    #[tokio::test]
+    async fn compact_state_command_preserves_observable_replay_state() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        let failed_path = dir.path().join("failed.ndjson");
+
+        let mut wal = crate::state::wal::FileWal::open(&wal_path).expect("open wal");
+        let a_v1 = crate::ids::FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: None,
+        };
+        let a_v2 = crate::ids::FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 11,
+            mtime_unix_secs: 101,
+            etag: None,
+        };
+        let b_v1 = crate::ids::FileFingerprint {
+            canonical_path: "/x/b.txt".to_string(),
+            size_bytes: 20,
+            mtime_unix_secs: 200,
+            etag: None,
+        };
+        wal.append(crate::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: a_v1.clone(),
+        })
+        .expect("append work");
+        wal.append(crate::state::wal::WalRecord::SinkAckV2 {
+            fingerprint: a_v1.clone(),
+        })
+        .expect("append ack");
+        wal.append(crate::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: a_v2.clone(),
+        })
+        .expect("append pending work");
+        wal.append(crate::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: b_v1.clone(),
+        })
+        .expect("append b work");
+        wal.append(crate::state::wal::WalRecord::SinkAckV2 {
+            fingerprint: b_v1.clone(),
+        })
+        .expect("append b ack");
+        wal.append(crate::state::wal::WalRecord::DeleteDocument {
+            canonical_path: "/x/c.txt".to_string(),
+        })
+        .expect("append delete");
+
+        let mut failed = FileFailedWorkStore::open(&failed_path).expect("open failed");
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: crate::state::wal::WalRecord::DeleteDocument {
+                    canonical_path: "/x/c.txt".to_string(),
+                },
+                failure_kind: crate::state::failed::FailedWorkFailureKind::Sink,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 3,
+            })
+            .expect("append failed exhausted");
+        failed
+            .append(FailedWorkRecord::Requeued { exhausted_id: 1 })
+            .expect("append requeued");
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 2,
+                work: crate::state::wal::WalRecord::WorkItemV2 {
+                    fingerprint: a_v2.clone(),
+                },
+                failure_kind: crate::state::failed::FailedWorkFailureKind::Embed,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::NonRetryable,
+                attempts: 1,
+            })
+            .expect("append pending failed exhausted");
+
+        let wal_before = crate::state::wal::FileWal::open(&wal_path)
+            .expect("reopen wal")
+            .read_all()
+            .expect("read wal before");
+        let failed_before = FileFailedWorkStore::open(&failed_path)
+            .expect("reopen failed")
+            .read_all()
+            .expect("read failed before");
+
+        let summary = compact_state_command(&CompactStateConfig {
+            state_path: wal_path.to_string_lossy().to_string(),
+        })
+        .await
+        .expect("compact state");
+
+        assert!(summary.wal.records_after <= summary.wal.records_before);
+        assert!(summary.failed_work.records_after <= summary.failed_work.records_before);
+
+        let wal_after = crate::state::wal::FileWal::open(&wal_path)
+            .expect("reopen wal after")
+            .read_all()
+            .expect("read wal after");
+        let failed_after = FileFailedWorkStore::open(&failed_path)
+            .expect("reopen failed after")
+            .read_all()
+            .expect("read failed after");
+
+        assert_eq!(
+            crate::state::wal::unacked_work_items(&wal_after),
+            crate::state::wal::unacked_work_items(&wal_before)
+        );
+        assert_eq!(
+            crate::state::wal::known_live_document_paths(&wal_after),
+            crate::state::wal::known_live_document_paths(&wal_before)
+        );
+        assert_eq!(
+            crate::state::failed::pending_failed_work(&failed_after),
+            crate::state::failed::pending_failed_work(&failed_before)
+        );
+        assert_eq!(
+            crate::state::failed::next_failed_work_id(&failed_after),
+            crate::state::failed::next_failed_work_id(&failed_before)
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_state_command_fails_on_malformed_wal_without_replacing_original() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        std::fs::write(&wal_path, "{not json}\n").expect("write malformed wal");
+
+        let err = compact_state_command(&CompactStateConfig {
+            state_path: wal_path.to_string_lossy().to_string(),
+        })
+        .await
+        .expect_err("malformed wal should fail");
+
+        assert!(
+            err.to_string()
+                .contains("failed to initialize persistent WAL")
+        );
+        assert_eq!(
+            std::fs::read_to_string(&wal_path).expect("read original wal"),
+            "{not json}\n"
+        );
     }
 
     #[test]

--- a/src/state/compact.rs
+++ b/src/state/compact.rs
@@ -1,0 +1,537 @@
+//! Crash-safe state compaction for append-only journals.
+//!
+//! # Why
+//! Ragloom's WAL and failed-work journal intentionally grow by durable appends.
+//! Explicit compaction lets operators reclaim space while preserving the
+//! replay, acknowledgement, and delete-sync behavior derived from those logs.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::error::{RagloomError, RagloomErrorKind};
+use crate::state::failed::{FailedWorkRecord, next_failed_work_id, pending_failed_work};
+use crate::state::wal::WalRecord;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JournalCompactionSummary {
+    pub records_before: usize,
+    pub records_after: usize,
+    pub bytes_before: u64,
+    pub bytes_after: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateCompactionSummary {
+    pub wal: JournalCompactionSummary,
+    pub failed_work: JournalCompactionSummary,
+}
+
+pub fn compact_wal_records(records: &[WalRecord]) -> Vec<WalRecord> {
+    let mut legacy = std::collections::BTreeMap::<[u8; 32], (usize, WalRecord)>::new();
+    let mut live_files = std::collections::BTreeMap::<String, (usize, WalRecord)>::new();
+    let mut pending_deletes = std::collections::BTreeMap::<String, (usize, WalRecord)>::new();
+
+    for (idx, record) in records.iter().enumerate() {
+        match record {
+            WalRecord::WorkItem { chunk_id } | WalRecord::SinkAck { chunk_id } => {
+                legacy.insert(*chunk_id, (idx, record.clone()));
+            }
+            WalRecord::WorkItemV2 { fingerprint } | WalRecord::SinkAckV2 { fingerprint } => {
+                pending_deletes.remove(&fingerprint.canonical_path);
+                live_files.insert(fingerprint.canonical_path.clone(), (idx, record.clone()));
+            }
+            WalRecord::DeleteDocument { canonical_path } => {
+                live_files.remove(canonical_path);
+                pending_deletes.insert(canonical_path.clone(), (idx, record.clone()));
+            }
+            WalRecord::DeleteAck { canonical_path } => {
+                pending_deletes.remove(canonical_path);
+            }
+        }
+    }
+
+    let mut compacted = legacy
+        .into_values()
+        .chain(live_files.into_values())
+        .chain(pending_deletes.into_values())
+        .collect::<Vec<_>>();
+    compacted.sort_by_key(|(idx, _)| *idx);
+    compacted.into_iter().map(|(_, record)| record).collect()
+}
+
+pub fn compact_failed_work_records(records: &[FailedWorkRecord]) -> Vec<FailedWorkRecord> {
+    let mut exhausted_by_id = std::collections::BTreeMap::<u64, (usize, FailedWorkRecord)>::new();
+    let mut requeued_by_id = std::collections::BTreeMap::<u64, (usize, FailedWorkRecord)>::new();
+
+    for (idx, record) in records.iter().enumerate() {
+        match record {
+            FailedWorkRecord::Exhausted { id, .. } => {
+                exhausted_by_id.insert(*id, (idx, record.clone()));
+            }
+            FailedWorkRecord::Requeued { exhausted_id } => {
+                requeued_by_id.insert(*exhausted_id, (idx, record.clone()));
+            }
+        }
+    }
+
+    let mut keep = pending_failed_work(records)
+        .into_iter()
+        .filter_map(|pending| exhausted_by_id.get(&pending.id).cloned())
+        .collect::<Vec<_>>();
+
+    let highest_id = next_failed_work_id(records).saturating_sub(1);
+    if highest_id != 0
+        && !keep.iter().any(|(_, record)| {
+            matches!(record, FailedWorkRecord::Exhausted { id, .. } if *id == highest_id)
+        })
+        && let (Some(exhausted), Some(requeued)) = (
+            exhausted_by_id.get(&highest_id),
+            requeued_by_id.get(&highest_id),
+        )
+    {
+        keep.push(exhausted.clone());
+        keep.push(requeued.clone());
+    }
+
+    keep.sort_by_key(|(idx, _)| *idx);
+    keep.into_iter().map(|(_, record)| record).collect()
+}
+
+pub fn compact_state_files(
+    wal_path: &Path,
+    failed_work_path: &Path,
+) -> Result<StateCompactionSummary, RagloomError> {
+    let wal_records = crate::state::wal::FileWal::open(wal_path)
+        .map_err(|e| e.with_context("failed to initialize persistent WAL"))?
+        .read_all()
+        .map_err(|e| e.with_context("failed to read WAL before compaction"))?;
+    let failed_records = crate::state::failed::FileFailedWorkStore::open(failed_work_path)
+        .map_err(|e| e.with_context("failed to initialize failed-work store"))?
+        .read_all()
+        .map_err(|e| e.with_context("failed to read failed-work store before compaction"))?;
+
+    let compacted_wal = compact_wal_records(&wal_records);
+    let compacted_failed = compact_failed_work_records(&failed_records);
+
+    let wal_summary = rewrite_journal_file(
+        wal_path,
+        &wal_records,
+        &compacted_wal,
+        serde_json::to_string,
+        "WAL",
+    )?;
+    let failed_work_summary = rewrite_journal_file(
+        failed_work_path,
+        &failed_records,
+        &compacted_failed,
+        serde_json::to_string,
+        "failed-work",
+    )?;
+
+    Ok(StateCompactionSummary {
+        wal: wal_summary,
+        failed_work: failed_work_summary,
+    })
+}
+
+fn rewrite_journal_file<T>(
+    path: &Path,
+    before: &[T],
+    after: &[T],
+    encode: impl Fn(&T) -> Result<String, serde_json::Error>,
+    label: &str,
+) -> Result<JournalCompactionSummary, RagloomError> {
+    let bytes_before = file_len_or_zero(path)?;
+    let temp_path = temp_compaction_path(path);
+    rewrite_journal_file_with_temp_path(path, &temp_path, after, &encode, label)?;
+    let bytes_after = file_len_or_zero(path)?;
+
+    Ok(JournalCompactionSummary {
+        records_before: before.len(),
+        records_after: after.len(),
+        bytes_before,
+        bytes_after,
+    })
+}
+
+fn rewrite_journal_file_with_temp_path<T>(
+    path: &Path,
+    temp_path: &Path,
+    records: &[T],
+    encode: &impl Fn(&T) -> Result<String, serde_json::Error>,
+    label: &str,
+) -> Result<(), RagloomError> {
+    let mut temp_file = create_temp_compaction_file(temp_path, label)?;
+    write_ndjson_records(&mut temp_file, records, encode, path, label)?;
+    temp_file.sync_data().map_err(|e| {
+        RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+            "failed to sync compacted {label} temp file: {}",
+            temp_path.display()
+        ))
+    })?;
+    drop(temp_file);
+
+    replace_file_with_temp(path, temp_path, label).inspect_err(|_| {
+        let _ = std::fs::remove_file(temp_path);
+    })?;
+    sync_parent_directory(path, label)?;
+    Ok(())
+}
+
+fn write_ndjson_records<T>(
+    file: &mut File,
+    records: &[T],
+    encode: &impl Fn(&T) -> Result<String, serde_json::Error>,
+    path: &Path,
+    label: &str,
+) -> Result<(), RagloomError> {
+    for record in records {
+        let encoded = encode(record).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e)
+                .with_context(format!("failed to encode compacted {label} record"))
+        })?;
+        writeln!(file, "{encoded}").map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to write compacted {label} temp file for {}",
+                path.display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn file_len_or_zero(path: &Path) -> Result<u64, RagloomError> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.len()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(err) => Err(RagloomError::new(RagloomErrorKind::State, err)
+            .with_context(format!("failed to stat state file: {}", path.display()))),
+    }
+}
+
+fn temp_compaction_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("state.ndjson");
+    path.with_file_name(format!("{file_name}.compact.tmp"))
+}
+
+fn create_temp_compaction_file(path: &Path, label: &str) -> Result<File, RagloomError> {
+    std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to create compacted {label} temp file: {}",
+                path.display()
+            ))
+        })
+}
+
+fn replace_file_with_temp(path: &Path, temp_path: &Path, label: &str) -> Result<(), RagloomError> {
+    #[cfg(unix)]
+    {
+        std::fs::rename(temp_path, path).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to replace {label} file with compacted temp file: {}",
+                path.display()
+            ))
+        })?;
+        return Ok(());
+    }
+
+    #[cfg(windows)]
+    {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+
+        fn wide(s: &OsStr) -> Vec<u16> {
+            s.encode_wide().chain(std::iter::once(0)).collect()
+        }
+
+        unsafe extern "system" {
+            fn ReplaceFileW(
+                lpReplacedFileName: *const u16,
+                lpReplacementFileName: *const u16,
+                lpBackupFileName: *const u16,
+                dwReplaceFlags: u32,
+                lpExclude: *mut core::ffi::c_void,
+                lpReserved: *mut core::ffi::c_void,
+            ) -> i32;
+        }
+
+        const REPLACEFILE_WRITE_THROUGH: u32 = 0x0000_0001;
+        const REPLACEFILE_IGNORE_MERGE_ERRORS: u32 = 0x0000_0002;
+
+        let target = wide(path.as_os_str());
+        let replacement = wide(temp_path.as_os_str());
+
+        // Use the native replace primitive on Windows so compaction can
+        // replace an existing journal without first deleting the original.
+        let replaced = unsafe {
+            ReplaceFileW(
+                target.as_ptr(),
+                replacement.as_ptr(),
+                std::ptr::null(),
+                REPLACEFILE_WRITE_THROUGH | REPLACEFILE_IGNORE_MERGE_ERRORS,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if replaced == 0 {
+            return Err(RagloomError::new(
+                RagloomErrorKind::State,
+                std::io::Error::last_os_error(),
+            )
+            .with_context(format!(
+                "failed to replace {label} file with compacted temp file: {}",
+                path.display()
+            )));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (path, temp_path, label);
+        Err(RagloomError::from_kind(RagloomErrorKind::State)
+            .with_context("state compaction file replacement is unsupported on this platform"))
+    }
+}
+
+fn sync_parent_directory(path: &Path, label: &str) -> Result<(), RagloomError> {
+    #[cfg(unix)]
+    {
+        let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        else {
+            return Ok(());
+        };
+        File::open(parent)
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to open {label} parent directory: {}",
+                    parent.display()
+                ))
+            })?
+            .sync_all()
+            .map_err(|e| {
+                RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                    "failed to sync {label} parent directory: {}",
+                    parent.display()
+                ))
+            })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (path, label);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::FileFingerprint;
+    use crate::pipeline::planner::Planner;
+    use crate::source::FileVersionDiscovered;
+    use crate::state::failed::{
+        FailedWorkFailureKind, FailedWorkTerminalReason, pending_failed_work,
+    };
+    use crate::state::wal::{known_live_document_paths, unacked_work_items};
+    use tempfile::tempdir;
+
+    fn work(path: &str, mtime: i64) -> WalRecord {
+        WalRecord::WorkItemV2 {
+            fingerprint: FileFingerprint {
+                canonical_path: path.to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: mtime,
+                etag: None,
+            },
+        }
+    }
+
+    fn ack(path: &str, mtime: i64) -> WalRecord {
+        match work(path, mtime) {
+            WalRecord::WorkItemV2 { fingerprint } => WalRecord::SinkAckV2 { fingerprint },
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn compact_wal_records_preserves_replay_and_live_document_observables() {
+        let records = vec![
+            work("/x/a.txt", 100),
+            ack("/x/a.txt", 100),
+            work("/x/b.txt", 200),
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+            WalRecord::DeleteAck {
+                canonical_path: "/x/a.txt".to_string(),
+            },
+            work("/x/c.txt", 300),
+            ack("/x/c.txt", 300),
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/d.txt".to_string(),
+            },
+            WalRecord::WorkItem {
+                chunk_id: [7u8; 32],
+            },
+            WalRecord::SinkAck {
+                chunk_id: [7u8; 32],
+            },
+        ];
+
+        let compacted = compact_wal_records(&records);
+
+        assert_eq!(unacked_work_items(&compacted), unacked_work_items(&records));
+        assert_eq!(
+            known_live_document_paths(&compacted),
+            known_live_document_paths(&records)
+        );
+
+        let discovered = FileVersionDiscovered {
+            fingerprint: FileFingerprint {
+                canonical_path: "/x/c.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 300,
+                etag: None,
+            },
+            file_version_id: crate::ids::file_version_id(&FileFingerprint {
+                canonical_path: "/x/c.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 300,
+                etag: None,
+            }),
+        };
+
+        let original_wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+        let compacted_wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+        let mut original_planner = Planner::from_wal_records(&records);
+        let mut compacted_planner = Planner::from_wal_records(&compacted);
+        original_planner
+            .plan_file_version(&discovered, &original_wal)
+            .expect("plan from original");
+        compacted_planner
+            .plan_file_version(&discovered, &compacted_wal)
+            .expect("plan from compacted");
+        assert_eq!(
+            original_wal
+                .try_lock()
+                .expect("original wal")
+                .read_all()
+                .expect("read original wal"),
+            compacted_wal
+                .try_lock()
+                .expect("compacted wal")
+                .read_all()
+                .expect("read compacted wal")
+        );
+    }
+
+    #[test]
+    fn compact_wal_records_is_idempotent() {
+        let records = vec![
+            work("/x/a.txt", 100),
+            ack("/x/a.txt", 100),
+            WalRecord::DeleteDocument {
+                canonical_path: "/x/b.txt".to_string(),
+            },
+        ];
+
+        let once = compact_wal_records(&records);
+        let twice = compact_wal_records(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn compact_failed_work_records_preserves_pending_and_next_id() {
+        let records = vec![
+            FailedWorkRecord::Exhausted {
+                id: 1,
+                work: work("/x/a.txt", 100),
+                failure_kind: FailedWorkFailureKind::Embed,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 3,
+            },
+            FailedWorkRecord::Requeued { exhausted_id: 1 },
+            FailedWorkRecord::Exhausted {
+                id: 2,
+                work: work("/x/b.txt", 200),
+                failure_kind: FailedWorkFailureKind::Sink,
+                terminal_reason: FailedWorkTerminalReason::NonRetryable,
+                attempts: 1,
+            },
+        ];
+
+        let compacted = compact_failed_work_records(&records);
+
+        assert_eq!(
+            pending_failed_work(&compacted),
+            pending_failed_work(&records)
+        );
+        assert_eq!(
+            next_failed_work_id(&compacted),
+            next_failed_work_id(&records)
+        );
+    }
+
+    #[test]
+    fn compact_failed_work_records_is_idempotent() {
+        let records = vec![
+            FailedWorkRecord::Exhausted {
+                id: 9,
+                work: work("/x/a.txt", 100),
+                failure_kind: FailedWorkFailureKind::Io,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            },
+            FailedWorkRecord::Requeued { exhausted_id: 9 },
+        ];
+
+        let once = compact_failed_work_records(&records);
+        let twice = compact_failed_work_records(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn rewrite_journal_file_with_temp_path_keeps_original_when_temp_creation_fails() {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("wal.ndjson");
+        std::fs::write(&path, "{\"type\":\"work_item\",\"chunk_id\":[1]}\n").expect("write");
+        let temp_path = dir.path().join("wal.ndjson.compact.tmp");
+        std::fs::write(&temp_path, "busy").expect("precreate temp");
+
+        let err = rewrite_journal_file_with_temp_path(
+            &path,
+            &temp_path,
+            &[WalRecord::DeleteDocument {
+                canonical_path: "/x/a.txt".to_string(),
+            }],
+            &|record| serde_json::to_string(record),
+            "WAL",
+        )
+        .expect_err("temp creation should fail");
+
+        assert!(
+            err.to_string()
+                .contains("failed to create compacted WAL temp file")
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read original"),
+            "{\"type\":\"work_item\",\"chunk_id\":[1]}\n"
+        );
+    }
+}

--- a/src/state/compact.rs
+++ b/src/state/compact.rs
@@ -240,7 +240,7 @@ fn replace_file_with_temp(path: &Path, temp_path: &Path, label: &str) -> Result<
                 path.display()
             ))
         })?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(windows)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,6 +5,7 @@
 //! not be tied to a specific storage engine, so we define a small trait surface
 //! that keeps the system open for extension.
 
+pub mod compact;
 pub mod failed;
 pub mod wal;
 

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -348,10 +348,8 @@ fn release_workflow_packages_named_assets_and_keeps_macos_best_effort() {
         "expected release workflow to package Windows assets as zip archives"
     );
     assert!(
-        supported_job_yaml.matches("upload-artifact: false").count() == 1
-            && best_effort_yaml.matches("upload-artifact: false").count() == 1
-            && !workflow_yaml.contains("upload-release-assets: true"),
-        "expected SBOM generation to avoid duplicate artifact uploads and let the explicit release artifact step own publication"
+        !workflow_yaml.contains("anchore/sbom-action") && !workflow_yaml.contains(".spdx.json"),
+        "expected the release workflow to avoid publishing low-value SBOM sidecar assets"
     );
     assert!(
         supported_job_yaml.contains("x86_64-unknown-linux-gnu")
@@ -368,6 +366,12 @@ fn release_workflow_packages_named_assets_and_keeps_macos_best_effort() {
             && best_effort_yaml.contains("aarch64-apple-darwin")
             && best_effort_yaml.contains("continue-on-error: true"),
         "expected macOS artifacts to remain best-effort and non-blocking"
+    );
+    assert!(
+        publish_release_yaml.contains("pattern: release-*")
+            && publish_release_yaml.contains("merge-multiple: true")
+            && !publish_release_yaml.contains("name: lcov"),
+        "expected publish-release to download only named release artifacts instead of unrelated workflow artifacts"
     );
     assert!(
         !publish_release_yaml.contains("release-binaries-best-effort"),


### PR DESCRIPTION
## Summary
- add an explicit `ragloom compact-state` CLI command wired through startup helpers
- compact WAL and failed-work journals down to the minimum records needed to preserve replay, delete-sync, and failed-work semantics
- document the operator workflow and platform-specific safety boundary for journal replacement

## Why
Issue #151 asks for an explicit, crash-safe state compaction command that reclaims append-only journal growth without changing Ragloom's replay behavior.

## Validation
- `cargo qa`

## Notes
- PR targets `ragloom/ragloom:main` from `BizerNotNull:fix/compact-state-command`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.4.1

* **New Features**
  * Added `compact-state` command to safely compact state journals while preserving replay and deduplication semantics

* **Documentation**
  * Updated installation examples to v0.4.1
  * Added documentation for new `compact-state` command with platform-specific behavior notes

* **Chores**
  * Version bump to 0.4.1
  * Removed SBOM artifacts from GitHub release bundles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->