### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-02
+
 ### Added
 - Checked-in `v0.4.0` and `v0.4.1` state fixtures plus compatibility contract
   tests that open, replay, compact, and re-open supported `wal.ndjson` and
@@ -12,6 +14,11 @@
   `RUSTSEC-2026-0187`. The no-fix `ttf-parser` maintenance advisory remains a
   narrowly scoped `cargo-deny` exception until `lopdf` migrates away from it.
 - Updated `quinn-proto` to `0.11.15` to address `RUSTSEC-2026-0185`.
+- Accepted the narrowly scoped `RUSTSEC-2024-0436` maintenance risk for
+  `paste 1.0.15`, which remains only in the opt-in `fastembed` dependency
+  graph while the upstream `tokenizers` migration is unresolved. The default
+  embedding path does not include this dependency, and removal remains tracked
+  in issue #67.
 - Defined the `v0.5.0` on-disk compatibility contract as direct readability of
   supported released `v0.4.x` WAL state, with `v0.4.0` as the minimum
   supported WAL version and `failed.ndjson` support applying from `v0.4.1+`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ragloom"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ragloom"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 authors = ["Bizer <3411596361@qq.com>"]
 description = "The minimalist RAG ingestion engine"

--- a/README.md
+++ b/README.md
@@ -227,12 +227,12 @@ Download the archive for your platform from the GitHub Release page, extract it,
 Examples:
 
 ```bash
-tar -xzf ragloom-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf ragloom-v0.5.0-x86_64-unknown-linux-gnu.tar.gz
 ./ragloom --version
 ```
 
 ```powershell
-Expand-Archive .\ragloom-v0.4.1-x86_64-pc-windows-msvc.zip -DestinationPath .
+Expand-Archive .\ragloom-v0.5.0-x86_64-pc-windows-msvc.zip -DestinationPath .
 .\ragloom.exe --version
 ```
 
@@ -829,11 +829,23 @@ Status: shipped in `v0.2.0`, with restart-safe delete synchronization refined in
 
 ### v0.4 - Explicit platform expansion boundaries
 
+Status: shipped in `v0.4.1`.
+
 - keep the local-filesystem and polling-S3 ingest paths release-ready on supported Linux and Windows targets
 - require green `ci` and `quality-deep` workflow states, or equivalent local maintainer verification, before cutting the release
 - keep feature-gated paths such as `fastembed` exercised by dedicated checks without making them the default runtime path
 - document PDF and DOCX extraction limits explicitly instead of implying broader parser guarantees
 - keep remote-source scope narrow by supporting S3 only rather than expanding into a general remote-ingestion platform
+
+### v0.5 - State and recovery hardening
+
+Status: shipped in `v0.5.0`.
+
+- crash-safe explicit compaction for WAL and failed-work state
+- direct compatibility with supported released `v0.4.x` state
+- recovery contracts covering pending work, deletes, acknowledgements, and point identity
+- state preflight checks and operator-facing replay summaries
+- durable-state backlog and journal-size metrics
 
 ## Limitations
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -25,7 +25,7 @@ Ragloom publishes artifacts through:
 
 Maintainers should start releases from `.github/workflows/release.yml` using
 `workflow_dispatch` with an explicit crate version from `Cargo.toml`
-(for example `0.4.1`).
+(for example `0.5.0`).
 
 The release workflow verifies that:
 
@@ -43,16 +43,16 @@ published notes come from the repository event history rather than ad hoc local
 release text.
 
 GitHub Release archives are published with explicit target names such as
-`ragloom-v0.4.1-x86_64-unknown-linux-gnu.tar.gz` and
-`ragloom-v0.4.1-x86_64-pc-windows-msvc.zip`.
+`ragloom-v0.5.0-x86_64-unknown-linux-gnu.tar.gz` and
+`ragloom-v0.5.0-x86_64-pc-windows-msvc.zip`.
 
 Each published archive also includes a matching `.sha256.txt` checksum file.
 Release checksums are generated with a platform-aware command so Linux targets
 use `sha256sum` while macOS targets use `shasum -a 256`.
 
-## v0.4 Support Readiness
+## v0.5 Support Readiness
 
-For the current `v0.4` support surface, maintainers should treat the following
+For the current `v0.5` support surface, maintainers should treat the following
 as release-blocking for the commit being released:
 
 - `ci` is green for the release commit or release branch tip
@@ -65,6 +65,14 @@ The following are not release-blocking by default:
 
 - macOS artifact failures, unless maintainers explicitly promote macOS to a supported release target
 - experimental semantic chunking behavior, as long as the default non-semantic ingest path remains healthy
+
+The optional `fastembed` graph in `v0.5.0` retains `paste 1.0.15`, which is
+covered by the unmaintained-crate advisory `RUSTSEC-2024-0436`. There is no
+patched `paste` release, and upstream `tokenizers` has not completed its
+migration. Maintainers accept this narrowly scoped risk for `v0.5.0` because
+`fastembed` is experimental and opt-in, the default embedding path does not
+include it, and dedicated feature checks remain green. Removal continues to be
+tracked in issue #67.
 
 ## Support Scope
 
@@ -141,7 +149,7 @@ making released state unreadable is incompatible. Incompatible changes require r
 
 ## Feature Boundaries
 
-Core support boundary maintainers are hardening for the current `v0.4`
+Core support boundary maintainers are hardening for the current `v0.5`
 support boundary:
 
 - local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix


### PR DESCRIPTION
## Summary

Prepare the repository for the v0.5.0 state and recovery hardening release.

## Related issue

Related to #157 and explicitly dispositions the optional-feature dependency risk tracked in #67.

## Type of change

- [x] Documentation update
- [x] Build / CI change
- [x] Other: release preparation

## Changes made

- bump the crate and lockfile version to 0.5.0
- freeze the v0.5.0 changelog with the release date
- update release artifact examples and roadmap status
- document the accepted, opt-in `fastembed` transitive `paste` maintenance risk

## How to test

1. `cargo maintainer-qa`
2. `cargo package --allow-dirty`
3. `cargo publish --dry-run --allow-dirty`
4. verify `EXPECTED_VERSION=0.5.0` and `EXPECTED_TAG=v0.5.0` with `.github/scripts/verify-release-version.py`

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

`cargo maintainer-qa` passed locally. The remaining `paste 1.0.15` advisory is an unmaintained-crate warning with no patched release; it is limited to the experimental, opt-in `fastembed` graph and remains tracked in #67.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the release version to **0.5.0**.

* **Documentation**
  * Updated installation examples and release references to **v0.5.0**.
  * Added new release notes and roadmap entries for **0.5.0**, including state and recovery hardening highlights.
  * Refreshed support guidance for the **v0.5** line.

* **Security**
  * Added a note about an accepted, narrowly scoped advisory risk affecting the optional **fastembed** path, while the default path remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->