### PR TITLE
Define Rust 1.88 MSRV policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  msrv:
+    name: msrv (Rust 1.88)
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: "1.88"
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Check workspace at MSRV
+        run: cargo check --workspace --all-targets --all-features --locked
+
   rust-ci:
     name: rust-ci (${{ matrix.os }})
     if: github.event_name != 'pull_request_target'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+- Established Rust 1.88 as the MSRV, declared it in both workspace package
+  manifests, and added a dedicated all-targets, all-features MSRV CI check.
+  Patch releases will not raise the MSRV.
+
 ### Removed
 - Removed the deprecated `ChunkerConfig`, `ChunkingStrategy`,
   `chunk_document`, and `chunk_text` compatibility APIs. Use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 Issues and pull requests are welcome. Keep changes small, test-backed, and aligned with Ragloom's minimalist design goals.
 
+## Rust Toolchain
+
+The workspace MSRV is Rust 1.88. Use the latest stable Rust release for normal
+development and the full local quality gates. When changing dependencies,
+language features, or build configuration, also verify the MSRV:
+
+```bash
+cargo +1.88 check --workspace --all-targets --all-features --locked
+```
+
+Do not merge a dependency update that requires a newer compiler without also
+updating both `package.rust-version` declarations, the MSRV CI job,
+`SUPPORT.md`, and the release notes. MSRV increases are not allowed in patch
+releases.
+
 ## Local Verification
 
 The local verification commands are:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ragloom"
 version = "0.5.0"
 edition = "2024"
+rust-version = "1.88"
 authors = ["Bizer <3411596361@qq.com>"]
 description = "The minimalist RAG ingestion engine"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ If you prefer or need an unsupported target, install from source with Cargo.
 
 ### Build from source
 
+Building Ragloom requires Rust 1.88 or newer. The latest stable Rust release is
+recommended.
+
 ```bash
 git clone https://github.com/ragloom/ragloom
 cd ragloom

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -50,6 +50,22 @@ Each published archive also includes a matching `.sha256.txt` checksum file.
 Release checksums are generated with a platform-aware command so Linux targets
 use `sha256sum` while macOS targets use `shasum -a 256`.
 
+## Rust Version Support
+
+Ragloom's minimum supported Rust version (MSRV) is 1.88. Both workspace
+packages declare this requirement through `package.rust-version`.
+
+CI checks the complete workspace, including all targets and features, on the
+MSRV. The full formatting, Clippy, test, documentation, and maintainer gates
+run on the latest stable Rust release. Versions between the MSRV and latest
+stable are supported but are not tested individually.
+
+Patch releases do not raise the MSRV. An MSRV increase requires a minor release
+or a new major release, an updated `rust-version` declaration and MSRV CI job,
+and a release-note entry. Maintainers may raise the MSRV when the project or a
+required dependency needs a newer compiler; the change must not be made only
+through a dependency update without updating this policy and the CI gate.
+
 ## v0.5 Support Readiness
 
 For the current `v0.5` support surface, maintainers should treat the following

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,5 +2,6 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Define and enforce Ragloom's Rust version support policy with Rust 1.88 as the minimum supported Rust version (MSRV).

## Related issue

No linked issue.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test update
- [x] Build / CI change
- [ ] Other

## Changes made

- declare Rust 1.88 in the `ragloom` and `xtask` package manifests
- add an Ubuntu CI job that checks all workspace targets and features on Rust 1.88 with the lockfile enforced
- document the latest-stable and MSRV responsibilities, the version-raising policy, and contributor verification steps

## How to test

1. Run `cargo +1.88.0 check --workspace --all-targets --all-features --locked`.
2. Run `cargo qa`.
3. Confirm Cargo metadata reports `rust_version = 1.88` for both workspace packages.

## Screenshots or recordings

Not applicable.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

Rust 1.88 is the effective dependency floor in the current lockfile. The dedicated MSRV check passed locally, and `cargo qa` passed with 259 library tests plus all workspace integration and tooling tests.
