### PR TITLE
[codex] Prepare v1.0.0-rc.1

### DIFF
--- a/.github/scripts/verify-release-version.py
+++ b/.github/scripts/verify-release-version.py
@@ -68,9 +68,11 @@ def main() -> None:
         )
 
     tag = expected_tag or f"v{expected_version}"
+    prerelease = "true" if "-" in expected_version else "false"
     append_output("crate_version", crate_version)
     append_output("version", expected_version)
     append_output("tag", tag)
+    append_output("prerelease", prerelease)
 
     print(
         f"verified Cargo.toml package.version '{crate_version}' for release tag '{tag}'",

--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Wait for Qdrant readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:6333/readyz >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Qdrant did not become ready within 30 seconds" >&2
+          exit 1
+
       - name: Run live Qdrant smoke test
         env:
           RAGLOOM_QDRANT_URL: http://127.0.0.1:6333

--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -16,6 +16,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  qdrant-live:
+    name: qdrant-live
+    runs-on: ubuntu-latest
+    services:
+      qdrant:
+        image: qdrant/qdrant:v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c
+        ports:
+          - 6333:6333
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run live Qdrant smoke test
+        env:
+          RAGLOOM_QDRANT_URL: http://127.0.0.1:6333
+        run: cargo test --test qdrant_live_smoke -- --ignored --exact live_qdrant_bootstrap_upsert_and_delete
+
   coverage:
     name: coverage
     if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       version: ${{ steps.verify.outputs.version }}
       tag: ${{ steps.verify.outputs.tag }}
+      prerelease: ${{ steps.verify.outputs.prerelease }}
       release_ref: ${{ steps.plan.outputs.release_ref }}
       create_tag: ${{ steps.plan.outputs.create_tag }}
     steps:
@@ -285,6 +286,8 @@ jobs:
           name: ${{ needs.prepare-release.outputs.tag }}
           target_commitish: ${{ needs.prepare-release.outputs.release_ref }}
           generate_release_notes: true
+          prerelease: ${{ needs.prepare-release.outputs.prerelease }}
+          make_latest: ${{ needs.prepare-release.outputs.prerelease == 'true' && 'false' || 'true' }}
           files: release-artifacts/**/*
 
   publish-best-effort-release-assets:
@@ -309,6 +312,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
+          prerelease: ${{ needs.prepare-release.outputs.prerelease }}
+          make_latest: ${{ needs.prepare-release.outputs.prerelease == 'true' && 'false' || 'true' }}
           files: release-artifacts-macos/**/*
 
   publish-crate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,27 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.1] - 2026-07-03
+
+### Added
+- Defined the v1 compatibility boundary for deterministic point IDs,
+  Qdrant payloads, CLI defaults, durable state, and supported release targets.
+- Added checked-in `v0.5.0` state fixtures and upgrade contract tests covering
+  direct reads, failed-work replay, compaction, and stable observable state.
+- Added a release-blocking live Qdrant smoke test for collection bootstrap,
+  deterministic upsert, and document deletion.
+- Added prerelease-aware release workflow behavior so release candidates are
+  never marked as the latest stable GitHub Release or container image.
+
 ### Changed
 - Established Rust 1.88 as the MSRV, declared it in both workspace package
   manifests, and added a dedicated all-targets, all-features MSRV CI check.
   Patch releases will not raise the MSRV.
+- Declared `1.0.0-rc.1` as a release candidate. The operator-facing v1
+  contract is frozen for validation; the Rust library API remains preview
+  until the final `1.0.0` release.
+- Updated `anyhow` to `1.0.103`, removing `RUSTSEC-2026-0190` from the locked
+  dependency graph.
 
 ### Removed
 - Removed the deprecated `ChunkerConfig`, `ChunkingStrategy`,
@@ -13,6 +30,12 @@
   `RecursiveChunker` through the `Chunker` trait instead.
 
 ### Security
+- Retained the documented `RUSTSEC-2024-0436` maintenance exception for
+  `paste 1.0.15` in the experimental, opt-in `fastembed` graph. Removal
+  remains tracked in issue #67.
+- Retained the exact `RUSTSEC-2026-0192` maintenance exception for
+  `ttf-parser 0.25.1` in the PDF extraction graph. The advisory has no patched
+  release; remove the exception when `lopdf` migrates to a maintained parser.
 - Accepted temporary, exact advisory exceptions for `RUSTSEC-2026-0194` and
   `RUSTSEC-2026-0195`. The affected `quick-xml` versions remain transitive
   through `docx-lite 0.2.0` and `rust-s3 0.37.2`, whose released dependency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -2640,7 +2640,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ragloom"
-version = "0.5.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ragloom"
-version = "0.5.0"
+version = "1.0.0-rc.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Bizer <3411596361@qq.com>"]
@@ -8,8 +8,20 @@ description = "The minimalist RAG ingestion engine"
 readme = "README.md"
 repository = "https://github.com/ragloom/ragloom"
 license = "Apache-2.0"
