### PR TITLE
Expose durable state backlog metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,22 @@ Current metrics:
 - `ragloom_retry_exhausted_total`
 - `ragloom_retry_queue_depth`
 - `ragloom_work_queue_depth`
+- `ragloom_state_wal_bytes`
+- `ragloom_state_failed_work_bytes`
+- `ragloom_state_wal_pending_work`
+- `ragloom_state_failed_work_pending`
+
+Durable-state metrics are numeric only:
+
+- `ragloom_state_wal_bytes` reports the current WAL file size in bytes
+- `ragloom_state_failed_work_bytes` reports the current `failed.ndjson` size in bytes
+- `ragloom_state_wal_pending_work` reports the current count of durable WAL work items awaiting acknowledgement
+- `ragloom_state_failed_work_pending` reports the current count of durable failed-work items still pending operator replay
+
+These metrics do not expose document text, API keys, canonical paths, local
+paths, or failure-detail payloads. Ragloom updates them at startup and at
+durable state transition points; it does not re-parse the full journals on each
+metrics scrape.
 
 For first-run validation, look for `ragloom.ingest.summary`. Ragloom emits it after an ingest window goes idle and again on shutdown when there is still unreported work. The summary stays structured and includes counters such as:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use ragloom::startup::{
     compact_state_command, prepare_startup, replay_failed_command, validate_reloadable_changes,
     validate_startup,
 };
+use ragloom::state::durable_state_snapshot_from_paths;
 use ragloom::state::failed::{
     FailedWorkJournal, FileFailedWorkStore, failed_work_path_from_state_path,
 };
@@ -1089,6 +1090,15 @@ async fn start_running_system(cfg: &RunConfig) -> Result<RunningSystem, RagloomE
             }
         };
 
+    let durable_state = durable_state_snapshot_from_paths(std::path::Path::new(&cfg.state_path))
+        .map_err(|e| e.with_context("failed to summarize durable state metrics"))?;
+    metrics.seed_durable_state(
+        durable_state.wal_bytes,
+        durable_state.failed_work_bytes,
+        durable_state.wal_pending_work,
+        durable_state.failed_work_pending,
+    );
+
     let previously_observed_paths = {
         let guard = wal.lock().await;
         let records = guard
@@ -1133,6 +1143,7 @@ async fn start_running_system(cfg: &RunConfig) -> Result<RunningSystem, RagloomE
     let executor = AckingExecutor {
         inner: pipeline,
         wal: std::sync::Arc::clone(&wal),
+        metrics: Some(metrics.clone()),
     };
     let retry_policy = RetryPolicy {
         max_attempts: cfg.retry_max_attempts,

--- a/src/observability/health.rs
+++ b/src/observability/health.rs
@@ -352,6 +352,18 @@ ragloom_retry_queue_depth {}
 # HELP ragloom_work_queue_depth Current runtime-to-worker queue depth.
 # TYPE ragloom_work_queue_depth gauge
 ragloom_work_queue_depth {}
+# HELP ragloom_state_wal_bytes Current WAL file size in bytes.
+# TYPE ragloom_state_wal_bytes gauge
+ragloom_state_wal_bytes {}
+# HELP ragloom_state_failed_work_bytes Current failed-work journal size in bytes.
+# TYPE ragloom_state_failed_work_bytes gauge
+ragloom_state_failed_work_bytes {}
+# HELP ragloom_state_wal_pending_work Current durable WAL work items awaiting acknowledgement.
+# TYPE ragloom_state_wal_pending_work gauge
+ragloom_state_wal_pending_work {}
+# HELP ragloom_state_failed_work_pending Current durable failed-work items pending operator replay.
+# TYPE ragloom_state_failed_work_pending gauge
+ragloom_state_failed_work_pending {}
 ",
         snapshot.discovered_files_total,
         snapshot.indexed_files_total,
@@ -361,7 +373,11 @@ ragloom_work_queue_depth {}
         snapshot.retry_attempts_total,
         snapshot.retry_exhausted_total,
         snapshot.retry_queue_depth,
-        snapshot.work_queue_depth
+        snapshot.work_queue_depth,
+        snapshot.wal_bytes,
+        snapshot.failed_work_bytes,
+        snapshot.wal_pending_work,
+        snapshot.failed_work_pending
     )
 }
 
