### PR TITLE
docs: define v0.5 compatibility boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,32 @@
   lines, truncated final writes, and unsupported state shapes now have
   explicit contract coverage and remain startup errors instead of best-effort
   recovery cases.
+- Defined the v0.5 compatibility boundary for deterministic point identity,
+  Qdrant payloads, CLI defaults, and durable state.
+  The Qdrant point ID is the chunk identity.
+  It is not duplicated as a `chunk_id` payload field.
+  Strategy-fingerprint changes intentionally open a new point-ID space.
+  IDs are not reused for different chunk content.
+- Marked `canonical_path`, `doc_id`, `tenant_id`, `file_extension`,
+  `size_bytes`, `mtime_unix_secs`, `chunk_index`, `total_chunks`,
+  `previous_chunk_id`, `next_chunk_id`, `chunk_start_byte`, `chunk_end_byte`,
+  `chunk_char_len`, `chunk_text_sha256`, and `strategy_fingerprint` as the
+  stable v0.5 payload fields. `chunk_text` is optional compatibility data;
+  additive fields remain non-contractual until explicitly promoted.
+- Recorded that the default embedding backend remains OpenAI with
+  `text-embedding-3-small`, the default chunker mode remains `router`, state
+  remains at `.ragloom/wal.ndjson`, health remains disabled, and existing
+  sizing and retry defaults remain unchanged. Semantic chunking remains
+  experimental and opt-in.
 
 ### Docs
 - Documented the state upgrade contract consistently across `README.md`,
   `SUPPORT.md`, and `CHANGELOG.md`, including the minimum supported state
   version and the requirement for explicit migration notes before any future
   incompatible state change.
+- Added an operator action matrix for the v0.5 compatibility boundary:
+  additive payload fields and behavior-preserving fixes do not require
+  operator action. Incompatible changes require release-note migration guidance.
 
 ## [0.4.1] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   `failed.ndjson` shapes under the current implementation.
 
 ### Changed
+- Upgraded `pdf-extract` to `0.12.0` and `lopdf` to `0.42.0` to address
+  `RUSTSEC-2026-0187`. The no-fix `ttf-parser` maintenance advisory remains a
+  narrowly scoped `cargo-deny` exception until `lopdf` migrates away from it.
+- Updated `quinn-proto` to `0.11.15` to address `RUSTSEC-2026-0185`.
 - Defined the `v0.5.0` on-disk compatibility contract as direct readability of
   supported released `v0.4.x` WAL state, with `v0.4.0` as the minimum
   supported WAL version and `failed.ndjson` support applying from `v0.4.1+`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,12 +357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "cff-parser"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
 
 [[package]]
 name = "cfg-if"