-keywords = []
-categories = []
+keywords = ["rag", "embeddings", "qdrant", "ingestion", "vector-search"]
+categories = ["command-line-utilities", "text-processing"]
+include = [
+    "/src/**/*.rs",
+    "/tests/**",
+    "/benches/**",
+    "/Cargo.toml",
+    "/Cargo.lock",
+    "/README.md",
+    "/LICENSE",
+    "/CHANGELOG.md",
+    "/SUPPORT.md",
+    "/SECURITY.md",
+]
 
 [workspace]
 members = ["xtask"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Point Ragloom at a folder. It watches local files, chunks documents, generates e
 Use it when you want a small, inspectable ingestion pipeline instead of a full RAG platform.
 
 ![Rust](https://img.shields.io/badge/Rust-2024-000000?logo=rust)
-![Status](https://img.shields.io/badge/status-alpha-b36b00)
+![Status](https://img.shields.io/badge/status-v1.0.0--rc.1-orange)
 
 ## Why Ragloom?
 
@@ -23,14 +23,12 @@ It is built for developers who want to:
 
 ## Status
 
-Ragloom is currently alpha software.
+Ragloom `v1.0.0-rc.1` is a release candidate for the first stable operator
+contract. It is intended for production-like validation before `v1.0.0`.
+Report compatibility regressions against the contract below before the final
+release.
 
-It is useful for local-folder to Qdrant ingestion experiments and small automation tasks.
-
-The v0.4 direction is to widen the ingestion surface carefully without losing
-the project's explicit support boundaries.
-
-Core path the project is hardening for the current v0.4 support boundary:
+Core v1 support boundary:
 
 - local filesystem source
 - polling S3 source
@@ -60,19 +58,22 @@ Not supported yet:
 - broad job-management or dead-letter queue subsystems beyond the local failed-work journal
 - built-in collection lifecycle management
 
-### v0.4 support matrix
+### v1 support matrix
 
-| Area | Supported in v0.4 | Explicitly out of scope |
+| Area | Supported in v1 | Explicitly out of scope |
 | --- | --- | --- |
 | sources | local filesystem, polling S3 | non-S3 remote sources |
 | document loading | UTF-8 text, Markdown, source code, embedded-text PDF extraction, deterministic DOCX text extraction | OCR, rich layout reconstruction, broader office-suite parsing |
 | operations | local health endpoint, local metrics endpoint, optional first-run collection bootstrap | non-local operator surfaces, broader collection lifecycle management |
 
-### v0.5 compatibility boundary
+### v1 compatibility boundary
 
-The v0.5 compatibility boundary covers operator-visible point identity, Qdrant
-payload shape, CLI defaults, and durable state upgrades. It does not guarantee
-undocumented internal Rust APIs.
+The v1 compatibility boundary covers operator-visible point identity, Qdrant
+payload shape, CLI defaults, durable state upgrades, and supported release
+targets. `v1.0.0-rc.1` freezes this contract for release-candidate validation.
+The Rust library API remains preview during the RC series; breaking Rust API
+changes must be documented in a later RC, and the public Rust API becomes
+SemVer-stable with the final `v1.0.0` release.
 
 The Qdrant point ID is the chunk identity. It is derived from the canonical
 source identity, chunk index, and exact chunker strategy fingerprint. The same
@@ -82,12 +83,12 @@ chunks under reused IDs. Operators should reindex and then drop or
 garbage-collect old points when they want a clean collection. The identity is
 not duplicated as a `chunk_id` payload field.
 
-For v0.5, the stable Qdrant payload fields are `canonical_path`, `doc_id`,
+For v1, the stable Qdrant payload fields are `canonical_path`, `doc_id`,
 `tenant_id`, `file_extension`, `size_bytes`, `mtime_unix_secs`, `chunk_index`,
 `total_chunks`, `previous_chunk_id`, `next_chunk_id`, `chunk_start_byte`,
 `chunk_end_byte`, `chunk_char_len`, `chunk_text_sha256`, and
 `strategy_fingerprint`. Their names, presence, and JSON value kinds are the
-compatibility contract. `chunk_text` is optional compatibility data: v0.5
+compatibility contract. `chunk_text` is optional compatibility data: v1
 emits it, but consumers should tolerate its omission. Newly added payload
 fields are non-contractual until they are explicitly added to this list.
 Identity, extension, hash, and strategy fields are strings; size, time, index,
@@ -227,12 +228,12 @@ Download the archive for your platform from the GitHub Release page, extract it,
 Examples:
 
 ```bash
-tar -xzf ragloom-v0.5.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf ragloom-v1.0.0-rc.1-x86_64-unknown-linux-gnu.tar.gz
 ./ragloom --version
 ```
 
 ```powershell
-Expand-Archive .\ragloom-v0.5.0-x86_64-pc-windows-msvc.zip -DestinationPath .
+Expand-Archive .\ragloom-v1.0.0-rc.1-x86_64-pc-windows-msvc.zip -DestinationPath .
 .\ragloom.exe --version
 ```
 
@@ -487,9 +488,9 @@ record so the durability boundary remains one acknowledged append at a time.
 
 ### State compatibility contract
 
-Ragloom `v0.5.0` directly reads the supported released `v0.4.x` WAL format,
-with `v0.4.0` as the minimum supported on-disk WAL version. `failed.ndjson`
-enters that compatibility surface in `v0.4.1`; older state directories may not
+Ragloom `v1.0.0-rc.1` directly reads the supported released `v0.4.x` and
+`v0.5.0` WAL formats, with `v0.4.0` as the minimum supported on-disk WAL
+version. `failed.ndjson` enters that compatibility surface in `v0.4.1`; older state directories may not
 have a failed-work journal yet.
 
 These files are durable user-owned state. Ragloom does not silently skip or
@@ -746,10 +747,10 @@ build/version information:
 {
   "status": "ready",
   "ready": true,
-  "version": "0.4.0",
+  "version": "1.0.0-rc.1",
   "build": {
     "package": "ragloom",
-    "version": "0.4.0"
+    "version": "1.0.0-rc.1"
   }
 }
 ```
@@ -849,6 +850,16 @@ Status: shipped in `v0.5.0`.
 - recovery contracts covering pending work, deletes, acknowledgements, and point identity
 - state preflight checks and operator-facing replay summaries
 - durable-state backlog and journal-size metrics
+
+### v1.0 - Stable operator contract
+
+Status: release candidate in `v1.0.0-rc.1`.
+
+- frozen point-ID, payload, CLI-default, and durable-state contracts
+- direct upgrade coverage from released v0.4 and v0.5 state
+- Rust 1.88 MSRV policy and supported-platform release gates
+- live Qdrant collection, upsert, and delete smoke verification
+- prerelease-safe GitHub Release and container publication
 
 ## Limitations
 
@@ -966,7 +977,7 @@ Before opening a pull request, run:
 cargo qa
 ```
 
-Maintainers preparing release-sensitive or v0.4 support-boundary work should also run
+Maintainers preparing release-sensitive or v1 support-boundary work should also run
 the authoritative deeper local gate:
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,4 +15,12 @@ Please allow time for investigation and coordinated remediation before public di
 
 ## Supported Versions
 
-Ragloom currently supports the latest released minor line only.
+During the release-candidate period, `1.0.0-rc.x` receives security fixes.
+After the final `1.0.0` release, the latest released v1 minor line is
+supported. The v0 line receives no fixes after final v1 availability.
+
+DOCX files and configured S3 endpoints are trusted-input boundaries for
+`v1.0.0-rc.1` because their transitive `quick-xml` versions have known
+resource-exhaustion advisories. Do not expose these inputs as an
+unauthenticated parsing service. This restriction will be removed when the
+upstream dependency constraints permit `quick-xml 0.41.0` or newer.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -25,7 +25,7 @@ Ragloom publishes artifacts through:
 
 Maintainers should start releases from `.github/workflows/release.yml` using
 `workflow_dispatch` with an explicit crate version from `Cargo.toml`
-(for example `0.5.0`).
+(for example `1.0.0-rc.1`).
 
 The release workflow verifies that:
 
@@ -43,8 +43,8 @@ published notes come from the repository event history rather than ad hoc local
 release text.
 
 GitHub Release archives are published with explicit target names such as
-`ragloom-v0.5.0-x86_64-unknown-linux-gnu.tar.gz` and
-`ragloom-v0.5.0-x86_64-pc-windows-msvc.zip`.
+`ragloom-v1.0.0-rc.1-x86_64-unknown-linux-gnu.tar.gz` and
+`ragloom-v1.0.0-rc.1-x86_64-pc-windows-msvc.zip`.
 
 Each published archive also includes a matching `.sha256.txt` checksum file.
 Release checksums are generated with a platform-aware command so Linux targets
@@ -66,9 +66,13 @@ and a release-note entry. Maintainers may raise the MSRV when the project or a
 required dependency needs a newer compiler; the change must not be made only
 through a dependency update without updating this policy and the CI gate.
 
-## v0.5 Support Readiness
+Release-candidate versions are published as GitHub prereleases and are never
+marked as the latest stable GitHub Release or container image. The canonical
+RC version and tag forms are `1.0.0-rc.1` and `v1.0.0-rc.1`.
 
-For the current `v0.5` support surface, maintainers should treat the following
+## v1 Support Readiness
+
+For the v1 support surface, maintainers should treat the following
 as release-blocking for the commit being released:
 
 - `ci` is green for the release commit or release branch tip
@@ -82,13 +86,19 @@ The following are not release-blocking by default:
 - macOS artifact failures, unless maintainers explicitly promote macOS to a supported release target
 - experimental semantic chunking behavior, as long as the default non-semantic ingest path remains healthy
 
-The optional `fastembed` graph in `v0.5.0` retains `paste 1.0.15`, which is
+The optional `fastembed` graph in `v1.0.0-rc.1` retains `paste 1.0.15`, which is
 covered by the unmaintained-crate advisory `RUSTSEC-2024-0436`. There is no
 patched `paste` release, and upstream `tokenizers` has not completed its
-migration. Maintainers accept this narrowly scoped risk for `v0.5.0` because
+migration. Maintainers accept this narrowly scoped risk for `v1.0.0-rc.1` because
 `fastembed` is experimental and opt-in, the default embedding path does not
 include it, and dedicated feature checks remain green. Removal continues to be
 tracked in issue #67.
+
+The default PDF extraction graph retains `ttf-parser 0.25.1`, covered by the
+unmaintained-crate advisory `RUSTSEC-2026-0192`. There is no patched
+`ttf-parser` release. The dependency remains transitive through `lopdf`, PDF
+extraction has dedicated tests, and the exception is scoped to that exact
+advisory. Remove it when `lopdf` migrates to a maintained font parser.
 
 The released `docx-lite 0.2.0` and `rust-s3 0.37.2` dependency constraints
 retain `quick-xml` versions affected by `RUSTSEC-2026-0194` and
@@ -96,7 +106,9 @@ retain `quick-xml` versions affected by `RUSTSEC-2026-0194` and
 `quick-xml 0.41.0`. Crafted DOCX XML or responses from a configured S3
 endpoint can cause CPU or memory exhaustion. The exact advisory exceptions in
 `deny.toml` and `.cargo/audit.toml` are temporary and must be removed as soon
-as both upstream crates permit the patched version.
+as both upstream crates permit the patched version. Until then, DOCX files and
+configured S3 endpoints are trusted-input boundaries; operators must not expose
+either path as an unauthenticated document parsing service.
 
 ## Support Scope
 
@@ -115,21 +127,22 @@ original journal is the durability boundary and the command returns a `state`
 error instead of dropping records.
 
 The on-disk state compatibility contract is also part of that support boundary.
-`v0.5.0` directly reads supported released `v0.4.x` WAL state, with `v0.4.0`
-as the minimum supported WAL version. `failed.ndjson` is part of that contract
-starting in `v0.4.1`, when the failed-work journal first became a released
-state surface.
+`v1.0.0-rc.1` directly reads supported released `v0.4.x` and `v0.5.0` WAL
+state, with `v0.4.0` as the minimum supported WAL version. `failed.ndjson` is
+part of that contract starting in `v0.4.1`, when the failed-work journal first
+became a released state surface.
 
 Unknown future record variants, malformed lines, truncated final writes, and
 other unsupported state shapes fail closed with a `state` error. Maintainers
 should treat any future incompatible state change as requiring an explicit,
 documented migration boundary rather than a silent format reinterpretation.
 
-## v0.5 compatibility boundary
+## v1 compatibility boundary
 
-The v0.5 compatibility boundary covers operator-visible point identity, Qdrant
-payload shape, CLI defaults, and durable state upgrades. Undocumented internal
-Rust APIs are outside this support promise.
+The v1 compatibility boundary covers operator-visible point identity, Qdrant
+payload shape, CLI defaults, durable state upgrades, and supported release
+targets. The Rust library API remains preview during the release-candidate
+series and becomes SemVer-stable with final `v1.0.0`.
 
 The Qdrant point ID is the chunk identity. It is derived from canonical source
 identity, chunk index, and the exact chunker strategy fingerprint.
@@ -139,12 +152,12 @@ Operators who need a clean collection should reindex and then drop or
 garbage-collect the old point-ID space.
 The identity is not duplicated as a `chunk_id` payload field.
 
-The stable v0.5 payload fields are `canonical_path`, `doc_id`, `tenant_id`,
+The stable v1 payload fields are `canonical_path`, `doc_id`, `tenant_id`,
 `file_extension`, `size_bytes`, `mtime_unix_secs`, `chunk_index`,
 `total_chunks`, `previous_chunk_id`, `next_chunk_id`, `chunk_start_byte`,
 `chunk_end_byte`, `chunk_char_len`, `chunk_text_sha256`, and
 `strategy_fingerprint`. Their names, presence, and JSON value kinds are
-supported. `chunk_text` is optional compatibility data: v0.5 emits it, but
+supported. `chunk_text` is optional compatibility data: v1 emits it, but
 payload consumers should tolerate its omission. Additive fields are
 non-contractual until this policy names them as stable.
 Identity, extension, hash, and strategy fields are strings; size, time, index,
@@ -173,8 +186,7 @@ making released state unreadable is incompatible. Incompatible changes require r
 
 ## Feature Boundaries
 
-Core support boundary maintainers are hardening for the current `v0.5`
-support boundary:
+Core v1 support boundary:
 
 - local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix
 - UTF-8 text, Markdown, source code, deterministic PDF text loading, and deterministic DOCX text extraction

--- a/src/state/failed.rs
+++ b/src/state/failed.rs
@@ -5,7 +5,7 @@
 //! changing the WAL's acknowledgement/replay semantics.
 //!
 //! The journal shares the WAL's fail-closed compatibility posture: released
-//! `v0.4.1+` newline-delimited JSON records remain directly readable, while
+//! `v0.4.1+` newline-delimited JSON records remain directly readable through v1, while
 //! unknown future variants or malformed lines fail with `state` context.
 
 use std::fs::File;

--- a/src/state/wal.rs
+++ b/src/state/wal.rs
@@ -6,7 +6,7 @@
 //! coordination.
 //!
 //! The on-disk contract is intentionally small and fail-closed: released
-//! `v0.4.x` newline-delimited JSON records stay directly readable, while
+//! `v0.4.x` and `v0.5.0` newline-delimited JSON records stay directly readable, while
 //! unknown future variants or malformed lines fail with `state` context rather
 //! than being skipped.
 

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -7,12 +7,12 @@ fn read_repo_file(path: &str) -> String {
 }
 
 #[test]
-fn readme_describes_v0_4_sources_formats_and_s3_example() {
+fn readme_describes_v1_sources_formats_and_s3_example() {
     let readme = read_repo_file("README.md");
 
     assert!(
-        readme.contains("v0.4"),
-        "expected README to frame the current support story around v0.4"
+        readme.contains("Core v1 support boundary"),
+        "expected README to frame the current support story around v1"
     );
     assert!(
         readme.contains("local filesystem source")
@@ -33,12 +33,12 @@ fn readme_describes_v0_4_sources_formats_and_s3_example() {
 }
 
 #[test]
-fn support_policy_describes_current_v0_4_support_boundary() {
+fn support_policy_describes_current_v1_support_boundary() {
     let support = read_repo_file("SUPPORT.md");
 
     assert!(
-        support.contains("v0.4"),
-        "expected SUPPORT.md to describe the current support boundary in v0.4 terms"
+        support.contains("Core v1 support boundary"),
+        "expected SUPPORT.md to describe the current support boundary in v1 terms"
     );
     assert!(
         support.contains("local filesystem ingestion under one configured directory, plus polling S3 ingestion under one configured bucket/prefix"),
@@ -98,8 +98,9 @@ fn state_compatibility_contract_is_consistent_across_docs() {
     let support = read_repo_file("SUPPORT.md");
     let changelog = read_repo_file("CHANGELOG.md");
 
-    let readme_direct_read_phrase = "directly reads the supported released `v0.4.x` WAL format";
-    let support_direct_read_phrase = "directly reads supported released `v0.4.x` WAL state";
+    let readme_direct_read_phrase =
+        "directly reads the supported released `v0.4.x` and\n`v0.5.0` WAL formats";
+    let support_direct_read_phrase = "directly reads supported released `v0.4.x` and `v0.5.0` WAL";
     let min_version_phrase = "v0.4.0";
     let fail_closed_phrase = "truncated final writes";
 
@@ -108,7 +109,7 @@ fn state_compatibility_contract_is_consistent_across_docs() {
             && readme.contains(readme_direct_read_phrase)
             && readme.contains(min_version_phrase)
             && readme.contains(fail_closed_phrase),
-        "expected README to define the v0.5 state compatibility contract"
+        "expected README to define the v1 state compatibility contract"
     );
     assert!(
         support.contains("on-disk state compatibility contract")
@@ -126,7 +127,7 @@ fn state_compatibility_contract_is_consistent_across_docs() {
 }
 
 #[test]
-fn v0_5_compatibility_boundary_is_consistent_across_docs() {
+fn v1_compatibility_boundary_is_consistent_across_docs() {
     let readme = read_repo_file("README.md");
     let support = read_repo_file("SUPPORT.md");
     let changelog = read_repo_file("CHANGELOG.md");
@@ -137,8 +138,8 @@ fn v0_5_compatibility_boundary_is_consistent_across_docs() {
         ("CHANGELOG.md", changelog.as_str()),
     ] {
         assert!(
-            document.contains("v0.5 compatibility boundary"),
-            "expected {name} to name the v0.5 compatibility boundary"
+            document.contains("v1 compatibility boundary"),
+            "expected {name} to name the v1 compatibility boundary"
         );
         assert!(
             document.contains("Qdrant point ID is the chunk identity"),

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -120,7 +120,7 @@ fn state_compatibility_contract_is_consistent_across_docs() {
         "expected SUPPORT.md to treat the state compatibility contract as supported surface"
     );
     assert!(
-        changelog.contains("on-disk compatibility contract")
+        changelog.contains("v1 compatibility boundary")
             && changelog.contains(min_version_phrase)
             && changelog.contains(fail_closed_phrase),
         "expected CHANGELOG.md to record the state compatibility contract work"

--- a/tests/docs_support_contract.rs
+++ b/tests/docs_support_contract.rs
@@ -98,15 +98,16 @@ fn state_compatibility_contract_is_consistent_across_docs() {
     let support = read_repo_file("SUPPORT.md");
     let changelog = read_repo_file("CHANGELOG.md");
 
-    let readme_direct_read_phrase =
-        "directly reads the supported released `v0.4.x` and\n`v0.5.0` WAL formats";
+    let readme_direct_read_prefix = "directly reads the supported released `v0.4.x` and";
+    let readme_direct_read_suffix = "`v0.5.0` WAL formats";
     let support_direct_read_phrase = "directly reads supported released `v0.4.x` and `v0.5.0` WAL";
     let min_version_phrase = "v0.4.0";
     let fail_closed_phrase = "truncated final writes";
 
     assert!(
         readme.contains("State compatibility contract")
-            && readme.contains(readme_direct_read_phrase)
+            && readme.contains(readme_direct_read_prefix)
+            && readme.contains(readme_direct_read_suffix)
             && readme.contains(min_version_phrase)
             && readme.contains(fail_closed_phrase),
         "expected README to define the v1 state compatibility contract"

--- a/tests/fixtures/state/v0.5.0/failed.ndjson
+++ b/tests/fixtures/state/v0.5.0/failed.ndjson
@@ -1,0 +1,3 @@
+{"type":"exhausted","id":1,"work":{"type":"work_item_v2","fingerprint":{"canonical_path":"/docs/v0.5-already-requeued.md","size_bytes":180,"mtime_unix_secs":1710000700,"etag":null}},"failure_kind":"embed","terminal_reason":"retry_exhausted","attempts":3}
+{"type":"requeued","exhausted_id":1}
+{"type":"exhausted","id":2,"work":{"type":"work_item_v2","fingerprint":{"canonical_path":"/docs/v0.5-retry.md","size_bytes":240,"mtime_unix_secs":1710000800,"etag":"retry-etag"}},"failure_kind":"sink","terminal_reason":"retry_exhausted","attempts":3}

--- a/tests/fixtures/state/v0.5.0/wal.ndjson
+++ b/tests/fixtures/state/v0.5.0/wal.ndjson
@@ -1,0 +1,6 @@
+{"type":"work_item_v2","fingerprint":{"canonical_path":"/docs/v0.5-acked.md","size_bytes":200,"mtime_unix_secs":1710000500,"etag":null}}
+{"type":"sink_ack_v2","fingerprint":{"canonical_path":"/docs/v0.5-acked.md","size_bytes":200,"mtime_unix_secs":1710000500,"etag":null}}
+{"type":"work_item_v2","fingerprint":{"canonical_path":"/docs/v0.5-pending.md","size_bytes":220,"mtime_unix_secs":1710000600,"etag":"v0.5-etag"}}
+{"type":"delete_document","canonical_path":"/docs/v0.5-pending-delete.md"}
+{"type":"delete_document","canonical_path":"/docs/v0.5-acked-delete.md"}
+{"type":"delete_ack","canonical_path":"/docs/v0.5-acked-delete.md"}

--- a/tests/pipeline_point_id_strategy.rs
+++ b/tests/pipeline_point_id_strategy.rs
@@ -106,4 +106,9 @@ async fn two_strategies_yield_distinct_point_ids() {
         ids_a,
         ids_b
     );
+    assert_eq!(
+        points_a[0].id.as_str(),
+        "9904e630-a206-4da1-b15f-aa169b35f7de",
+        "v1 must preserve the point-ID algorithm released by v0.5"
+    );
 }

--- a/tests/qdrant_live_smoke.rs
+++ b/tests/qdrant_live_smoke.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use ragloom::sink::qdrant::{QdrantConfig, QdrantSink};
 use ragloom::sink::{DocumentIdentity, PointId, Sink, VectorPoint};
 
+type SmokeResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
 #[tokio::test]
 #[ignore = "requires RAGLOOM_QDRANT_URL pointing to a live Qdrant instance"]
 async fn live_qdrant_bootstrap_upsert_and_delete() {
@@ -23,11 +25,31 @@ async fn live_qdrant_bootstrap_upsert_and_delete() {
     })
     .expect("build Qdrant sink");
 
-    sink.ensure_collection_exists(4)
+    let smoke_result =
+        exercise_live_qdrant(&sink, &client, &base_url, &collection, point_id, doc_id).await;
+    let cleanup_result = client
+        .delete(format!("{base_url}/collections/{collection}"))
+        .send()
         .await
-        .expect("bootstrap collection");
+        .and_then(reqwest::Response::error_for_status);
+
+    if let Err(error) = cleanup_result {
+        panic!("live Qdrant smoke cleanup failed after {smoke_result:?}: {error}");
+    }
+    smoke_result.expect("live Qdrant smoke failed");
+}
+
+async fn exercise_live_qdrant(
+    sink: &QdrantSink,
+    client: &reqwest::Client,
+    base_url: &str,
+    collection: &str,
+    point_id: &str,
+    doc_id: &str,
+) -> SmokeResult {
+    sink.ensure_collection_exists(4).await?;
     sink.upsert_points(vec![VectorPoint {
-        id: PointId::parse(point_id).expect("valid UUID"),
+        id: PointId::parse(point_id)?,
         vector: vec![1.0, 0.0, 0.0, 0.0],
         payload: serde_json::json!({
             "canonical_path": "file:///live-smoke.md",
@@ -37,53 +59,40 @@ async fn live_qdrant_bootstrap_upsert_and_delete() {
             "strategy_fingerprint": "live-smoke-v1"
         }),
     }])
-    .await
-    .expect("upsert point");
+    .await?;
 
     let point_url =
         format!("{base_url}/collections/{collection}/points/{point_id}?with_payload=true");
     let inserted: serde_json::Value = client
         .get(&point_url)
         .send()
-        .await
-        .expect("retrieve inserted point")
-        .error_for_status()
-        .expect("inserted point status")
+        .await?
+        .error_for_status()?
         .json()
-        .await
-        .expect("decode inserted point");
-    assert_eq!(inserted["result"]["payload"]["doc_id"], doc_id);
+        .await?;
+    if inserted["result"]["payload"]["doc_id"] != doc_id {
+        return Err(std::io::Error::other(format!(
+            "inserted point has unexpected payload: {inserted}"
+        ))
+        .into());
+    }
 
     sink.delete_document_points(DocumentIdentity {
         canonical_path: "file:///live-smoke.md".to_string(),
         doc_id: doc_id.to_string(),
     })
-    .await
-    .expect("delete document points");
+    .await?;
 
-    let deleted_response = client
-        .get(&point_url)
-        .send()
-        .await
-        .expect("retrieve deleted point");
+    let deleted_response = client.get(&point_url).send().await?;
     if deleted_response.status() != reqwest::StatusCode::NOT_FOUND {
-        let deleted: serde_json::Value = deleted_response
-            .error_for_status()
-            .expect("deleted point status")
-            .json()
-            .await
-            .expect("decode deleted point");
-        assert!(
-            deleted["result"].is_null(),
-            "expected document deletion to remove the point: {deleted}"
-        );
+        let deleted: serde_json::Value = deleted_response.error_for_status()?.json().await?;
+        if !deleted["result"].is_null() {
+            return Err(std::io::Error::other(format!(
+                "document deletion did not remove the point: {deleted}"
+            ))
+            .into());
+        }
     }
 
-    client
-        .delete(format!("{base_url}/collections/{collection}"))
-        .send()
-        .await
-        .expect("delete smoke collection")
-        .error_for_status()
-        .expect("delete collection status");
+    Ok(())
 }

--- a/tests/qdrant_live_smoke.rs
+++ b/tests/qdrant_live_smoke.rs
@@ -1,0 +1,89 @@
+use std::time::Duration;
+
+use ragloom::sink::qdrant::{QdrantConfig, QdrantSink};
+use ragloom::sink::{DocumentIdentity, PointId, Sink, VectorPoint};
+
+#[tokio::test]
+#[ignore = "requires RAGLOOM_QDRANT_URL pointing to a live Qdrant instance"]
+async fn live_qdrant_bootstrap_upsert_and_delete() {
+    let base_url =
+        std::env::var("RAGLOOM_QDRANT_URL").expect("RAGLOOM_QDRANT_URL must be configured");
+    let collection = format!("ragloom_rc_smoke_{}", std::process::id());
+    let point_id = "7c5ac739-ecf5-4f6b-a92f-0f98e8919708";
+    let doc_id = "live-smoke-doc";
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .no_proxy()
+        .build()
+        .expect("build verification client");
+    let sink = QdrantSink::new(QdrantConfig {
+        base_url: base_url.clone(),
+        collection: collection.clone(),
+        timeout: Duration::from_secs(10),
+    })
+    .expect("build Qdrant sink");
+
+    sink.ensure_collection_exists(4)
+        .await
+        .expect("bootstrap collection");
+    sink.upsert_points(vec![VectorPoint {
+        id: PointId::parse(point_id).expect("valid UUID"),
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: serde_json::json!({
+            "canonical_path": "file:///live-smoke.md",
+            "doc_id": doc_id,
+            "chunk_index": 0,
+            "total_chunks": 1,
+            "strategy_fingerprint": "live-smoke-v1"
+        }),
+    }])
+    .await
+    .expect("upsert point");
+
+    let point_url =
+        format!("{base_url}/collections/{collection}/points/{point_id}?with_payload=true");
+    let inserted: serde_json::Value = client
+        .get(&point_url)
+        .send()
+        .await
+        .expect("retrieve inserted point")
+        .error_for_status()
+        .expect("inserted point status")
+        .json()
+        .await
+        .expect("decode inserted point");
+    assert_eq!(inserted["result"]["payload"]["doc_id"], doc_id);
+
+    sink.delete_document_points(DocumentIdentity {
+        canonical_path: "file:///live-smoke.md".to_string(),
+        doc_id: doc_id.to_string(),
+    })
+    .await
+    .expect("delete document points");
+
+    let deleted_response = client
+        .get(&point_url)
+        .send()
+        .await
+        .expect("retrieve deleted point");
+    if deleted_response.status() != reqwest::StatusCode::NOT_FOUND {
+        let deleted: serde_json::Value = deleted_response
+            .error_for_status()
+            .expect("deleted point status")
+            .json()
+            .await
+            .expect("decode deleted point");
+        assert!(
+            deleted["result"].is_null(),
+            "expected document deletion to remove the point: {deleted}"
+        );
+    }
+
+    client
+        .delete(format!("{base_url}/collections/{collection}"))
+        .send()
+        .await
+        .expect("delete smoke collection")
+        .error_for_status()
+        .expect("delete collection status");
+}

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -262,6 +262,8 @@ fn quality_deep_workflow_exposes_pre_merge_stability_gate() {
         qdrant_live_yaml.contains(
             "qdrant/qdrant:v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c",
         )
+            && qdrant_live_yaml.contains("Wait for Qdrant readiness")
+            && qdrant_live_yaml.contains("http://127.0.0.1:6333/readyz")
             && qdrant_live_yaml.contains("cargo test --test qdrant_live_smoke")
             && qdrant_live_yaml.contains("RAGLOOM_QDRANT_URL"),
         "expected the release-quality gate to exercise bootstrap, writes, and deletes against a pinned live Qdrant"
@@ -313,11 +315,38 @@ fn release_version_verifier_accepts_v_prefixed_manual_version_input() {
 
 #[test]
 fn release_version_verifier_marks_stable_versions_as_not_prerelease() {
-    let script = read_repo_file(".github/scripts/verify-release-version.py");
+    let temp = tempfile::tempdir().expect("create temporary repository");
+    let scripts_dir = temp.path().join(".github").join("scripts");
+    fs::create_dir_all(&scripts_dir).expect("create temporary scripts directory");
+    fs::write(
+        scripts_dir.join("verify-release-version.py"),
+        read_repo_file(".github/scripts/verify-release-version.py"),
+    )
+    .expect("copy release verifier");
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"release-verifier-test\"\nversion = \"1.0.0\"\n",
+    )
+    .expect("write stable temporary manifest");
+    let output_file = tempfile::NamedTempFile::new().expect("create temporary GITHUB_OUTPUT");
 
+    let output = Command::new("python")
+        .arg(".github/scripts/verify-release-version.py")
+        .current_dir(temp.path())
+        .env("EXPECTED_VERSION", "1.0.0")
+        .env("EXPECTED_TAG", "v1.0.0")
+        .env("GITHUB_OUTPUT", output_file.path())
+        .output()
+        .expect("run stable release version verifier with Python");
     assert!(
-        script.contains("prerelease = \"true\" if \"-\" in expected_version else \"false\""),
-        "expected the verifier to distinguish stable versions from prereleases"
+        output.status.success(),
+        "expected stable version verification to succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let github_output = fs::read_to_string(output_file.path()).expect("read GITHUB_OUTPUT");
+    assert!(
+        github_output.lines().any(|line| line == "prerelease=false"),
+        "expected stable versions to be marked as not prerelease"
     );
 }
 

--- a/tests/release_workflow_contract.rs
+++ b/tests/release_workflow_contract.rs
@@ -86,6 +86,13 @@ fn release_workflow_supports_version_dispatch_and_release_notes() {
         "expected release workflow to generate release notes deterministically"
     );
     assert!(
+        workflow_yaml.contains("prerelease: ${{ needs.prepare-release.outputs.prerelease }}")
+            && workflow_yaml.contains(
+                "make_latest: ${{ needs.prepare-release.outputs.prerelease == 'true' && 'false' || 'true' }}",
+            ),
+        "expected release candidates to publish as prereleases without replacing the latest stable release"
+    );
+    assert!(
         workflow_yaml.contains("release_ref=\"$(git rev-list -n 1 \"${release_tag}\")\"")
             && workflow_yaml.contains("echo \"release_ref=${GITHUB_SHA}\" >> \"$GITHUB_OUTPUT\"")
             && !workflow_yaml.contains("echo \"release_ref=${GITHUB_REF}\" >> \"$GITHUB_OUTPUT\""),
@@ -215,11 +222,16 @@ fn quality_deep_workflow_exposes_pre_merge_stability_gate() {
         .get(serde_yaml::Value::String("docs-and-security".to_string()))
         .and_then(serde_yaml::Value::as_mapping)
         .expect("expected quality workflow to define a docs-and-security job");
+    let qdrant_live = jobs
+        .get(serde_yaml::Value::String("qdrant-live".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("expected quality workflow to define a live Qdrant job");
 
     let fastembed_yaml = serde_yaml::to_string(fastembed).expect("serialize fastembed job");
     let loom_yaml = serde_yaml::to_string(loom).expect("serialize loom job");
     let docs_and_security_yaml =
         serde_yaml::to_string(docs_and_security).expect("serialize docs-and-security job");
+    let qdrant_live_yaml = serde_yaml::to_string(qdrant_live).expect("serialize live Qdrant job");
     let fastembed_steps = fastembed
         .get(serde_yaml::Value::String("steps".to_string()))
         .and_then(serde_yaml::Value::as_sequence)
@@ -245,6 +257,14 @@ fn quality_deep_workflow_exposes_pre_merge_stability_gate() {
             && docs_and_security_yaml.contains("cargo audit")
             && docs_and_security_yaml.contains("cargo doc --workspace --no-deps"),
         "expected PR-visible stability checks to cover docs, cargo-deny, and cargo-audit"
+    );
+    assert!(
+        qdrant_live_yaml.contains(
+            "qdrant/qdrant:v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c",
+        )
+            && qdrant_live_yaml.contains("cargo test --test qdrant_live_smoke")
+            && qdrant_live_yaml.contains("RAGLOOM_QDRANT_URL"),
+        "expected the release-quality gate to exercise bootstrap, writes, and deletes against a pinned live Qdrant"
     );
     assert!(
         fastembed_checkout_yaml.contains("persist-credentials: false"),
@@ -285,8 +305,19 @@ fn release_version_verifier_accepts_v_prefixed_manual_version_input() {
     let output_lines: Vec<_> = github_output.lines().collect();
     assert!(
         output_lines.contains(&format!("version={version}").as_str())
-            && output_lines.contains(&format!("tag=v{version}").as_str()),
-        "expected verifier to normalize the version output and derive the release tag"
+            && output_lines.contains(&format!("tag=v{version}").as_str())
+            && output_lines.contains(&"prerelease=true"),
+        "expected verifier to normalize the version output, derive the release tag, and identify the RC"
+    );
+}
+
+#[test]
+fn release_version_verifier_marks_stable_versions_as_not_prerelease() {
+    let script = read_repo_file(".github/scripts/verify-release-version.py");
+
+    assert!(
+        script.contains("prerelease = \"true\" if \"-\" in expected_version else \"false\""),
+        "expected the verifier to distinguish stable versions from prereleases"
     );
 }
 
@@ -407,5 +438,15 @@ fn support_docs_describe_release_dispatch_runbook() {
     assert!(
         support.contains("ragloom-v") && support.contains(".tar.gz") && support.contains(".zip"),
         "expected support docs to describe the published release archive naming convention"
+    );
+}
+
+#[test]
+fn container_workflow_never_promotes_prereleases_to_latest() {
+    let container = read_repo_file(".github/workflows/container.yml");
+
+    assert!(
+        container.contains("type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}",),
+        "expected prerelease container tags to leave the stable latest tag unchanged"
     );
 }

--- a/tests/state_compat_contract.rs
+++ b/tests/state_compat_contract.rs
@@ -52,10 +52,8 @@ fn fp(path: &str, size_bytes: u64, mtime_unix_secs: i64) -> FileFingerprint {
 
 fn fp_with_etag(path: &str, size_bytes: u64, mtime_unix_secs: i64, etag: &str) -> FileFingerprint {
     FileFingerprint {
-        canonical_path: path.to_string(),
-        size_bytes,
-        mtime_unix_secs,
         etag: Some(etag.to_string()),
+        ..fp(path, size_bytes, mtime_unix_secs)
     }
 }
 
@@ -356,11 +354,14 @@ async fn compact_state_command_preserves_v0_5_0_observables() {
         .read_all()
         .expect("read failed before");
 
-    compact_state_command(&CompactStateConfig {
+    let summary = compact_state_command(&CompactStateConfig {
         state_path: wal_path.to_string_lossy().to_string(),
     })
     .await
     .expect("compact v0.5.0");
+
+    assert!(summary.wal.records_after <= summary.wal.records_before);
+    assert!(summary.failed_work.records_after <= summary.failed_work.records_before);
 
     let wal_after = FileWal::open(&wal_path)
         .expect("open wal after")

--- a/tests/state_compat_contract.rs
+++ b/tests/state_compat_contract.rs
@@ -50,6 +50,15 @@ fn fp(path: &str, size_bytes: u64, mtime_unix_secs: i64) -> FileFingerprint {
     }
 }
 
+fn fp_with_etag(path: &str, size_bytes: u64, mtime_unix_secs: i64, etag: &str) -> FileFingerprint {
+    FileFingerprint {
+        canonical_path: path.to_string(),
+        size_bytes,
+        mtime_unix_secs,
+        etag: Some(etag.to_string()),
+    }
+}
+
 #[test]
 fn v0_4_0_wal_fixture_is_directly_readable() {
     let wal = FileWal::open(fixture_path("v0.4.0/wal.ndjson")).expect("open v0.4.0 wal");
@@ -109,6 +118,42 @@ fn v0_4_1_state_fixtures_are_directly_readable() {
         vec![2, 3]
     );
     assert_eq!(next_failed_work_id(&failed_records), 4);
+}
+
+#[test]
+fn v0_5_0_state_fixtures_are_directly_readable() {
+    let wal = FileWal::open(fixture_path("v0.5.0/wal.ndjson")).expect("open v0.5.0 wal");
+    let failed =
+        FileFailedWorkStore::open(fixture_path("v0.5.0/failed.ndjson")).expect("open failed");
+    let wal_records = wal.read_all().expect("read v0.5.0 wal");
+    let failed_records = failed.read_all().expect("read v0.5.0 failed");
+
+    assert_eq!(
+        unacked_work_items(&wal_records),
+        vec![
+            WalRecord::WorkItemV2 {
+                fingerprint: fp_with_etag("/docs/v0.5-pending.md", 220, 1_710_000_600, "v0.5-etag",),
+            },
+            WalRecord::DeleteDocument {
+                canonical_path: "/docs/v0.5-pending-delete.md".to_string(),
+            },
+        ]
+    );
+    assert_eq!(
+        known_live_document_paths(&wal_records),
+        HashSet::from([
+            "/docs/v0.5-acked.md".to_string(),
+            "/docs/v0.5-pending.md".to_string(),
+        ])
+    );
+    assert_eq!(
+        pending_failed_work(&failed_records)
+            .into_iter()
+            .map(|record| record.id)
+            .collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert_eq!(next_failed_work_id(&failed_records), 3);
 }
 
 #[tokio::test]
@@ -180,6 +225,42 @@ async fn replay_failed_command_replays_pending_v0_4_1_failed_work() {
 }
 
 #[tokio::test]
+async fn replay_failed_command_replays_pending_v0_5_0_failed_work() {
+    let dir = copy_fixture_tree("v0.5.0");
+    let wal_path = dir.path().join("wal.ndjson");
+    let failed_path = dir.path().join("failed.ndjson");
+
+    let replayed = replay_failed_command(&ReplayFailedConfig {
+        state_path: wal_path.to_string_lossy().to_string(),
+    })
+    .await
+    .expect("replay v0.5.0");
+
+    assert_eq!(replayed.pending, 1);
+    assert_eq!(replayed.requeued, 1);
+    assert_eq!(replayed.skipped, 1);
+    assert_eq!(replayed.failed, 0);
+
+    let wal_records = FileWal::open(&wal_path)
+        .expect("reopen wal")
+        .read_all()
+        .expect("read wal after replay");
+    assert_eq!(
+        wal_records.last(),
+        Some(&WalRecord::WorkItemV2 {
+            fingerprint: fp_with_etag("/docs/v0.5-retry.md", 240, 1_710_000_800, "retry-etag",),
+        })
+    );
+
+    let failed_records = FileFailedWorkStore::open(&failed_path)
+        .expect("reopen failed")
+        .read_all()
+        .expect("read failed after replay");
+    assert!(pending_failed_work(&failed_records).is_empty());
+    assert_eq!(next_failed_work_id(&failed_records), 3);
+}
+
+#[tokio::test]
 async fn compact_state_command_preserves_v0_4_0_observables() {
     let dir = copy_fixture_tree("v0.4.0");
     let wal_path = dir.path().join("wal.ndjson");
@@ -232,6 +313,54 @@ async fn compact_state_command_preserves_v0_4_1_observables() {
 
     assert!(summary.wal.records_after <= summary.wal.records_before);
     assert!(summary.failed_work.records_after <= summary.failed_work.records_before);
+
+    let wal_after = FileWal::open(&wal_path)
+        .expect("open wal after")
+        .read_all()
+        .expect("read wal after");
+    let failed_after = FileFailedWorkStore::open(&failed_path)
+        .expect("open failed after")
+        .read_all()
+        .expect("read failed after");
+
+    assert_eq!(
+        unacked_work_items(&wal_after),
+        unacked_work_items(&wal_before)
+    );
+    assert_eq!(
+        known_live_document_paths(&wal_after),
+        known_live_document_paths(&wal_before)
+    );
+    assert_eq!(
+        pending_failed_work(&failed_after),
+        pending_failed_work(&failed_before)
+    );
+    assert_eq!(
+        next_failed_work_id(&failed_after),
+        next_failed_work_id(&failed_before)
+    );
+}
+
+#[tokio::test]
+async fn compact_state_command_preserves_v0_5_0_observables() {
+    let dir = copy_fixture_tree("v0.5.0");
+    let wal_path = dir.path().join("wal.ndjson");
+    let failed_path = dir.path().join("failed.ndjson");
+
+    let wal_before = FileWal::open(&wal_path)
+        .expect("open wal before")
+        .read_all()
+        .expect("read wal before");
+    let failed_before = FileFailedWorkStore::open(&failed_path)
+        .expect("open failed before")
+        .read_all()
+        .expect("read failed before");
+
+    compact_state_command(&CompactStateConfig {
+        state_path: wal_path.to_string_lossy().to_string(),
+    })
+    .await
+    .expect("compact v0.5.0");
 
     let wal_after = FileWal::open(&wal_path)
         .expect("open wal after")


### PR DESCRIPTION
## Summary

Prepare Ragloom `v1.0.0-rc.1` and freeze the first release-candidate operator contract.

## Related issue

No single issue; this is the v1 release-readiness change set.

## Type of change

- [x] Breaking change
- [x] Documentation update
- [x] Test update
- [x] Build / CI change

## Changes made

- set the crate version and release documentation to `1.0.0-rc.1`
- define v1 point-ID, payload, CLI-default, state-upgrade, MSRV, and support contracts
- add v0.5 state fixtures, replay/compaction coverage, and a point-ID snapshot
- mark GitHub release candidates as prereleases and keep `latest` stable
- update `anyhow` to 1.0.103 and document remaining exact advisory dispositions
- add a digest-pinned live Qdrant bootstrap/upsert/delete quality gate

## How to test

1. `cargo +1.88 check --workspace --all-targets --all-features --locked`
2. `cargo maintainer-qa`
3. `cargo publish --dry-run --allow-dirty`
4. Run `qdrant_live_smoke` against Qdrant v1.18.2.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have tested my changes locally.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] I have checked that this change does not introduce unintended breaking changes.
- [x] My code follows the existing style of the project.

## Additional notes

The remaining `paste`, `ttf-parser`, and `quick-xml` advisories are explicitly scoped and documented in `SUPPORT.md`, `SECURITY.md`, and `CHANGELOG.md`. No release tag is created by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-candidate support with prerelease-aware publishing and “latest” tagging behavior.
  * Introduced a live database smoke test in quality checks for stronger end-to-end confidence.

* **Bug Fixes**
  * Improved version detection for tagged releases, including prerelease handling.
  * Strengthened compatibility checks around state and point-ID behavior.

* **Documentation**
  * Updated README, support, and security guidance for the v1.0.0-rc.1 release candidate and revised compatibility/support boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->