@@ -484,6 +500,7 @@ mod tests {
         metrics.record_retry_scheduled(1);
         metrics.record_retry_exhausted(0);
         metrics.record_failure();
+        metrics.seed_durable_state(17, 9, 3, 2);
         let (addr, server) = spawn_server_with_metrics(state, metrics).await;
 
         let response = request(addr, "GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
@@ -501,6 +518,12 @@ mod tests {
         assert!(body.contains("ragloom_retry_exhausted_total 1"));
         assert!(body.contains("ragloom_retry_queue_depth 0"));
         assert!(body.contains("ragloom_work_queue_depth 0"));
+        assert!(body.contains("ragloom_state_wal_bytes 17"));
+        assert!(body.contains("ragloom_state_failed_work_bytes 9"));
+        assert!(body.contains("ragloom_state_wal_pending_work 3"));
+        assert!(body.contains("ragloom_state_failed_work_pending 2"));
+        assert!(!body.contains("/x/a.txt"));
+        assert!(!body.contains("scripted failure"));
 
         server.shutdown().await;
     }

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -18,6 +18,10 @@ pub struct IngestionMetricsSnapshot {
     pub retry_exhausted_total: u64,
     pub retry_queue_depth: u64,
     pub work_queue_depth: u64,
+    pub wal_bytes: u64,
+    pub failed_work_bytes: u64,
+    pub wal_pending_work: u64,
+    pub failed_work_pending: u64,
 }
 
 #[derive(Debug, Default)]
@@ -31,6 +35,10 @@ struct IngestionMetricsState {
     retry_exhausted_total: AtomicU64,
     retry_queue_depth: AtomicU64,
     work_queue_depth: AtomicU64,
+    wal_bytes: AtomicU64,
+    failed_work_bytes: AtomicU64,
+    wal_pending_work: AtomicU64,
+    failed_work_pending: AtomicU64,
 }
 
 /// Monotonic ingest counters plus current queue/pending gauges.
@@ -106,6 +114,84 @@ impl IngestionMetrics {
             .store(queue_depth as u64, Ordering::Relaxed);
     }
 
+    pub fn seed_durable_state(
+        &self,
+        wal_bytes: u64,
+        failed_work_bytes: u64,
+        wal_pending_work: usize,
+        failed_work_pending: usize,
+    ) {
+        self.replace_durable_state(
+            wal_bytes,
+            failed_work_bytes,
+            wal_pending_work,
+            failed_work_pending,
+        );
+    }
+
+    pub fn replace_durable_state(
+        &self,
+        wal_bytes: u64,
+        failed_work_bytes: u64,
+        wal_pending_work: usize,
+        failed_work_pending: usize,
+    ) {
+        self.inner.wal_bytes.store(wal_bytes, Ordering::Relaxed);
+        self.inner
+            .failed_work_bytes
+            .store(failed_work_bytes, Ordering::Relaxed);
+        self.inner
+            .wal_pending_work
+            .store(wal_pending_work as u64, Ordering::Relaxed);
+        self.inner
+            .failed_work_pending
+            .store(failed_work_pending as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_wal_appended_bytes(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        self.inner
+            .wal_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_failed_work_appended_bytes(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        self.inner
+            .failed_work_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_wal_pending_increase(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        self.inner
+            .wal_pending_work
+            .fetch_add(count as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_wal_pending_decrease(&self, count: usize) {
+        self.saturating_sub(&self.inner.wal_pending_work, count);
+    }
+
+    pub fn record_failed_work_pending_increase(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        self.inner
+            .failed_work_pending
+            .fetch_add(count as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_failed_work_pending_decrease(&self, count: usize) {
+        self.saturating_sub(&self.inner.failed_work_pending, count);
+    }
+
     pub fn snapshot(&self) -> IngestionMetricsSnapshot {
         IngestionMetricsSnapshot {
             discovered_files_total: self.inner.discovered_files_total.load(Ordering::Relaxed),
@@ -117,6 +203,10 @@ impl IngestionMetrics {
             retry_exhausted_total: self.inner.retry_exhausted_total.load(Ordering::Relaxed),
             retry_queue_depth: self.inner.retry_queue_depth.load(Ordering::Relaxed),
             work_queue_depth: self.inner.work_queue_depth.load(Ordering::Relaxed),
+            wal_bytes: self.inner.wal_bytes.load(Ordering::Relaxed),
+            failed_work_bytes: self.inner.failed_work_bytes.load(Ordering::Relaxed),
+            wal_pending_work: self.inner.wal_pending_work.load(Ordering::Relaxed),
+            failed_work_pending: self.inner.failed_work_pending.load(Ordering::Relaxed),
         }
     }
 
@@ -125,6 +215,14 @@ impl IngestionMetrics {
             .pending_files
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
                 Some(value.saturating_sub(1))
+            })
+            .ok();
+    }
+
+    fn saturating_sub(&self, gauge: &AtomicU64, count: usize) {
+        gauge
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                Some(value.saturating_sub(count as u64))
             })
             .ok();
     }
@@ -159,6 +257,71 @@ mod tests {
                 retry_exhausted_total: 1,
                 retry_queue_depth: 0,
                 work_queue_depth: 1,
+                wal_bytes: 0,
+                failed_work_bytes: 0,
+                wal_pending_work: 0,
+                failed_work_pending: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn metrics_track_durable_state_gauges() {
+        let metrics = IngestionMetrics::default();
+
+        metrics.seed_durable_state(17, 9, 3, 2);
+        metrics.record_wal_appended_bytes(11);
+        metrics.record_failed_work_appended_bytes(7);
+        metrics.record_wal_pending_increase(2);
+        metrics.record_wal_pending_decrease(4);
+        metrics.record_failed_work_pending_increase(3);
+        metrics.record_failed_work_pending_decrease(4);
+
+        assert_eq!(
+            metrics.snapshot(),
+            IngestionMetricsSnapshot {
+                discovered_files_total: 0,
+                indexed_files_total: 0,
+                failed_files_total: 0,
+                emitted_points_total: 0,
+                pending_files: 0,
+                retry_attempts_total: 0,
+                retry_exhausted_total: 0,
+                retry_queue_depth: 0,
+                work_queue_depth: 0,
+                wal_bytes: 28,
+                failed_work_bytes: 16,
+                wal_pending_work: 1,
+                failed_work_pending: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn metrics_replace_durable_state_after_compaction() {
+        let metrics = IngestionMetrics::default();
+
+        metrics.seed_durable_state(30, 12, 5, 4);
+        metrics.record_wal_appended_bytes(8);
+        metrics.record_failed_work_appended_bytes(6);
+        metrics.replace_durable_state(14, 5, 2, 1);
+
+        assert_eq!(
+            metrics.snapshot(),
+            IngestionMetricsSnapshot {
+                discovered_files_total: 0,
+                indexed_files_total: 0,
+                failed_files_total: 0,
+                emitted_points_total: 0,
+                pending_files: 0,
+                retry_attempts_total: 0,
+                retry_exhausted_total: 0,
+                retry_queue_depth: 0,
+                work_queue_depth: 0,
+                wal_bytes: 14,
+                failed_work_bytes: 5,
+                wal_pending_work: 2,
+                failed_work_pending: 1,
             }
         );
     }

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -653,8 +653,7 @@ async fn run_worker_with_retry_inner(
                     } else {
                         FailedWorkTerminalReason::NonRetryable
                     };
-
-                    if let Err(persist_err) = failed_work
+                    match failed_work
                         .append_exhausted(
                             record.clone(),
                             FailedWorkFailureKind::from_error_kind(err.kind),
@@ -663,14 +662,31 @@ async fn run_worker_with_retry_inner(
                         )
                         .await
                     {
-                        tracing::error!(
-                            event.name = "ragloom.failed_work.persist_failed",
-                            record_type,
-                            canonical_path = canonical_path,
-                            error.kind = %persist_err.kind,
-                            error.message = %persist_err,
-                            "ragloom.failed_work.persist_failed"
-                        );
+                        Err(persist_err) => {
+                            tracing::error!(
+                                event.name = "ragloom.failed_work.persist_failed",
+                                record_type,
+                                canonical_path = canonical_path,
+                                error.kind = %persist_err.kind,
+                                error.message = %persist_err,
+                                "ragloom.failed_work.persist_failed"
+                            );
+                        }
+                        Ok(id) => {
+                            let failed_record = crate::state::failed::FailedWorkRecord::Exhausted {
+                                id,
+                                work: record.clone(),
+                                failure_kind: FailedWorkFailureKind::from_error_kind(err.kind),
+                                terminal_reason,
+                                attempts: attempt,
+                            };
+                            if let (Some(metrics), Ok(failed_record_len)) =
+                                (&metrics, ndjson_record_len(&failed_record))
+                            {
+                                metrics.record_failed_work_appended_bytes(failed_record_len);
+                                metrics.record_failed_work_pending_increase(1);
+                            }
+                        }
                     }
                 }
 
@@ -1030,6 +1046,14 @@ impl WorkExecutor for PipelineExecutor {
 pub struct AckingExecutor<E: WorkExecutor, W: WalStore = InMemoryWal> {
     pub inner: E,
     pub wal: std::sync::Arc<tokio::sync::Mutex<W>>,
+    pub metrics: Option<IngestionMetrics>,
+}
+
+impl<E: WorkExecutor, W: WalStore> AckingExecutor<E, W> {
+    pub fn with_metrics(mut self, metrics: IngestionMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
 }
 
 #[async_trait::async_trait]
@@ -1055,9 +1079,14 @@ impl<E: WorkExecutor, W: WalStore + 'static> WorkExecutor for AckingExecutor<E, 
         if let Some(ack) = ack {
             let mut wal = self.wal.lock().await;
             let elapsed = std::time::Instant::now();
+            let ack_len = ndjson_record_len(&ack)?;
             wal.append(ack).map_err(|e| {
                 RagloomError::new(e.kind, e).with_context("failed to append sink ack")
             })?;
+            if let Some(metrics) = &self.metrics {
+                metrics.record_wal_appended_bytes(ack_len);
+                metrics.record_wal_pending_decrease(1);
+            }
             tracing::debug!(
                 ack_type = "sink_ack",
                 elapsed_ms = elapsed.elapsed().as_millis() as u64,
@@ -1066,6 +1095,14 @@ impl<E: WorkExecutor, W: WalStore + 'static> WorkExecutor for AckingExecutor<E, 
         }
         Ok(())
     }
+}
+
+fn ndjson_record_len<T: serde::Serialize>(record: &T) -> Result<usize, RagloomError> {
+    let encoded = serde_json::to_string(record).map_err(|e| {
+        RagloomError::new(RagloomErrorKind::State, e)
+            .with_context("failed to encode durable state record")
+    })?;
+    Ok(encoded.len() + 1)
 }
 
 /// Stops a running async runtime.
@@ -1250,6 +1287,19 @@ impl<S: Source + Send + 'static, W: WalStore + 'static> AsyncRuntime<S, W> {
                 let mut discovered_files = 0usize;
 
                 for record in after_records.into_iter().skip(before) {
+                    if let Some(metrics) = &self.metrics
+                        && matches!(
+                            record,
+                            WalRecord::WorkItem { .. }
+                                | WalRecord::WorkItemV2 { .. }
+                                | WalRecord::DeleteDocument { .. }
+                        )
+                    {
+                        if let Ok(record_len) = ndjson_record_len(&record) {
+                            metrics.record_wal_appended_bytes(record_len);
+                        }
+                        metrics.record_wal_pending_increase(1);
+                    }
                     if matches!(
                         record,
                         WalRecord::WorkItem { .. } | WalRecord::WorkItemV2 { .. }
@@ -1440,6 +1490,28 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[tokio::test]
+    async fn async_runtime_updates_durable_state_metrics_when_planning_work() {
+        let mut source = FakeSource::default();
+        source.push([1u8; 32]);
+        let metrics = IngestionMetrics::default();
+        metrics.seed_durable_state(0, 0, 0, 0);
+
+        let runtime = Runtime::new(source);
+        let (mut rx, shutdown) = AsyncRuntime::new(runtime, 1)
+            .with_metrics(metrics.clone())
+            .start();
+
+        let record = rx.recv().await.expect("planned work");
+        assert!(matches!(record, WalRecord::WorkItemV2 { .. }));
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.wal_pending_work, 1);
+        assert!(snapshot.wal_bytes > 0);
+
+        shutdown.shutdown();
     }
 
     #[tokio::test]
@@ -1707,6 +1779,7 @@ mod tests {
                 std::sync::Arc::new(loader.clone()),
             ),
             wal: std::sync::Arc::clone(&wal),
+            metrics: None,
         };
 
         tokio::spawn(async move {
@@ -1830,6 +1903,7 @@ mod tests {
             )
             .with_summary(summary.clone()),
             wal: std::sync::Arc::clone(&wal),
+            metrics: None,
         };
 
         let wal_for_worker = std::sync::Arc::clone(&wal);
@@ -1968,6 +2042,7 @@ mod tests {
                 std::sync::Arc::new(loader.clone()),
             ),
             wal: std::sync::Arc::clone(&wal),
+            metrics: None,
         };
 
         tokio::spawn(async move {
@@ -2097,6 +2172,7 @@ mod tests {
         let executor = AckingExecutor {
             inner,
             wal: std::sync::Arc::clone(&wal),
+            metrics: None,
         };
 
         executor
@@ -2123,6 +2199,43 @@ mod tests {
             }),
             "expected SinkAckV2"
         );
+    }
+
+    #[tokio::test]
+    async fn executor_writes_sink_ack_updates_durable_state_metrics() {
+        let wal = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::state::wal::InMemoryWal::new(),
+        ));
+        let metrics = IngestionMetrics::default();
+        metrics.seed_durable_state(0, 0, 1, 0);
+
+        let inner = RecordingExecutor {
+            seen: std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        };
+        let executor = AckingExecutor {
+            inner,
+            wal: std::sync::Arc::clone(&wal),
+            metrics: None,
+        }
+        .with_metrics(metrics.clone());
+
+        executor
+            .execute(WalRecord::WorkItemV2 {
+                fingerprint: crate::ids::FileFingerprint {
+                    canonical_path: "/x/a.txt".to_string(),
+                    size_bytes: 10,
+                    mtime_unix_secs: 100,
+                    etag: None,
+                },
+            })
+            .await
+            .expect("execute");
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.wal_pending_work, 0);
+        assert!(snapshot.wal_bytes > 0);
+        assert_eq!(snapshot.failed_work_pending, 0);
+        assert_eq!(snapshot.failed_work_bytes, 0);
     }
 
     #[tokio::test]
@@ -2184,6 +2297,7 @@ mod tests {
         let executor = AckingExecutor {
             inner,
             wal: std::sync::Arc::clone(&wal),
+            metrics: None,
         };
 
         tokio::spawn(async move {
@@ -2367,6 +2481,58 @@ mod tests {
                 attempts: 2,
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn retry_worker_updates_durable_failed_work_metrics() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let failed_work = crate::state::failed::FailedWorkJournal::new(
+            crate::state::failed::InMemoryFailedWorkStore::new(),
+        );
+        let failed_work_for_worker = failed_work.clone();
+        let metrics = IngestionMetrics::default();
+        metrics.seed_durable_state(0, 0, 1, 0);
+        let executor = ScriptedExecutor::new(vec![
+            Err(RagloomErrorKind::Embed),
+            Err(RagloomErrorKind::Embed),
+        ]);
+
+        let metrics_for_worker = metrics.clone();
+        let worker = tokio::spawn(async move {
+            run_worker_with_live_retry_failed_work_and_metrics(
+                rx,
+                executor,
+                LiveRetryPolicy::new(RetryPolicy {
+                    max_attempts: 2,
+                    max_queued_retries: 1,
+                    initial_backoff: std::time::Duration::ZERO,
+                    max_backoff: std::time::Duration::ZERO,
+                })
+                .expect("policy"),
+                Some(failed_work_for_worker),
+                None,
+                Some(metrics_for_worker),
+            )
+            .await;
+        });
+
+        tx.send(WalRecord::WorkItemV2 {
+            fingerprint: crate::ids::FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: None,
+            },
+        })
+        .await
+        .expect("send");
+        drop(tx);
+        worker.await.expect("worker");
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.wal_pending_work, 1);
+        assert_eq!(snapshot.failed_work_pending, 1);
+        assert!(snapshot.failed_work_bytes > 0);
     }
 
     #[tokio::test]

--- a/src/pipeline/runtime.rs
+++ b/src/pipeline/runtime.rs
@@ -1505,11 +1505,12 @@ mod tests {
             .start();
 
         let record = rx.recv().await.expect("planned work");
+        let expected_record_len = ndjson_record_len(&record).expect("record len") as u64;
         assert!(matches!(record, WalRecord::WorkItemV2 { .. }));
 
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.wal_pending_work, 1);
-        assert!(snapshot.wal_bytes > 0);
+        assert_eq!(snapshot.wal_bytes, expected_record_len);
 
         shutdown.shutdown();
     }
@@ -2219,21 +2220,25 @@ mod tests {
         }
         .with_metrics(metrics.clone());
 
+        let fingerprint = crate::ids::FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: None,
+        };
+        let expected_ack_len = ndjson_record_len(&WalRecord::SinkAckV2 {
+            fingerprint: fingerprint.clone(),
+        })
+        .expect("ack len") as u64;
+
         executor
-            .execute(WalRecord::WorkItemV2 {
-                fingerprint: crate::ids::FileFingerprint {
-                    canonical_path: "/x/a.txt".to_string(),
-                    size_bytes: 10,
-                    mtime_unix_secs: 100,
-                    etag: None,
-                },
-            })
+            .execute(WalRecord::WorkItemV2 { fingerprint })
             .await
             .expect("execute");
 
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.wal_pending_work, 0);
-        assert!(snapshot.wal_bytes > 0);
+        assert_eq!(snapshot.wal_bytes, expected_ack_len);
         assert_eq!(snapshot.failed_work_pending, 0);
         assert_eq!(snapshot.failed_work_bytes, 0);
     }
@@ -2516,23 +2521,35 @@ mod tests {
             .await;
         });
 
-        tx.send(WalRecord::WorkItemV2 {
-            fingerprint: crate::ids::FileFingerprint {
-                canonical_path: "/x/a.txt".to_string(),
-                size_bytes: 10,
-                mtime_unix_secs: 100,
-                etag: None,
+        let fingerprint = crate::ids::FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: None,
+        };
+        let failed_record = crate::state::failed::FailedWorkRecord::Exhausted {
+            id: 1,
+            work: WalRecord::WorkItemV2 {
+                fingerprint: fingerprint.clone(),
             },
-        })
-        .await
-        .expect("send");
+            failure_kind: crate::state::failed::FailedWorkFailureKind::Embed,
+            terminal_reason: crate::state::failed::FailedWorkTerminalReason::RetryExhausted,
+            attempts: 2,
+        };
+
+        tx.send(WalRecord::WorkItemV2 { fingerprint })
+            .await
+            .expect("send");
         drop(tx);
         worker.await.expect("worker");
 
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.wal_pending_work, 1);
         assert_eq!(snapshot.failed_work_pending, 1);
-        assert!(snapshot.failed_work_bytes > 0);
+        assert_eq!(
+            snapshot.failed_work_bytes,
+            ndjson_record_len(&failed_record).expect("failed record len") as u64
+        );
     }
 
     #[tokio::test]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1606,6 +1606,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replay_failed_command_changes_durable_state_metrics_snapshot() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        let failed_path = failed_work_path_from_state_path(&wal_path);
+        let work = crate::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: crate::ids::FileFingerprint {
+                canonical_path: "/x/a.txt".to_string(),
+                size_bytes: 10,
+                mtime_unix_secs: 100,
+                etag: None,
+            },
+        };
+
+        FileFailedWorkStore::open(&failed_path)
+            .expect("open failed")
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: work.clone(),
+                failure_kind: crate::state::failed::FailedWorkFailureKind::Embed,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            })
+            .expect("append failed");
+
+        let metrics = crate::observability::metrics::IngestionMetrics::default();
+        let before = crate::state::durable_state_snapshot_from_paths(&wal_path)
+            .expect("state snapshot before replay");
+        metrics.replace_durable_state(
+            before.wal_bytes,
+            before.failed_work_bytes,
+            before.wal_pending_work,
+            before.failed_work_pending,
+        );
+
+        replay_failed_command(&ReplayFailedConfig {
+            state_path: wal_path.to_string_lossy().to_string(),
+        })
+        .await
+        .expect("replay failed");
+
+        let after = crate::state::durable_state_snapshot_from_paths(&wal_path)
+            .expect("state snapshot after replay");
+        metrics.replace_durable_state(
+            after.wal_bytes,
+            after.failed_work_bytes,
+            after.wal_pending_work,
+            after.failed_work_pending,
+        );
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(before.wal_pending_work, 0);
+        assert_eq!(before.failed_work_pending, 1);
+        assert_eq!(snapshot.wal_pending_work, 1);
+        assert_eq!(snapshot.failed_work_pending, 0);
+        assert!(snapshot.wal_bytes > before.wal_bytes);
+        assert!(snapshot.failed_work_bytes > 0);
+    }
+
+    #[tokio::test]
     async fn validate_startup_accepts_missing_state_directory_without_creating_it() {
         let dir = tempfile::tempdir().expect("temp dir");
         let state_dir = dir.path().join("missing").join("state");
@@ -1815,6 +1874,83 @@ mod tests {
             crate::state::failed::next_failed_work_id(&failed_after),
             crate::state::failed::next_failed_work_id(&failed_before)
         );
+    }
+
+    #[tokio::test]
+    async fn compact_state_command_changes_durable_state_metric_sizes_without_changing_backlog() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        let failed_path = dir.path().join("failed.ndjson");
+
+        let mut wal = crate::state::wal::FileWal::open(&wal_path).expect("open wal");
+        let fingerprint = crate::ids::FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: None,
+        };
+        wal.append(crate::state::wal::WalRecord::WorkItemV2 {
+            fingerprint: fingerprint.clone(),
+        })
+        .expect("append work");
+        wal.append(crate::state::wal::WalRecord::SinkAckV2 {
+            fingerprint: fingerprint.clone(),
+        })
+        .expect("append ack");
+        wal.append(crate::state::wal::WalRecord::DeleteDocument {
+            canonical_path: "/x/b.txt".to_string(),
+        })
+        .expect("append delete");
+
+        let mut failed = FileFailedWorkStore::open(&failed_path).expect("open failed");
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: crate::state::wal::WalRecord::DeleteDocument {
+                    canonical_path: "/x/b.txt".to_string(),
+                },
+                failure_kind: crate::state::failed::FailedWorkFailureKind::Sink,
+                terminal_reason: crate::state::failed::FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            })
+            .expect("append failed");
+        failed
+            .append(FailedWorkRecord::Requeued { exhausted_id: 1 })
+            .expect("append requeued");
+
+        let metrics = crate::observability::metrics::IngestionMetrics::default();
+        let before = crate::state::durable_state_snapshot_from_paths(&wal_path)
+            .expect("state snapshot before compaction");
+        metrics.replace_durable_state(
+            before.wal_bytes,
+            before.failed_work_bytes,
+            before.wal_pending_work,
+            before.failed_work_pending,
+        );
+
+        compact_state_command(&CompactStateConfig {
+            state_path: wal_path.to_string_lossy().to_string(),
+        })
+        .await
+        .expect("compact state");
+
+        let after = crate::state::durable_state_snapshot_from_paths(&wal_path)
+            .expect("state snapshot after compaction");
+        metrics.replace_durable_state(
+            after.wal_bytes,
+            after.failed_work_bytes,
+            after.wal_pending_work,
+            after.failed_work_pending,
+        );
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.wal_pending_work, before.wal_pending_work as u64);
+        assert_eq!(
+            snapshot.failed_work_pending,
+            before.failed_work_pending as u64
+        );
+        assert!(snapshot.wal_bytes <= before.wal_bytes);
+        assert!(snapshot.failed_work_bytes <= before.failed_work_bytes);
     }
 
     #[tokio::test]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1661,7 +1661,7 @@ mod tests {
         assert_eq!(snapshot.wal_pending_work, 1);
         assert_eq!(snapshot.failed_work_pending, 0);
         assert!(snapshot.wal_bytes > before.wal_bytes);