@@ -439,6 +433,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chunk"
@@ -1234,10 +1239,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1338,7 +1346,7 @@ dependencies = [
  "libc",
  "log",
  "native-tls",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1832,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags",
@@ -1842,14 +1850,13 @@ dependencies = [
  "ecb",
  "encoding_rs",
  "flate2",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "indexmap",
  "itoa",
  "log",
  "md-5",
  "nom 8.0.0",
- "nom_locate",
- "rand",
+ "rand 0.10.1",
  "rangemap",
  "sha2",
  "stringprep",
@@ -2080,17 +2087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom_locate"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 8.0.0",
-]
-
-[[package]]
 name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,9 +2307,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf-extract"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
  "cff-parser",
@@ -2493,7 +2489,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2596,7 +2592,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2692,7 +2688,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2702,7 +2709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2715,12 +2722,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2756,7 +2769,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -3549,7 +3562,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-bash = "0.25"
-pdf-extract = "0.10"
+pdf-extract = "0.12"
 docx-lite = "0.2.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,54 @@ Not supported yet:
 | document loading | UTF-8 text, Markdown, source code, embedded-text PDF extraction, deterministic DOCX text extraction | OCR, rich layout reconstruction, broader office-suite parsing |
 | operations | local health endpoint, local metrics endpoint, optional first-run collection bootstrap | non-local operator surfaces, broader collection lifecycle management |
 
+### v0.5 compatibility boundary
+
+The v0.5 compatibility boundary covers operator-visible point identity, Qdrant
+payload shape, CLI defaults, and durable state upgrades. It does not guarantee
+undocumented internal Rust APIs.
+
+The Qdrant point ID is the chunk identity. It is derived from the canonical
+source identity, chunk index, and exact chunker strategy fingerprint. The same
+inputs keep the same ID. Strategy-fingerprint changes intentionally open a new point-ID space.
+This prevents changed chunk boundaries or semantics from overwriting older
+chunks under reused IDs. Operators should reindex and then drop or
+garbage-collect old points when they want a clean collection. The identity is
+not duplicated as a `chunk_id` payload field.
+
+For v0.5, the stable Qdrant payload fields are `canonical_path`, `doc_id`,
+`tenant_id`, `file_extension`, `size_bytes`, `mtime_unix_secs`, `chunk_index`,
+`total_chunks`, `previous_chunk_id`, `next_chunk_id`, `chunk_start_byte`,
+`chunk_end_byte`, `chunk_char_len`, `chunk_text_sha256`, and
+`strategy_fingerprint`. Their names, presence, and JSON value kinds are the
+compatibility contract. `chunk_text` is optional compatibility data: v0.5
+emits it, but consumers should tolerate its omission. Newly added payload
+fields are non-contractual until they are explicitly added to this list.
+Identity, extension, hash, and strategy fields are strings; size, time, index,
+count, offset, and length fields are non-negative integers; neighboring chunk
+IDs are either UUID strings or `null`.
+
+The default embedding backend remains OpenAI with
+`https://api.openai.com/v1/embeddings` and `text-embedding-3-small`; the
+default chunker mode remains `router`, using character sizing with
+`max=2000`, `min=0`, and `overlap=0`. The default state path remains
+`.ragloom/wal.ndjson`, collection bootstrap and the health endpoint remain
+disabled, and the retry defaults remain 3 attempts, 128 queued retries, 100 ms
+initial backoff, and 2000 ms maximum backoff. Semantic chunking remains
+experimental and opt-in.
+
+Additive payload fields and bug fixes that preserve these identities, fields,
+defaults, and readable state are compatible. Removing or renaming a stable
+payload field, changing a default, reusing an old ID for different chunk
+content, or making released state unreadable is incompatible. Incompatible changes require release-note migration guidance.
+See the state-specific rules below for the supported upgrade path.
+
+| Upgrade observation | Operator action |
+| --- | --- |
+| Point IDs, stable payload fields, defaults, and released state remain compatible | No action |
+| Strategy fingerprint changes | Reindex; drop or garbage-collect the old point-ID space if a clean collection is required |
+| Stable payload field or CLI default changes | Follow the release notes; update payload consumers or pin the old configuration before upgrading |
+| Released state is not directly readable | Back up the state directory and follow the documented migration before starting the new release |
+
 ## Quickstart
 
 This example runs Ragloom from source against a local Qdrant instance and the default OpenAI embedding backend.
@@ -601,7 +649,7 @@ remains a feature-gated semantic provider and requires building with `--features
 
 ## Indexed Payload
 
-Each Qdrant point includes chunk text plus metadata such as:
+Each Qdrant point currently includes chunk text plus metadata such as:
 
 ```json
 {
@@ -614,7 +662,7 @@ Each Qdrant point includes chunk text plus metadata such as:
   "chunk_index": 0,
   "total_chunks": 3,
   "previous_chunk_id": null,
-  "next_chunk_id": "chunk_...",
+  "next_chunk_id": "9c5eb1c7-f9a7-4fc2-a260-761842356849",
   "chunk_start_byte": 0,
   "chunk_end_byte": 842,
   "chunk_char_len": 842,
@@ -623,6 +671,10 @@ Each Qdrant point includes chunk text plus metadata such as:
   "chunk_text": "..."
 }
 ```
+
+The Qdrant point ID is the chunk identity and is not duplicated as a
+`chunk_id` payload field. `previous_chunk_id` and `next_chunk_id` contain those
+same deterministic point-ID values for neighboring chunks.
 
 This is the part of Ragloom that makes inspection easier: you can look at a point in Qdrant and see where it came from, how it was chunked, and which neighboring chunks surround it.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -93,6 +93,52 @@ other unsupported state shapes fail closed with a `state` error. Maintainers
 should treat any future incompatible state change as requiring an explicit,
 documented migration boundary rather than a silent format reinterpretation.
 
+## v0.5 compatibility boundary
+
+The v0.5 compatibility boundary covers operator-visible point identity, Qdrant
+payload shape, CLI defaults, and durable state upgrades. Undocumented internal
+Rust APIs are outside this support promise.
+
+The Qdrant point ID is the chunk identity. It is derived from canonical source
+identity, chunk index, and the exact chunker strategy fingerprint.
+Strategy-fingerprint changes intentionally open a new point-ID space.
+Ragloom must never silently reuse an old point ID for different chunk content.
+Operators who need a clean collection should reindex and then drop or
+garbage-collect the old point-ID space.
+The identity is not duplicated as a `chunk_id` payload field.
+
+The stable v0.5 payload fields are `canonical_path`, `doc_id`, `tenant_id`,
+`file_extension`, `size_bytes`, `mtime_unix_secs`, `chunk_index`,
+`total_chunks`, `previous_chunk_id`, `next_chunk_id`, `chunk_start_byte`,
+`chunk_end_byte`, `chunk_char_len`, `chunk_text_sha256`, and
+`strategy_fingerprint`. Their names, presence, and JSON value kinds are
+supported. `chunk_text` is optional compatibility data: v0.5 emits it, but
+payload consumers should tolerate its omission. Additive fields are
+non-contractual until this policy names them as stable.
+Identity, extension, hash, and strategy fields are strings; size, time, index,
+count, offset, and length fields are non-negative integers; neighboring chunk
+IDs are either UUID strings or `null`.
+
+The default embedding backend remains OpenAI with
+`https://api.openai.com/v1/embeddings` and `text-embedding-3-small`; the
+default chunker mode remains `router` with character sizing at `max=2000`,
+`min=0`, and `overlap=0`. The default state path remains `.ragloom/wal.ndjson`,
+collection bootstrap and health remain disabled by default, and retry defaults
+remain 3 attempts, 128 queued retries, 100 ms initial backoff, and 2000 ms
+maximum backoff. Semantic chunking remains experimental and opt-in.
+
+Additive payload fields and fixes that preserve the documented identity,
+payload, default, and state contracts are compatible. Removing or renaming a
+stable field, changing a default, reusing an ID for different content, or
+making released state unreadable is incompatible. Incompatible changes require release-note migration guidance.
+
+| Upgrade observation | Operator action |
+| --- | --- |
+| Point IDs, stable payload fields, defaults, and released state remain compatible | No action |
+| Strategy fingerprint changes | Reindex; drop or garbage-collect the old point-ID space if a clean collection is required |
+| Stable payload field or CLI default changes | Follow the release notes and update consumers or configuration |
+| Released state is not directly readable | Back up the state directory and complete the documented migration before startup |
+
 ## Feature Boundaries
 
 Core support boundary maintainers are hardening for the current `v0.4`

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,8 @@
 [advisories]
 version = 2
-ignore = []
+# lopdf 0.42.0 still requires ttf-parser, and RUSTSEC-2026-0192 has no
+# patched release. Remove this exact exception when lopdf migrates away.
+ignore = ["RUSTSEC-2026-0192"]
 
 [licenses]
 version = 2

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -124,3 +124,59 @@ fn state_compatibility_contract_is_consistent_across_docs() {
         "expected CHANGELOG.md to record the state compatibility contract work"
     );
 }
