### PR TITLE
Expand state preflight checks and replay summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,14 @@ cargo run --release -- dry-run \
   --openai-api-key "$OPENAI_API_KEY"
 ```
 
-`check` validates configuration, source wiring, chunker selection, and bootstrap prerequisites without starting ingest. `dry-run` performs the same validation and prints the effective startup choices, including source kind, chunker selection, and whether Ragloom would bootstrap the configured collection. Neither command sends embeddings or writes to Qdrant.
+`check` validates configuration, source wiring, chunker selection, bootstrap prerequisites,
+and local durable state without starting ingest. State preflight validates that existing WAL
+and failed-work journals are readable, use supported record formats, and are writable for a
+real run. Missing state directories succeed when their nearest existing parent is writable;
+the check does not create them. `check` prints the state path and concise journal statuses.
+`dry-run` performs the same validation and also prints the effective startup choices,
+including source kind, chunker selection, and whether Ragloom would bootstrap the configured
+collection. Neither command creates state, sends embeddings, or writes to Qdrant.
 
 With the default OpenAI model, `text-embedding-3-small`, Ragloom can infer the Qdrant vector size automatically during bootstrap.
 
@@ -474,6 +481,10 @@ ragloom replay-failed --config ./ragloom.yaml
 
 `replay-failed` requires either `--state-path` or `--config`. It does not require
 runtime ingest flags such as `--dir`, `--qdrant-url`, or `--collection`.
+On success it prints deterministic `pending`, `requeued`, `skipped`, and `failed`
+counts. `skipped` counts exhausted records already marked as requeued. An unsafe
+or incomplete replay returns a non-zero exit status and includes the partial
+summary in its error context.
 Replay is intentionally at-least-once: if a prior replay appended work into the
 WAL but crashed before marking the failed record requeued, rerunning
 `replay-failed` may append that work again rather than silently losing it.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -137,6 +137,18 @@ rich formatting, embedded assets, or full page layout fidelity.
 
 ## Getting Help
 
+### State preflight and replay diagnostics
+
+Run `ragloom check` with the normal runtime flags to validate local durable state
+before ingest startup. It reports the configured state path and whether the WAL
+and failed-work journal are readable and writable, or missing but safely
+creatable. The command does not create or append state.
+
+`ragloom replay-failed --state-path <path>` reports deterministic `pending`,
+`requeued`, `skipped`, and `failed` counts. A non-zero exit status means replay
+could not complete safely; preserve the journals and include the sanitized error
+context when requesting support.
+
 ### Check the documentation first
 
 - Review `README.md` for quickstart and configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -897,8 +897,11 @@ async fn try_main() -> Result<(), RagloomError> {
             return Ok(());
         }
         ParsedCommand::Check(cfg) => {
-            let _ = validate_startup(&cfg).await?;
-            println!("ragloom check ok");
+            let summary = validate_startup(&cfg).await?;
+            println!(
+                "ragloom check ok state_path={} wal={} failed_work={}",
+                summary.state_path, summary.wal_status, summary.failed_work_status
+            );
             return Ok(());
         }
         ParsedCommand::DryRun(cfg) => {
@@ -907,8 +910,11 @@ async fn try_main() -> Result<(), RagloomError> {
             return Ok(());
         }
         ParsedCommand::ReplayFailed(cfg) => {
-            let replayed = replay_failed_command(&cfg).await?;
-            println!("ragloom replay-failed requeued {replayed} work items");
+            let summary = replay_failed_command(&cfg).await?;
+            println!(
+                "ragloom replay-failed pending={} requeued={} skipped={} failed={}",
+                summary.pending, summary.requeued, summary.skipped, summary.failed
+            );
             return Ok(());
         }
         ParsedCommand::CompactState(cfg) => {
@@ -1775,6 +1781,23 @@ sink:
             "replay-failed".to_string(),
             "--state-path".to_string(),
             ".state/ragloom.ndjson".to_string(),
+        ];
+
+        let cmd = parse_args(&args).expect("replay-failed command");
+        assert_eq!(
+            cmd,
+            ParsedCommand::ReplayFailed(ReplayFailedConfig {
+                state_path: ".state/ragloom.ndjson".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_args_returns_replay_failed_command_with_inline_state_path() {
+        let args = vec![
+            "ragloom".to_string(),
+            "replay-failed".to_string(),
+            "--state-path=.state/ragloom.ndjson".to_string(),
         ];
 
         let cmd = parse_args(&args).expect("replay-failed command");

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1664,7 +1664,11 @@ mod tests {
         std::fs::set_permissions(&state_dir, original_permissions)
             .expect("restore state dir permissions");
         assert_eq!(err.kind, RagloomErrorKind::State);
-        assert!(err.to_string().contains("WAL path is not writable"));
+        let message = err.to_string();
+        assert!(
+            message.contains("failed to read WAL file")
+                || message.contains("WAL path is not writable")
+        );
     }
 
     #[tokio::test]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::error::{RagloomError, RagloomErrorKind};
@@ -93,6 +94,14 @@ pub struct ReplayFailedConfig {
     pub state_path: String,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ReplayFailedSummary {
+    pub pending: usize,
+    pub requeued: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CompactStateConfig {
     pub state_path: String,
@@ -128,6 +137,9 @@ pub struct StartupValidationSummary {
     pub embed_backend: String,
     pub chunker_selection: String,
     pub bootstrap: BootstrapPlan,
+    pub state_path: String,
+    pub wal_status: String,
+    pub failed_work_status: String,
 }
 
 impl StartupValidationSummary {
@@ -139,6 +151,9 @@ impl StartupValidationSummary {
             &format!("embed_backend={}", self.embed_backend),
             &format!("chunker={}", self.chunker_selection),
             &format!("bootstrap={}", self.bootstrap.render()),
+            &format!("state_path={}", self.state_path),
+            &format!("wal={}", self.wal_status),
+            &format!("failed_work={}", self.failed_work_status),
         ]
         .join("\n")
     }
@@ -487,6 +502,7 @@ pub async fn prepare_startup(
 pub async fn validate_startup(cfg: &RunConfig) -> Result<StartupValidationSummary, RagloomError> {
     let _ = prepare_startup(cfg, false).await?;
     let _ = prepare_source_runtime(&cfg.source, HashSet::new())?;
+    let state = validate_state_preflight(Path::new(&cfg.state_path))?;
 
     Ok(StartupValidationSummary {
         source_kind: cfg.source.kind().to_string(),
@@ -494,7 +510,124 @@ pub async fn validate_startup(cfg: &RunConfig) -> Result<StartupValidationSummar
         embed_backend: cfg.embed_backend.name().to_string(),
         chunker_selection: chunker_selection(cfg)?,
         bootstrap: bootstrap_plan(cfg)?,
+        state_path: cfg.state_path.clone(),
+        wal_status: state.wal_status,
+        failed_work_status: state.failed_work_status,
     })
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct StatePreflightSummary {
+    wal_status: String,
+    failed_work_status: String,
+}
+
+fn validate_state_preflight(state_path: &Path) -> Result<StatePreflightSummary, RagloomError> {
+    let failed_path = failed_work_path_from_state_path(state_path);
+    let wal_status = validate_state_journal::<crate::state::wal::WalRecord>(state_path, "WAL")?;
+    let failed_work_status =
+        validate_state_journal::<FailedWorkRecord>(&failed_path, "failed-work")?;
+    Ok(StatePreflightSummary {
+        wal_status,
+        failed_work_status,
+    })
+}
+
+fn validate_state_journal<T>(path: &Path, journal_name: &str) -> Result<String, RagloomError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            ensure_writable_path(path, journal_name)?;
+            let mut records = 0usize;
+            for (idx, line) in contents.lines().enumerate() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                serde_json::from_str::<T>(line).map_err(|e| {
+                    RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                        "failed to parse {journal_name} record at line {} in {}",
+                        idx + 1,
+                        path.display()
+                    ))
+                })?;
+                records += 1;
+            }
+            Ok(format!("readable,writable,records={records}"))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let parent = nearest_existing_parent(path)?;
+            ensure_writable_path(&parent, journal_name)?;
+            Ok("missing,creatable".to_string())
+        }
+        Err(err) => Err(
+            RagloomError::new(RagloomErrorKind::State, err).with_context(format!(
+                "failed to read {journal_name} file: {}",
+                path.display()
+            )),
+        ),
+    }
+}
+
+fn nearest_existing_parent(path: &Path) -> Result<PathBuf, RagloomError> {
+    let mut candidate = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    loop {
+        match std::fs::metadata(candidate) {
+            Ok(metadata) if metadata.is_dir() => return Ok(candidate.to_path_buf()),
+            Ok(_) => {
+                return Err(
+                    RagloomError::from_kind(RagloomErrorKind::State).with_context(format!(
+                        "state parent is not a directory: {}",
+                        candidate.display()
+                    )),
+                );
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                candidate = candidate.parent().unwrap_or_else(|| Path::new("."));
+            }
+            Err(err) => {
+                return Err(
+                    RagloomError::new(RagloomErrorKind::State, err).with_context(format!(
+                        "failed to inspect state parent: {}",
+                        candidate.display()
+                    )),
+                );
+            }
+        }
+    }
+}
+
+fn ensure_writable_path(path: &Path, journal_name: &str) -> Result<(), RagloomError> {
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+            "failed to inspect {journal_name} path: {}",
+            path.display()
+        ))
+    })?;
+    if metadata.permissions().readonly() || !has_write_mode(&metadata) {
+        return Err(
+            RagloomError::from_kind(RagloomErrorKind::State).with_context(format!(
+                "{journal_name} path is not writable: {}",
+                path.display()
+            )),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn has_write_mode(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o222 != 0
+}
+
+#[cfg(not(unix))]
+fn has_write_mode(_metadata: &std::fs::Metadata) -> bool {
+    true
 }
 
 pub fn validate_reloadable_changes(
@@ -582,21 +715,33 @@ pub fn validate_reloadable_changes(
 pub fn replay_failed_into_wal(
     wal: &mut impl WalStore,
     failed_store: &mut impl FailedWorkStore,
-) -> Result<usize, RagloomError> {
+) -> Result<ReplayFailedSummary, RagloomError> {
     let records = failed_store
         .read_all()
         .map_err(|e| e.with_context("failed to read failed-work store"))?;
 
     let pending = pending_failed_work(&records);
-    let replayed = pending.len();
+    let pending_count = pending.len();
+    let exhausted_count = records
+        .iter()
+        .filter(|record| matches!(record, FailedWorkRecord::Exhausted { .. }))
+        .count();
+    let skipped = exhausted_count.saturating_sub(pending_count);
+    let mut requeued = 0usize;
     for item in pending {
-        wal.append(item.work.clone())
-            .map_err(|e| e.with_context("failed to append replayed work into WAL"))?;
-        failed_store
-            .append(FailedWorkRecord::Requeued {
-                exhausted_id: item.id,
-            })
-            .map_err(|e| e.with_context("failed to mark failed work as requeued"))?;
+        if let Err(err) = wal.append(item.work.clone()) {
+            return Err(err.with_context(format!(
+                "failed to append replayed work into WAL; replay summary: pending={pending_count} requeued={requeued} skipped={skipped} failed=1"
+            )));
+        }
+        if let Err(err) = failed_store.append(FailedWorkRecord::Requeued {
+            exhausted_id: item.id,
+        }) {
+            return Err(err.with_context(format!(
+                "failed to mark failed work as requeued; replay summary: pending={pending_count} requeued={requeued} skipped={skipped} failed=1"
+            )));
+        }
+        requeued += 1;
 
         tracing::info!(
             event.name = "ragloom.failed_work.requeued",
@@ -607,10 +752,17 @@ pub fn replay_failed_into_wal(
         );
     }
 
-    Ok(replayed)
+    Ok(ReplayFailedSummary {
+        pending: pending_count,
+        requeued,
+        skipped,
+        failed: 0,
+    })
 }
 
-pub async fn replay_failed_command(cfg: &ReplayFailedConfig) -> Result<usize, RagloomError> {
+pub async fn replay_failed_command(
+    cfg: &ReplayFailedConfig,
+) -> Result<ReplayFailedSummary, RagloomError> {
     let failed_path = failed_work_path_from_state_path(&cfg.state_path);
     let mut wal = crate::state::wal::FileWal::open(&cfg.state_path)
         .map_err(|e| e.with_context("failed to initialize persistent WAL"))?;
@@ -1121,16 +1273,12 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         let summary = runtime.block_on(validate_startup(&cfg)).expect("summary");
 
-        assert_eq!(
-            summary,
-            StartupValidationSummary {
-                source_kind: "filesystem".to_string(),
-                source_target: "/tmp/docs".to_string(),
-                embed_backend: "http".to_string(),
-                chunker_selection: "router".to_string(),
-                bootstrap: BootstrapPlan::Disabled,
-            }
-        );
+        assert_eq!(summary.source_kind, "filesystem");
+        assert_eq!(summary.source_target, "/tmp/docs");
+        assert_eq!(summary.embed_backend, "http");
+        assert_eq!(summary.chunker_selection, "router");
+        assert_eq!(summary.bootstrap, BootstrapPlan::Disabled);
+        assert_eq!(summary.state_path, ".ragloom/wal.ndjson");
     }
 
     #[cfg_attr(miri, ignore = "Miri does not support TCP socket tests")]
@@ -1292,8 +1440,16 @@ mod tests {
             })
             .expect("append exhausted");
 
-        let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
-        assert_eq!(replayed, 1);
+        let summary = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
+        assert_eq!(
+            summary,
+            ReplayFailedSummary {
+                pending: 1,
+                requeued: 1,
+                skipped: 0,
+                failed: 0,
+            }
+        );
         assert_eq!(wal.read_all().expect("read wal"), vec![work]);
         assert_eq!(
             failed.read_all().expect("read failed"),
@@ -1337,8 +1493,16 @@ mod tests {
             .append(FailedWorkRecord::Requeued { exhausted_id: 1 })
             .expect("append requeued");
 
-        let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
-        assert_eq!(replayed, 0);
+        let summary = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
+        assert_eq!(
+            summary,
+            ReplayFailedSummary {
+                pending: 0,
+                requeued: 0,
+                skipped: 1,
+                failed: 0,
+            }
+        );
         assert!(wal.read_all().expect("read wal").is_empty());
     }
 
@@ -1366,9 +1530,113 @@ mod tests {
             })
             .expect("append exhausted");
 
-        let replayed = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
-        assert_eq!(replayed, 1);
+        let summary = replay_failed_into_wal(&mut wal, &mut failed).expect("replay");
+        assert_eq!(summary.requeued, 1);
         assert_eq!(wal.read_all().expect("read wal"), vec![work.clone(), work]);
+    }
+
+    #[test]
+    fn replay_failed_into_wal_reports_partial_summary_on_failure() {
+        struct FailingWal;
+
+        impl crate::state::wal::WalStore for FailingWal {
+            fn append(
+                &mut self,
+                _record: crate::state::wal::WalRecord,
+            ) -> Result<(), RagloomError> {
+                Err(RagloomError::from_kind(RagloomErrorKind::State)
+                    .with_context("simulated WAL failure"))
+            }
+
+            fn read_all(&self) -> Result<Vec<crate::state::wal::WalRecord>, RagloomError> {
+                Ok(Vec::new())
+            }
+
+            fn is_empty(&self) -> bool {
+                true
+            }
+        }
+
+        let mut failed = crate::state::failed::InMemoryFailedWorkStore::new();
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: crate::state::wal::WalRecord::DeleteDocument {
+                    canonical_path: "/x/a.txt".to_string(),
+                },
+                failure_kind: crate::state::failed::FailedWorkFailureKind::State,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            })
+            .expect("append exhausted");
+
+        let err =
+            replay_failed_into_wal(&mut FailingWal, &mut failed).expect_err("replay should fail");
+
+        assert!(
+            err.to_string()
+                .contains("replay summary: pending=1 requeued=0 skipped=0 failed=1")
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_startup_accepts_missing_state_directory_without_creating_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let state_dir = dir.path().join("missing").join("state");
+        let mut cfg = sample_run_config();
+        cfg.state_path = state_dir.join("wal.ndjson").to_string_lossy().to_string();
+
+        let summary = validate_startup(&cfg).await.expect("validate startup");
+
+        assert_eq!(summary.wal_status, "missing,creatable");
+        assert_eq!(summary.failed_work_status, "missing,creatable");
+        assert!(
+            !state_dir.exists(),
+            "check must not create the state directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_startup_rejects_malformed_existing_wal_without_mutating_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        std::fs::write(&wal_path, "{not json}\n").expect("write malformed wal");
+        let before = std::fs::read(&wal_path).expect("read before");
+        let mut cfg = sample_run_config();
+        cfg.state_path = wal_path.to_string_lossy().to_string();
+
+        let err = validate_startup(&cfg)
+            .await
+            .expect_err("malformed WAL should fail check");
+
+        assert_eq!(err.kind, RagloomErrorKind::State);
+        assert!(err.to_string().contains("failed to parse WAL record"));
+        assert_eq!(std::fs::read(&wal_path).expect("read after"), before);
+        assert!(!dir.path().join("failed.ndjson").exists());
+    }
+
+    #[tokio::test]
+    async fn validate_startup_rejects_read_only_existing_wal() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        std::fs::write(&wal_path, "").expect("write WAL");
+        let original_permissions = std::fs::metadata(&wal_path)
+            .expect("WAL metadata")
+            .permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&wal_path, permissions).expect("make WAL read-only");
+        let mut cfg = sample_run_config();
+        cfg.state_path = wal_path.to_string_lossy().to_string();
+
+        let err = validate_startup(&cfg)
+            .await
+            .expect_err("read-only WAL should fail check");
+
+        assert_eq!(err.kind, RagloomErrorKind::State);
+        assert!(err.to_string().contains("WAL path is not writable"));
+
+        std::fs::set_permissions(&wal_path, original_permissions).expect("restore WAL permissions");
     }
 
     #[tokio::test]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -537,11 +538,19 @@ fn validate_state_journal<T>(path: &Path, journal_name: &str) -> Result<String, 
 where
     T: serde::de::DeserializeOwned,
 {
-    match std::fs::read_to_string(path) {
-        Ok(contents) => {
+    match std::fs::File::open(path) {
+        Ok(file) => {
             ensure_writable_path(path, journal_name)?;
             let mut records = 0usize;
-            for (idx, line) in contents.lines().enumerate() {
+            for (idx, line) in std::io::BufReader::new(file).lines().enumerate() {
+                let line = line.map_err(|e| {
+                    RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                        "failed to read {journal_name} record at line {} in {}",
+                        idx + 1,
+                        path.display()
+                    ))
+                })?;
+                let line = line.strip_suffix('\r').unwrap_or(&line);
                 if line.trim().is_empty() {
                     continue;
                 }
@@ -608,7 +617,12 @@ fn ensure_writable_path(path: &Path, journal_name: &str) -> Result<(), RagloomEr
             path.display()
         ))
     })?;
-    if metadata.permissions().readonly() || !has_write_mode(&metadata) {
+    let writable = if metadata.is_dir() {
+        has_directory_create_mode(&metadata)
+    } else {
+        has_write_mode(&metadata)
+    };
+    if metadata.permissions().readonly() || !writable {
         return Err(
             RagloomError::from_kind(RagloomErrorKind::State).with_context(format!(
                 "{journal_name} path is not writable: {}",
@@ -625,8 +639,20 @@ fn has_write_mode(metadata: &std::fs::Metadata) -> bool {
     metadata.permissions().mode() & 0o222 != 0
 }
 
+#[cfg(unix)]
+fn has_directory_create_mode(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = metadata.permissions().mode();
+    (mode & 0o222 != 0) && (mode & 0o111 != 0)
+}
+
 #[cfg(not(unix))]
 fn has_write_mode(_metadata: &std::fs::Metadata) -> bool {
+    true
+}
+
+#[cfg(not(unix))]
+fn has_directory_create_mode(_metadata: &std::fs::Metadata) -> bool {
     true
 }
 
@@ -1600,7 +1626,7 @@ mod tests {
     async fn validate_startup_rejects_malformed_existing_wal_without_mutating_it() {
         let dir = tempfile::tempdir().expect("temp dir");
         let wal_path = dir.path().join("wal.ndjson");
-        std::fs::write(&wal_path, "{not json}\n").expect("write malformed wal");
+        std::fs::write(&wal_path, "{not json}\r\n").expect("write malformed wal");
         let before = std::fs::read(&wal_path).expect("read before");
         let mut cfg = sample_run_config();
         cfg.state_path = wal_path.to_string_lossy().to_string();
@@ -1613,6 +1639,32 @@ mod tests {
         assert!(err.to_string().contains("failed to parse WAL record"));
         assert_eq!(std::fs::read(&wal_path).expect("read after"), before);
         assert!(!dir.path().join("failed.ndjson").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn validate_startup_rejects_missing_state_when_parent_lacks_execute_bit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let state_dir = dir.path().join("state");
+        std::fs::create_dir(&state_dir).expect("create state dir");
+        let original_permissions = std::fs::metadata(&state_dir)
+            .expect("state dir metadata")
+            .permissions();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o222))
+            .expect("remove execute bit");
+        let mut cfg = sample_run_config();
+        cfg.state_path = state_dir.join("wal.ndjson").to_string_lossy().to_string();
+
+        let err = validate_startup(&cfg)
+            .await
+            .expect_err("missing WAL parent without execute bit should fail check");
+
+        std::fs::set_permissions(&state_dir, original_permissions)
+            .expect("restore state dir permissions");
+        assert_eq!(err.kind, RagloomErrorKind::State);
+        assert!(err.to_string().contains("WAL path is not writable"));
     }
 
     #[tokio::test]

--- a/tests/recovery_contract.rs
+++ b/tests/recovery_contract.rs
@@ -174,10 +174,10 @@ async fn retry_exhaustion_replay_failed_and_later_success_acknowledge_work() {
     })
     .await
     .expect("replay failed work");
-    assert_eq!(
-        replayed.requeued, 1,
-        "replay-failed should requeue the pending item"
-    );
+    assert_eq!(replayed.pending, 1, "one exhausted item was pending");
+    assert_eq!(replayed.requeued, 1, "pending item was requeued");
+    assert_eq!(replayed.skipped, 0, "no already-requeued items to skip");
+    assert_eq!(replayed.failed, 0, "replay succeeded without errors");
     assert!(
         pending_failed_work(&read_failed_work(&failed_path)).is_empty(),
         "requeued failed work should no longer be pending"

--- a/tests/recovery_contract.rs
+++ b/tests/recovery_contract.rs
@@ -174,7 +174,10 @@ async fn retry_exhaustion_replay_failed_and_later_success_acknowledge_work() {
     })
     .await
     .expect("replay failed work");
-    assert_eq!(replayed, 1, "replay-failed should requeue the pending item");
+    assert_eq!(
+        replayed.requeued, 1,
+        "replay-failed should requeue the pending item"
+    );
     assert!(
         pending_failed_work(&read_failed_work(&failed_path)).is_empty(),
         "requeued failed work should no longer be pending"

--- a/tests/state_compat_contract.rs
+++ b/tests/state_compat_contract.rs
@@ -123,7 +123,7 @@ async fn replay_failed_command_preserves_v0_4_0_empty_failed_surface() {
     .await
     .expect("replay v0.4.0");
 
-    assert_eq!(replayed, 0);
+    assert_eq!(replayed.requeued, 0);
     assert!(failed_path.exists());
     assert_eq!(fs::read_to_string(&failed_path).expect("read failed"), "");
 }
@@ -140,7 +140,7 @@ async fn replay_failed_command_replays_pending_v0_4_1_failed_work() {
     .await
     .expect("replay v0.4.1");
 
-    assert_eq!(replayed, 2);
+    assert_eq!(replayed.requeued, 2);
 
     let wal_records = FileWal::open(&wal_path)
         .expect("reopen wal")

--- a/tests/state_compat_contract.rs
+++ b/tests/state_compat_contract.rs
@@ -123,7 +123,10 @@ async fn replay_failed_command_preserves_v0_4_0_empty_failed_surface() {
     .await
     .expect("replay v0.4.0");
 
-    assert_eq!(replayed.requeued, 0);
+    assert_eq!(replayed.pending, 0, "empty failed-work surface");
+    assert_eq!(replayed.requeued, 0, "no items to requeue");
+    assert_eq!(replayed.skipped, 0, "no already-requeued items");
+    assert_eq!(replayed.failed, 0, "replay succeeded");
     assert!(failed_path.exists());
     assert_eq!(fs::read_to_string(&failed_path).expect("read failed"), "");
 }
@@ -140,7 +143,10 @@ async fn replay_failed_command_replays_pending_v0_4_1_failed_work() {
     .await
     .expect("replay v0.4.1");
 
-    assert_eq!(replayed.requeued, 2);
+    assert_eq!(replayed.pending, 2, "v0.4.1 fixture has 2 pending items");
+    assert_eq!(replayed.requeued, 2, "both pending items were requeued");
+    assert_eq!(replayed.skipped, 1, "one prior item was already requeued");
+    assert_eq!(replayed.failed, 0, "replay succeeded");
 
     let wal_records = FileWal::open(&wal_path)
         .expect("reopen wal")


### PR DESCRIPTION
## Summary

Expand non-ingesting state preflight checks and failed-work replay summaries for issue #154.

## Related issue

Closes #154

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- validate existing WAL and failed-work journals plus missing state-directory creatability without mutating state
- report deterministic state preflight and replay outcome summaries
- document operator-facing output and add focused regression/compatibility tests

## How to test

1. Run `cargo qa`.
2. Run `ragloom check` with an existing, malformed, read-only, or missing state path.
3. Run `ragloom replay-failed --state-path <path>` and inspect the four outcome counts.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

`check` uses read-only inspection and does not create missing state directories or journal files. Replay remains intentionally at-least-once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README with validation details for `check` and `dry-run` commands, including state preflight and output descriptions.
  * Added troubleshooting guide in SUPPORT for state diagnostics using `check` and `replay-failed` commands.

* **New Features**
  * `check` command now displays state path and journal status details.
  * `replay-failed` command reports deterministic pending, requeued, skipped, and failed counts with exit status indicating completion safety.
  * Enhanced state preflight validation for WAL and failed-work journal readiness.

* **Tests**
  * Extended test coverage for command parsing and replay diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->