-        assert!(snapshot.failed_work_bytes > 0);
+        assert!(snapshot.failed_work_bytes > before.failed_work_bytes);
     }
 
     #[tokio::test]
@@ -1758,7 +1758,7 @@ mod tests {
     async fn compact_state_command_preserves_observable_replay_state() {
         let dir = tempfile::tempdir().expect("temp dir");
         let wal_path = dir.path().join("wal.ndjson");
-        let failed_path = dir.path().join("failed.ndjson");
+        let failed_path = failed_work_path_from_state_path(&wal_path);
 
         let mut wal = crate::state::wal::FileWal::open(&wal_path).expect("open wal");
         let a_v1 = crate::ids::FileFingerprint {
@@ -1880,7 +1880,7 @@ mod tests {
     async fn compact_state_command_changes_durable_state_metric_sizes_without_changing_backlog() {
         let dir = tempfile::tempdir().expect("temp dir");
         let wal_path = dir.path().join("wal.ndjson");
-        let failed_path = dir.path().join("failed.ndjson");
+        let failed_path = failed_work_path_from_state_path(&wal_path);
 
         let mut wal = crate::state::wal::FileWal::open(&wal_path).expect("open wal");
         let fingerprint = crate::ids::FileFingerprint {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -9,6 +9,11 @@ pub mod compact;
 pub mod failed;
 pub mod wal;
 
+use std::io::ErrorKind;
+use std::path::Path;
+
+use crate::error::{RagloomError, RagloomErrorKind};
+
 /// Persistent state store abstraction.
 ///
 /// # Why
@@ -16,3 +21,146 @@ pub mod wal;
 /// outstanding work after restart. This trait defines that minimal contract
 /// without locking the core into a concrete database.
 pub trait StateStore: Send + Sync {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DurableStateSnapshot {
+    pub wal_bytes: u64,
+    pub failed_work_bytes: u64,
+    pub wal_pending_work: usize,
+    pub failed_work_pending: usize,
+}
+
+pub fn durable_state_snapshot_from_paths(
+    wal_path: &Path,
+) -> Result<DurableStateSnapshot, RagloomError> {
+    let failed_path = failed::failed_work_path_from_state_path(wal_path);
+    let wal_records = read_state_records::<wal::WalRecord>(wal_path, "WAL")?;
+    let failed_records =
+        read_state_records::<failed::FailedWorkRecord>(&failed_path, "failed-work")?;
+
+    Ok(DurableStateSnapshot {
+        wal_bytes: file_len_or_zero(wal_path)?,
+        failed_work_bytes: file_len_or_zero(&failed_path)?,
+        wal_pending_work: wal::unacked_work_items(&wal_records).len(),
+        failed_work_pending: failed::pending_failed_work(&failed_records).len(),
+    })
+}
+
+fn file_len_or_zero(path: &Path) -> Result<u64, RagloomError> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.len()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(0),
+        Err(err) => Err(RagloomError::new(RagloomErrorKind::State, err)
+            .with_context(format!("failed to stat state file: {}", path.display()))),
+    }
+}
+
+fn read_state_records<T>(path: &Path, label: &str) -> Result<Vec<T>, RagloomError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(RagloomError::new(RagloomErrorKind::State, err)
+                .with_context(format!("failed to read {label} file: {}", path.display())));
+        }
+    };
+
+    let mut records = Vec::new();
+    for (idx, line) in contents.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record = serde_json::from_str::<T>(line).map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to parse {label} record at line {} in {}",
+                idx + 1,
+                path.display()
+            ))
+        })?;
+        records.push(record);
+    }
+
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::durable_state_snapshot_from_paths;
+    use crate::ids::FileFingerprint;
+    use crate::state::failed::{
+        FailedWorkFailureKind, FailedWorkRecord, FailedWorkTerminalReason, FileFailedWorkStore,
+        failed_work_path_from_state_path,
+    };
+    use crate::state::wal::{FileWal, WalRecord};
+
+    #[test]
+    fn durable_state_snapshot_reports_zero_for_missing_journals() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("state").join("wal.ndjson");
+
+        let snapshot = durable_state_snapshot_from_paths(&wal_path).expect("state snapshot");
+
+        assert_eq!(snapshot.wal_bytes, 0);
+        assert_eq!(snapshot.failed_work_bytes, 0);
+        assert_eq!(snapshot.wal_pending_work, 0);
+        assert_eq!(snapshot.failed_work_pending, 0);
+    }
+
+    #[test]
+    fn durable_state_snapshot_reports_sizes_and_pending_counts() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wal_path = dir.path().join("wal.ndjson");
+        let failed_path = failed_work_path_from_state_path(&wal_path);
+        let fingerprint = FileFingerprint {
+            canonical_path: "/x/a.txt".to_string(),
+            size_bytes: 10,
+            mtime_unix_secs: 100,
+            etag: None,
+        };
+
+        let mut wal = FileWal::open(&wal_path).expect("open wal");
+        wal.append(WalRecord::WorkItemV2 {
+            fingerprint: fingerprint.clone(),
+        })
+        .expect("append work");
+        wal.append(WalRecord::DeleteDocument {
+            canonical_path: "/x/b.txt".to_string(),
+        })
+        .expect("append delete");
+        wal.append(WalRecord::SinkAckV2 {
+            fingerprint: fingerprint.clone(),
+        })
+        .expect("append ack");
+
+        let mut failed = FileFailedWorkStore::open(&failed_path).expect("open failed");
+        failed
+            .append(FailedWorkRecord::Exhausted {
+                id: 1,
+                work: WalRecord::DeleteDocument {
+                    canonical_path: "/x/b.txt".to_string(),
+                },
+                failure_kind: FailedWorkFailureKind::Sink,
+                terminal_reason: FailedWorkTerminalReason::RetryExhausted,
+                attempts: 2,
+            })
+            .expect("append failed");
+
+        let snapshot = durable_state_snapshot_from_paths(&wal_path).expect("state snapshot");
+
+        assert_eq!(
+            snapshot.wal_bytes,
+            std::fs::metadata(&wal_path).expect("wal metadata").len()
+        );
+        assert_eq!(
+            snapshot.failed_work_bytes,
+            std::fs::metadata(&failed_path)
+                .expect("failed metadata")
+                .len()
+        );
+        assert_eq!(snapshot.wal_pending_work, 1);
+        assert_eq!(snapshot.failed_work_pending, 1);
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -9,7 +9,7 @@ pub mod compact;
 pub mod failed;
 pub mod wal;
 