+
+#[test]
+fn v0_5_compatibility_boundary_is_consistent_across_docs() {
+    let readme = read_repo_file("README.md");
+    let support = read_repo_file("SUPPORT.md");
+    let changelog = read_repo_file("CHANGELOG.md");
+
+    for (name, document) in [
+        ("README.md", readme.as_str()),
+        ("SUPPORT.md", support.as_str()),
+        ("CHANGELOG.md", changelog.as_str()),
+    ] {
+        assert!(
+            document.contains("v0.5 compatibility boundary"),
+            "expected {name} to name the v0.5 compatibility boundary"
+        );
+        assert!(
+            document.contains("Qdrant point ID is the chunk identity"),
+            "expected {name} to define the point-ID compatibility surface"
+        );
+        assert!(
+            document.contains("not duplicated as a `chunk_id` payload field"),
+            "expected {name} to distinguish point identity from payload fields"
+        );
+        assert!(
+            document
+                .contains("Strategy-fingerprint changes intentionally open a new point-ID space."),
+            "expected {name} to explain when reindexing is required"
+        );
+        assert!(
+            document.contains("`canonical_path`")
+                && document.contains("`doc_id`")
+                && document.contains("`chunk_index`")
+                && document.contains("`total_chunks`")
+                && document.contains("`previous_chunk_id`")
+                && document.contains("`next_chunk_id`")
+                && document.contains("`strategy_fingerprint`")
+                && document.contains("`chunk_text_sha256`"),
+            "expected {name} to name the stable Qdrant payload fields"
+        );
+        assert!(
+            document.contains("`chunk_text` is optional compatibility data"),
+            "expected {name} to distinguish optional payload text"
+        );
+        assert!(
+            document.contains("default embedding backend remains OpenAI")
+                && document.contains("default chunker mode remains `router`")
+                && document.contains("semantic chunking remains experimental and opt-in"),
+            "expected {name} to preserve the stable CLI defaults and experimental boundary"
+        );
+        assert!(
+            document.contains("Incompatible changes require release-note migration guidance."),
+            "expected {name} to require migration guidance for incompatible changes"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Documents and contract-tests the v0.5 operator-visible compatibility boundary for deterministic point IDs, Qdrant payloads, CLI defaults, semantic chunking, and durable state upgrades. Also updates vulnerable transitive dependencies discovered by the PR security gate.

## Related issue

Closes #156

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update
- [ ] Build / CI change
- [ ] Other

## Changes made

- Define when point-ID and strategy-fingerprint changes require reindexing.
- Name stable and optional Qdrant payload fields and record current CLI defaults.
- Add an operator upgrade-action matrix and cross-document contract coverage.
- Upgrade `pdf-extract`/`lopdf` and `quinn-proto` to resolve `RUSTSEC-2026-0187` and `RUSTSEC-2026-0185`.
- Add a narrow `RUSTSEC-2026-0192` exception because `lopdf 0.42.0` still requires unmaintained `ttf-parser` and no patched release exists.

## How to test

1. Run `cargo test --test docs_support_contract`.
2. Run `cargo deny check` and `cargo audit`.
3. Run `cargo qa`.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

The Qdrant point ID remains the chunk identity; the compatibility documentation does not alter runtime semantics. The dependency updates preserve the existing PDF extraction API and pass the PDF regression tests.