-use std::io::ErrorKind;
+use std::io::{BufRead, ErrorKind};
 use std::path::Path;
 
 use crate::error::{RagloomError, RagloomErrorKind};
@@ -59,8 +59,8 @@ fn read_state_records<T>(path: &Path, label: &str) -> Result<Vec<T>, RagloomErro
 where
     T: serde::de::DeserializeOwned,
 {
-    let contents = match std::fs::read_to_string(path) {
-        Ok(contents) => contents,
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
         Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => {
             return Err(RagloomError::new(RagloomErrorKind::State, err)
@@ -68,12 +68,20 @@ where
         }
     };
 
+    let reader = std::io::BufReader::new(file);
     let mut records = Vec::new();
-    for (idx, line) in contents.lines().enumerate() {
+    for (idx, line_result) in reader.lines().enumerate() {
+        let line = line_result.map_err(|e| {
+            RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
+                "failed to read {label} line {} in {}",
+                idx + 1,
+                path.display()
+            ))
+        })?;
         if line.trim().is_empty() {
             continue;
         }
-        let record = serde_json::from_str::<T>(line).map_err(|e| {
+        let record = serde_json::from_str::<T>(&line).map_err(|e| {
             RagloomError::new(RagloomErrorKind::State, e).with_context(format!(
                 "failed to parse {label} record at line {} in {}",
                 idx + 1,

--- a/tests/delete_sync_restart.rs
+++ b/tests/delete_sync_restart.rs
@@ -84,6 +84,7 @@ async fn delete_sync_survives_restart_when_reusing_same_wal() {
     let executor = AckingExecutor {
         inner: DeleteOnlyExecutor::default(),
         wal: Arc::clone(&wal),
+        metrics: None,
     };
     let worker = tokio::spawn(async move {
         run_worker(rx, executor).await;

--- a/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
+++ b/tests/pipeline_embeds_text_loaded_from_fingerprint_v2.rs
@@ -97,6 +97,7 @@ async fn pipeline_embeds_text_loaded_from_fingerprint_v2() {
             Arc::new(loader.clone()),
         ),
         wal: Arc::clone(&wal),
+        metrics: None,
     };
 
     tokio::spawn(async move {

--- a/tests/recovery_contract.rs
+++ b/tests/recovery_contract.rs
@@ -408,6 +408,7 @@ async fn run_once(wal_path: &Path, executor: PipelineExecutor, work_items: Vec<W
     let executor = AckingExecutor {
         inner: executor,
         wal,
+        metrics: None,
     };
     let (tx, rx) = tokio::sync::mpsc::channel(work_items.len().max(1));
     let worker = tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Expose bounded durable-state backlog and journal size metrics so operators can see WAL / failed-work growth and pending recovery work without inspecting local state files.

## Related issue

Closes #155

## Type of change

- [x] New feature
- [x] Documentation update
- [x] Test update

## Changes made

- add four numeric-only metrics for WAL bytes, failed-work bytes, pending WAL work, and pending failed-work backlog
- seed and update durable-state gauges at startup, work planning, sink acknowledgement, failed-work persistence, and via replay / compaction state snapshot coverage
- document the new metrics in the README and keep the existing health endpoint content-free

## How to test

1. `cargo test --test recovery_contract`
2. `cargo test async_runtime_updates_durable_state_metrics_when_planning_work`
3. `cargo qa`

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

- This PR intentionally does not add a compaction timestamp/age metric. Issue #155 scoped that as optional only if it could be represented without adding persistent complexity, and the current implementation keeps durable state semantics unchanged.
- Metrics are updated from startup/runtime transition points and are not computed by reparsing the journals on every `/metrics` scrape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Prometheus durable-state metrics for WAL bytes, failed-work bytes, pending WAL work, and pending failed-work items.
  * Durable-state gauges are now seeded at startup and updated continuously during runtime state transitions.

* **Bug Fixes**
  * Improved failed-work terminal handling to record metrics only on successful persistence and to track exhausted failures more accurately.

* **Documentation**
  * Expanded metrics documentation with clearer durable-state definitions and explicit data-exposure guarantees.

* **Tests**
  * Updated and added coverage to validate durable-state metric behavior during replay and compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->